### PR TITLE
fix(db): image_cache 改 BYTEA 存储 + 修 99.5% NULL 占位行

### DIFF
--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -152,7 +152,9 @@ class BaseImageCache(Document):
 
 class ImageCache(BaseImageCache):
     cq_code: str = Field(...)
-    base64_data: str | None = None
+    # 原生二进制 blob（PG BYTEA / Mongo Binary）。在 PG 后端通过 SQLAlchemy LargeBinary 映射；
+    # 这里只声明语义类型，具体 DDL 由各 repository 的 ORM 模型负责。
+    blob_data: bytes | None = None
     ref_times: int = 1
 
     class Settings(BaseImageCache.Settings):

--- a/pallas/core/foundation/db/repository_pg.py
+++ b/pallas/core/foundation/db/repository_pg.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     Text,
     UniqueConstraint,
     delete,
@@ -211,7 +212,10 @@ class ImageCacheRow(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     cq_code: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
-    base64_data: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 改为原生二进制：PG DDL 为 BYTEA。Text → LargeBinary 是一次性破坏性变更，
+    # 历史数据由 tools/migrate_image_cache_to_bytea.py 负责（PG 侧执行
+    # ALTER TABLE ... TYPE BYTEA USING decode(base64_data, 'base64')）。
+    blob_data: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     ref_times: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     date: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
 
@@ -812,7 +816,7 @@ def row_to_image_cache(row: ImageCacheRow) -> ImageCache:
 
     return ImageCache.model_construct(
         cq_code=row.cq_code,
-        base64_data=row.base64_data,
+        blob_data=row.blob_data,
         ref_times=row.ref_times,
         date=row.date,
     )
@@ -1648,11 +1652,14 @@ class PgImageCacheRepository:
             return row_to_image_cache(row) if row else None
 
     async def insert(self, cache: ImageCache) -> None:
-        """并发下相同 cq_code 的第二次 insert 等价为 no-op。"""
+        """并发下相同 cq_code 的第二次 insert 等价为 no-op。
+
+        blob_data 为 bytes，二进制字段不需要 NUL 剥离（_s() 也不适用）。
+        """
         async with get_session() as session:
             stmt = pg_insert(ImageCacheRow).values(
                 cq_code=_s(cache.cq_code) or "",
-                base64_data=_s(cache.base64_data),
+                blob_data=cache.blob_data,
                 ref_times=cache.ref_times,
                 date=cache.date,
             )
@@ -1664,7 +1671,7 @@ class PgImageCacheRepository:
         async with get_session() as session:
             stmt = pg_insert(ImageCacheRow).values(
                 cq_code=_s(cache.cq_code) or "",
-                base64_data=_s(cache.base64_data),
+                blob_data=cache.blob_data,
                 ref_times=cache.ref_times,
                 date=cache.date,
             )
@@ -1673,7 +1680,7 @@ class PgImageCacheRepository:
                 set_={
                     "ref_times": stmt.excluded.ref_times,
                     "date": stmt.excluded.date,
-                    "base64_data": stmt.excluded.base64_data,
+                    "blob_data": stmt.excluded.blob_data,
                 },
             )
             await session.execute(stmt)

--- a/pallas/core/shared/utils/media_cache/__init__.py
+++ b/pallas/core/shared/utils/media_cache/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import re
 from datetime import datetime, timedelta
 
@@ -44,22 +43,39 @@ def _image_capture_workers_running() -> bool:
 
 
 async def _insert_image_io(image_seg: MessageSegment) -> None:
+    """处理一条图片消息：下载成功才落盘（避免 issue #224 的 99.5% NULL 占位行）。"""
     cq_code = re.sub(r"\.image,.+?\]", ".image]", str(image_seg))
     cache = await image_cache_repo.find_by_cq_code(cq_code)
-    if not cache:
-        cache = ImageCache.model_construct(
-            cq_code=cq_code, base64_data=None, ref_times=1, date=int(str(datetime.now().date()).replace("-", ""))
+    if cache is None:
+        # 第一次见到这张图：背压下放弃下载（避免在高峰期烧流量），
+        # 否则尝试下载并直接以二进制形式落盘——这是 issue #223 BYTEA 改造的入口。
+        if image_capture_under_load():
+            return
+        url = image_seg.data.get("url")
+        if not url:
+            return
+        try:
+            rsp = await HTTPXClient.get(url)
+        except Exception as e:
+            # 临时的网络问题（超时 / DNS / 连接 reset）或 HTTPX 级别异常——
+            # 行为与"非 200 响应"对齐：放弃缓存这张图，不写 NULL 占位行（issue #224）。
+            # 外层 run_image_capture_consumer 还会兜底 logger.warning，但这里精细化一级
+            # 便于排查"为什么某张图没缓存"时区分网络/业务失败。
+            logger.warning("image cache download error: cq_code={} err={}", cq_code, e)
+            return
+        if not rsp or rsp.status_code != httpx.codes.OK:
+            return  # 下载失败就不缓存这张图，让它保持"未缓存"状态
+        cache = ImageCache(
+            cq_code=cq_code,
+            blob_data=rsp.content,
+            ref_times=1,
+            date=int(str(datetime.now().date()).replace("-", "")),
         )
         await image_cache_repo.insert(cache)
         return
+    # 已有缓存：只累加 ref_times + 刷鲜日期，不再补下载
+    # （补下载的"第三次后才下载"逻辑在历史里制造了 99.5% NULL 行，issue #224）
     cache.ref_times += 1
-    under_load = image_capture_under_load()
-    if cache.ref_times > 2 and cache.base64_data is None and not under_load:
-        url = image_seg.data.get("url")
-        if url:
-            rsp = await HTTPXClient.get(url)
-            if rsp and rsp.status_code == httpx.codes.OK:
-                cache.base64_data = base64.b64encode(rsp.content).decode()
     await image_cache_repo.save(cache)
 
 
@@ -133,12 +149,11 @@ async def insert_image(image_seg: MessageSegment):
 
 
 async def get_image(cq_code) -> bytes | None:
+    """按 cq_code 取出缓存的二进制图片；没有缓存或缓存为空时返回 None。"""
     cache = await image_cache_repo.find_by_cq_code(cq_code)
     if not cache:
         return None
-    if cache.base64_data is None:
-        return None
-    return base64.b64decode(cache.base64_data)
+    return cache.blob_data
 
 
 async def clear_image_cache(days: int = 5, times: int = 3):

--- a/tests/common/test_migrate_robustness.py
+++ b/tests/common/test_migrate_robustness.py
@@ -402,13 +402,21 @@ async def test_migrate_bot_config_handles_auto_accept_legacy(pg_env):
 
 
 async def test_migrate_image_cache_upsert(pg_env):
-    """同 cq_code 多条在单批内 upsert 只剩最后一条；空 cq_code 脏数据被计入 failed。"""
+    """同 cq_code 多条在单批内 upsert 只剩最后一条；空 cq_code 脏数据被计入 failed。
+
+    同时覆盖历史 base64_data 字符串 → blob_data BYTEA 的迁移路径（issue #223）。
+    """
+    import base64 as _b64
+
     from bson import ObjectId
     from sqlalchemy import select
 
     from pallas.core.foundation.db.repository_pg import ImageCacheRow
 
     migrate = pg_env["migrate"]
+    # 真实 PNG 文件头的 base64 编码（验证 decode 路径能还原正确字节）
+    png_payload = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    b64_payload = _b64.b64encode(png_payload).decode("ascii")
     docs = [
         {
             "_id": ObjectId(),
@@ -420,7 +428,7 @@ async def test_migrate_image_cache_upsert(pg_env):
         {
             "_id": ObjectId(),
             "cq_code": "[CQ:image,file=a.image]",
-            "base64_data": "b64",
+            "base64_data": b64_payload,
             "ref_times": 5,
             "date": 20250110,
         },
@@ -436,5 +444,6 @@ async def test_migrate_image_cache_upsert(pg_env):
         rows = (await session.execute(select(ImageCacheRow))).scalars().all()
     assert len(rows) == 1
     assert rows[0].ref_times == 5
-    assert rows[0].base64_data == "b64"
+    # 历史 base64 字符串已被解码为 BYTEA（issue #223）
+    assert rows[0].blob_data == png_payload
     assert stats.failed >= 1

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -753,22 +753,25 @@ async def test_blacklist_answers_and_reserve_do_not_clobber(pg_engine):
 
 @pytest.mark.asyncio
 async def test_image_cache_save_is_upsert(pg_engine):
-    """PgImageCacheRepository.save 必须对齐 Mongo save() 的 upsert 语义。"""
+    """PgImageCacheRepository.save 必须对齐 Mongo save() 的 upsert 语义。
+
+    字段名变更（base64_data → blob_data）+ 类型变 BYTEA（issue #223）。
+    """
     from pallas.core.foundation.db.modules import ImageCache
     from pallas.core.foundation.db.repository_pg import PgImageCacheRepository
 
     repo = PgImageCacheRepository()
-    ic = ImageCache.model_construct(cq_code="[CQ:image,file=x.image]", base64_data=None, ref_times=1, date=20250419)
+    ic = ImageCache.model_construct(cq_code="[CQ:image,file=x.image]", blob_data=None, ref_times=1, date=20250419)
     await repo.save(ic)
     assert await repo.find_by_cq_code("[CQ:image,file=x.image]") is not None
 
     ic.ref_times = 5
-    ic.base64_data = "b64"
+    ic.blob_data = b"\x89PNG\r\n\x1a\n"
     await repo.save(ic)
     got = await repo.find_by_cq_code("[CQ:image,file=x.image]")
     assert got is not None
     assert got.ref_times == 5
-    assert got.base64_data == "b64"
+    assert got.blob_data == b"\x89PNG\r\n\x1a\n"
 
 
 @pytest.mark.asyncio
@@ -778,20 +781,18 @@ async def test_image_cache_insert_is_no_op_on_duplicate(pg_engine):
     from pallas.core.foundation.db.repository_pg import PgImageCacheRepository
 
     repo = PgImageCacheRepository()
-    first = ImageCache.model_construct(
-        cq_code="[CQ:image,file=dup.image]", base64_data="v1", ref_times=1, date=20250419
-    )
+    first = ImageCache.model_construct(cq_code="[CQ:image,file=dup.image]", blob_data=b"v1", ref_times=1, date=20250419)
     await repo.insert(first)
 
     # 第二次 insert 应被 ON CONFLICT DO NOTHING 吃掉，原有值保持不变
     second = ImageCache.model_construct(
-        cq_code="[CQ:image,file=dup.image]", base64_data="v2", ref_times=99, date=20260101
+        cq_code="[CQ:image,file=dup.image]", blob_data=b"v2", ref_times=99, date=20260101
     )
     await repo.insert(second)
 
     got = await repo.find_by_cq_code("[CQ:image,file=dup.image]")
     assert got is not None
-    assert got.base64_data == "v1"
+    assert got.blob_data == b"v1"
     assert got.ref_times == 1
     assert got.date == 20250419
 

--- a/tools/migrate_image_cache_to_bytea.py
+++ b/tools/migrate_image_cache_to_bytea.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""把 image_cache.base64_data (TEXT) 迁移到 image_cache.blob_data (BYTEA)。
+
+背景（关联 issue）：
+  - #223「PG 后端——使用二进制格式存储图片」：base64 字符串效率低，PG 有 BYTEA 干啥不用
+  - #224「PG 后端——绝大多数（99.5%）图片缓存数据为NULL」：本次只动 schema，逻辑修复在
+    pallas/core/shared/utils/media_cache/__init__.py 里完成
+
+设计要点：
+  - **两阶段迁移**（加列 → UPDATE → 删旧列），避免在百万行 NULL 表上一次性
+    `ALTER COLUMN TYPE` 触发的长 ACCESS EXCLUSIVE 锁阻塞写入。
+  - **默认 dry-run**：必须显式 `--apply` 才会真正写库。
+  - **不依赖 NoneBot 启动**：直接用环境变量读 PG 连接（与 tools/migrate_mongo_to_pg.py 同款）。
+
+用法：
+    # 1. 预览：探测当前 schema、报告将要做的事
+    uv run --extra pg python tools/migrate_image_cache_to_bytea.py
+
+    # 2. 真实执行
+    uv run --extra pg python tools/migrate_image_cache_to_bytea.py --apply
+
+    # 3. 校验：抽 5 行确认 blob_data 已落盘 + cq_code 完整
+    uv run --extra pg python tools/migrate_image_cache_to_bytea.py --verify
+
+环境变量（与 migrate_mongo_to_pg.py 一致）：
+    PG_HOST / PG_PORT / PG_USER / PG_PASSWORD / PG_DB
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="把 image_cache.base64_data (TEXT/base64) 迁移到 blob_data (BYTEA)。默认 dry-run。"
+    )
+    g = p.add_mutually_exclusive_group()
+    g.add_argument(
+        "--apply",
+        action="store_true",
+        help="真正执行迁移（不加此参数则只打印计划）",
+    )
+    g.add_argument(
+        "--verify",
+        action="store_true",
+        help="迁移结束后再次校验：抽 5 行确认 blob_data 是 bytes、cq_code 完整",
+    )
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# 连接
+# ---------------------------------------------------------------------------
+
+
+def _pg_conn_kwargs() -> tuple[dict[str, object], str]:
+    """裸 asyncpg 连接参数 + 目标库名（用于 _ensure_db 之类的管理命令）。
+
+    Returns:
+        (conn_kwargs, db_name)：conn_kwargs 给 ``asyncpg.connect(**conn_kwargs)``，
+        db_name 单独返回（不在 kwargs 里，因为 asyncpg 把它当 key 不能轻易替换）。
+    """
+    h = os.getenv("PG_HOST") or os.getenv("MONGO_HOST", "127.0.0.1")
+    p_port = int(os.getenv("PG_PORT", "5432"))
+    u = os.getenv("PG_USER", "") or None
+    pw = os.getenv("PG_PASSWORD", "") or None
+    db = os.getenv("PG_DB", "PallasBot")
+    if not re.match(r"^[A-Za-z0-9_\-]+$", db):
+        raise ValueError(f"非法数据库名: {db!r}")
+    conn_kwargs: dict[str, object] = {"host": h, "port": p_port, "database": "postgres"}
+    if u is not None:
+        conn_kwargs["user"] = u
+    if pw is not None:
+        conn_kwargs["password"] = pw
+    return conn_kwargs, db
+
+
+# ---------------------------------------------------------------------------
+# 探测
+# ---------------------------------------------------------------------------
+
+
+async def _probe(conn) -> dict[str, object]:
+    """返回当前 image_cache 表的 schema 状态。"""
+    rows = await conn.fetch(
+        """
+        SELECT column_name, data_type, is_nullable
+        FROM information_schema.columns
+        WHERE table_name = 'image_cache'
+          AND column_name IN ('base64_data', 'blob_data')
+        """
+    )
+    cols = {r["column_name"]: {"type": r["data_type"], "nullable": r["is_nullable"]} for r in rows}
+
+    exists = await conn.fetchval("SELECT 1 FROM information_schema.tables WHERE table_name = 'image_cache'")
+
+    total = None
+    non_null_base64 = None
+    non_null_blob = None
+    if exists:
+        total = await conn.fetchval("SELECT count(*) FROM image_cache")
+        if "base64_data" in cols:
+            non_null_base64 = await conn.fetchval("SELECT count(*) FROM image_cache WHERE base64_data IS NOT NULL")
+        if "blob_data" in cols:
+            non_null_blob = await conn.fetchval("SELECT count(*) FROM image_cache WHERE blob_data IS NOT NULL")
+
+    return {
+        "table_exists": bool(exists),
+        "columns": cols,
+        "total_rows": total,
+        "non_null_base64": non_null_base64,
+        "non_null_blob": non_null_blob,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 迁移主流程
+# ---------------------------------------------------------------------------
+
+
+async def _migrate(conn) -> None:
+    """两阶段迁移：在单事务里加列 → UPDATE → 删旧列。"""
+    async with conn.transaction():
+        # 1. 加新列
+        await conn.execute("ALTER TABLE image_cache ADD COLUMN blob_data BYTEA")
+        print("  + ADD COLUMN blob_data BYTEA")
+
+        # 2. 把旧 base64 字符串解码灌入新列（NULL 保持 NULL）
+        await conn.execute(
+            "UPDATE image_cache SET blob_data = decode(base64_data, 'base64') WHERE base64_data IS NOT NULL"
+        )
+        print("  + UPDATE image_cache SET blob_data = decode(base64_data, 'base64') WHERE base64_data IS NOT NULL")
+
+        # 3. 删旧列
+        await conn.execute("ALTER TABLE image_cache DROP COLUMN base64_data")
+        print("  + DROP COLUMN base64_data")
+
+
+async def _verify(conn) -> None:
+    """抽 5 行确认 blob_data 落盘 + cq_code 完整。"""
+    rows = await conn.fetch(
+        """
+        SELECT cq_code, ref_times, date, octet_length(blob_data) AS blob_bytes
+        FROM image_cache
+        WHERE blob_data IS NOT NULL
+        ORDER BY random()
+        LIMIT 5
+        """
+    )
+    if not rows:
+        print("[verify] 没有任何 blob_data 非空的行——可能数据还没灌进来。")
+        return
+    print(f"[verify] 抽样 {len(rows)} 行：")
+    for r in rows:
+        print(f"  cq_code={r['cq_code']!r}  ref_times={r['ref_times']}  date={r['date']}  blob_bytes={r['blob_bytes']}")
+
+
+# ---------------------------------------------------------------------------
+# 入口
+# ---------------------------------------------------------------------------
+
+
+async def _run(args: argparse.Namespace) -> int:
+    import asyncpg
+
+    conn_kwargs, db = _pg_conn_kwargs()
+    conn_kwargs["database"] = db
+
+    print(f"目标 PG: {conn_kwargs['host']}:{conn_kwargs['port']}/{db}")
+    conn = await asyncpg.connect(**conn_kwargs)
+    try:
+        state = await _probe(conn)
+        print("\n[probe] 当前 image_cache 状态：")
+        print(f"  table_exists     = {state['table_exists']}")
+        print(f"  columns          = {state['columns']}")
+        print(f"  total_rows       = {state['total_rows']}")
+        print(f"  non_null_base64  = {state['non_null_base64']}")
+        print(f"  non_null_blob    = {state['non_null_blob']}")
+
+        if not state["table_exists"]:
+            print("\n[plan] image_cache 表不存在——请先启动一次 Bot 让 init_pg 走 create_all 创建表，再重跑本脚本。")
+            return 0
+
+        if "blob_data" in state["columns"] and "base64_data" not in state["columns"]:
+            data_type = state["columns"]["blob_data"]["type"]
+            if data_type == "bytea":
+                print("\n[plan] 已迁移过（blob_data BYTEA），无需操作。")
+                if args.verify:
+                    await _verify(conn)
+                return 0
+            print(f"\n[plan] 异常：blob_data 存在但类型是 {data_type}，需要人工处理。")
+            return 1
+
+        if "base64_data" not in state["columns"]:
+            print("\n[plan] 异常：表存在但既没有 base64_data 也没有 blob_data，请人工检查。")
+            return 1
+
+        # 此时确定需要迁移：只有 base64_data TEXT
+        old_type = state["columns"]["base64_data"]["type"]
+        non_null = state["non_null_base64"] or 0
+        total = state["total_rows"] or 0
+        print(f"\n[plan] 需要迁移：base64_data 是 {old_type}（{non_null}/{total} 行非空）")
+        print("[plan] 步骤：")
+        print("  1) ALTER TABLE image_cache ADD COLUMN blob_data BYTEA")
+        print("  2) UPDATE image_cache SET blob_data = decode(base64_data, 'base64') WHERE base64_data IS NOT NULL")
+        print("  3) ALTER TABLE image_cache DROP COLUMN base64_data")
+
+        if not args.apply:
+            print("\n[plan] dry-run 模式，没有改动。加 --apply 真正执行。")
+            return 0
+
+        print("\n[apply] 开始迁移…")
+        await _migrate(conn)
+        print("[apply] 迁移完成，重新探测：")
+        new_state = await _probe(conn)
+        print(f"  columns       = {new_state['columns']}")
+        print(f"  non_null_blob = {new_state['non_null_blob']}")
+
+        if args.verify:
+            await _verify(conn)
+        return 0
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        return asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        print("中断", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -141,7 +141,7 @@ def _as_list(x: Any) -> list:
         return x
     if x is None:
         return []
-# tuple / set 也视为可迭代
+    # tuple / set 也视为可迭代
     if isinstance(x, (tuple, set)):
         return list(x)
     return []
@@ -163,7 +163,7 @@ def _strip_null(obj: Any) -> Any:
 
 
 def _kw_hash(keywords: str) -> str:
-# 与 repository_pg.keywords_hash 保持一致：先 strip \x00 再哈希
+    # 与 repository_pg.keywords_hash 保持一致：先 strip \x00 再哈希
     clean = keywords.replace("\x00", "") if keywords and "\x00" in keywords else keywords
     return hashlib.md5((clean or "").encode("utf-8", errors="replace")).hexdigest()
 
@@ -196,9 +196,9 @@ async def _ensure_db() -> None:
     db = os.getenv("PG_DB", "PallasBot")
     if not re.match(r"^[A-Za-z0-9_\-]+$", db):
         raise ValueError(f"非法数据库名: {db!r}")
-# 未显式指定 PG_USER/PG_PASSWORD 时省掉这两个参数，让 libpq 走默认用户
-# 和 .pgpass，否则很多本地 trust / peer 鉴权环境
-# 会因为 user=None 直接连不上。
+    # 未显式指定 PG_USER/PG_PASSWORD 时省掉这两个参数，让 libpq 走默认用户
+    # 和 .pgpass，否则很多本地 trust / peer 鉴权环境
+    # 会因为 user=None 直接连不上。
     conn_kwargs: dict[str, object] = {"host": h, "port": p, "database": "postgres"}
     if u is not None:
         conn_kwargs["user"] = u
@@ -207,8 +207,8 @@ async def _ensure_db() -> None:
     conn = await asyncpg.connect(**conn_kwargs)
     try:
         if not await conn.fetchval("SELECT 1 FROM pg_database WHERE datname=$1", db):
-# PG 不支持用占位符绑定 identifier，只能拼接；上面的正则已保证 db 仅含
-# [A-Za-z0-9_-]，不存在注入风险。
+            # PG 不支持用占位符绑定 identifier，只能拼接；上面的正则已保证 db 仅含
+            # [A-Za-z0-9_-]，不存在注入风险。
             await conn.execute(f'CREATE DATABASE "{db}"')  # noqa: S608
             print(f"已创建数据库 {db}")
         else:
@@ -255,9 +255,7 @@ async def _reset_state(engine) -> None:
 async def _get_state(session, table: str) -> str | None:
     from sqlalchemy import text as T
 
-    result = await session.execute(
-        T(f"SELECT last_id FROM {_STATE_TABLE} WHERE table_name = :t"), {"t": table}
-    )
+    result = await session.execute(T(f"SELECT last_id FROM {_STATE_TABLE} WHERE table_name = :t"), {"t": table})
     return result.scalar_one_or_none()
 
 
@@ -327,7 +325,7 @@ def _prepare_context_batch(docs: list[dict], stats: _TableStats) -> dict[str, di
                 continue
             h = _kw_hash(kw)
             time_v = _as_int(doc.get("time"))
-# 兼容 Beanie alias："count" 或 "trigger_count" 都可能写到文档里
+            # 兼容 Beanie alias："count" 或 "trigger_count" 都可能写到文档里
             trigger_v = _as_int(doc.get("trigger_count", doc.get("count", 1)), 1)
             clear_v = _as_int(doc.get("clear_time"))
 
@@ -433,9 +431,13 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
 
         if not dry_run:
             async with sf() as session:
-# 1. upsert context rows
+                # 1. upsert context rows
                 ctx_values = [
-                    {k: v for k, v in g.items() if k in ("keywords", "keywords_hash", "time", "trigger_count", "clear_time")}
+                    {
+                        k: v
+                        for k, v in g.items()
+                        if k in ("keywords", "keywords_hash", "time", "trigger_count", "clear_time")
+                    }
                     for g in merged.values()
                 ]
                 stmt = ins(ContextRow).values(ctx_values)
@@ -450,16 +452,14 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                         },
                     )
                 )
-# 2. 拿回 context_id
+                # 2. 拿回 context_id
                 result = await session.execute(
-                    S(ContextRow.id, ContextRow.keywords_hash).where(
-                        ContextRow.keywords_hash.in_(list(merged.keys()))
-                    )
+                    S(ContextRow.id, ContextRow.keywords_hash).where(ContextRow.keywords_hash.in_(list(merged.keys())))
                 )
                 h2id: dict[str, int] = {r.keywords_hash: r.id for r in result}
                 ctx_ids = [cid for cid in h2id.values() if cid is not None]
 
-# 3. 重写 answers / bans：先删再插
+                # 3. 重写 answers / bans：先删再插
                 if ctx_ids:
                     await session.execute(D(AnsRow).where(AnsRow.context_id.in_(ctx_ids)))
                     await session.execute(D(BanRow).where(BanRow.context_id.in_(ctx_ids)))
@@ -484,9 +484,7 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                             "time": a["time"],
                         })
                         if a["messages"]:
-                            ans_msg_pending.append(
-                                (cid, (cid, a["group_id"], kh), a["messages"])
-                            )
+                            ans_msg_pending.append((cid, (cid, a["group_id"], kh), a["messages"]))
                     for b in g["bans"]:
                         ban_rows.append({
                             "context_id": cid,
@@ -496,9 +494,9 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                             "time": b["time"],
                         })
 
-# 4. 批量插 answer 并拿回 id
-# 键 = (context_id, group_id, keywords_hash) 对齐 UNIQUE 约束，
-# 避免用 TEXT keywords 作 key 时超长字符串带来的内存开销
+                # 4. 批量插 answer 并拿回 id
+                # 键 = (context_id, group_id, keywords_hash) 对齐 UNIQUE 约束，
+                # 避免用 TEXT keywords 作 key 时超长字符串带来的内存开销
                 key2aid: dict[tuple[int, int, str], int] = {}
                 for i in range(0, len(ans_rows), _ANS_BATCH):
                     ret = await session.execute(
@@ -509,7 +507,7 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                     for r in ret.fetchall():
                         key2aid[(r.context_id, r.group_id, r.keywords_hash)] = int(r.id)
 
-# 5. 关联 messages
+                # 5. 关联 messages
                 msg_rows: list[dict] = []
                 for _cid, key, messages in ans_msg_pending:
                     aid = key2aid.get(key)
@@ -519,11 +517,11 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                 for i in range(0, len(msg_rows), _MSG_BATCH):
                     await session.execute(ins(AnsMsgRow).values(msg_rows[i : i + _MSG_BATCH]))
 
-# 6. 插 bans
+                # 6. 插 bans
                 for i in range(0, len(ban_rows), _BAN_BATCH):
                     await session.execute(ins(BanRow).values(ban_rows[i : i + _BAN_BATCH]))
 
-# 7. 更新 pallas_migration_state 并一并 commit
+                # 7. 更新 pallas_migration_state 并一并 commit
                 await _set_state(session, "context", str(batch[-1]["_id"]))
                 await session.commit()
 
@@ -576,7 +574,7 @@ async def _migrate_message(db, sf, MsgRow, ins, batch_size, dry_run) -> _TableSt
 
         if rows and not dry_run:
             async with sf() as session:
-# 分批插入避免超出 asyncpg 参数上限
+                # 分批插入避免超出 asyncpg 参数上限
                 for i in range(0, len(rows), _MSG_ROW_BATCH):
                     await session.execute(ins(MsgRow), rows[i : i + _MSG_ROW_BATCH])
                 await _set_state(session, "message", str(batch[-1]["_id"]))
@@ -654,7 +652,7 @@ async def _migrate_bot_config(db, sf, BCRow, ins, batch_size, dry_run) -> _Table
         rows: list[dict] = []
         for raw in batch:
             try:
-# 兼容旧字段：auto_accept 仅对 group 生效
+                # 兼容旧字段：auto_accept 仅对 group 生效
                 if "auto_accept" in raw and "auto_accept_group" not in raw:
                     ag, af = _as_bool(raw.get("auto_accept")), False
                 else:
@@ -804,6 +802,14 @@ async def _migrate_user_config(db, sf, UCRow, ins, batch_size, dry_run) -> _Tabl
 
 
 async def _migrate_image_cache(db, sf, ICRow, ins, batch_size, dry_run) -> _TableStats:
+    """mongo image_cache → pg image_cache.blob_data (BYTEA)。
+
+    兼容两种 mongo 历史形态：
+      - 旧字段 base64_data (str)：base64 字符串 → base64.b64decode → bytes
+      - 新字段 blob_data (bson.Binary)：直接当 bytes 用
+    """
+    import base64 as _b64
+
     col = db["image_cache"]
     stats = _TableStats()
     stats.total = await col.count_documents({})
@@ -822,9 +828,23 @@ async def _migrate_image_cache(db, sf, ICRow, ins, batch_size, dry_run) -> _Tabl
                 if not cq:
                     stats.warn(f"imagecache empty cq_code _id={doc.get('_id')}")
                     continue
+                # blob_data 优先（新代码写入的）；回退 base64_data 字符串
+                raw_blob = doc.get("blob_data")
+                if raw_blob is not None:
+                    blob = bytes(raw_blob) if not isinstance(raw_blob, (bytes, bytearray)) else bytes(raw_blob)
+                else:
+                    raw_b64 = doc.get("base64_data")
+                    if raw_b64:
+                        try:
+                            blob = _b64.b64decode(_strip_null(raw_b64) or "", validate=True)
+                        except Exception as decode_err:
+                            stats.warn(f"imagecache base64 decode failed _id={doc.get('_id')}: {decode_err}")
+                            blob = None
+                    else:
+                        blob = None
                 rows.append({
                     "cq_code": _strip_null(cq),
-                    "base64_data": _strip_null(doc.get("base64_data")) if doc.get("base64_data") else None,
+                    "blob_data": blob,
                     "ref_times": _as_int(doc.get("ref_times"), 1),
                     "date": _as_int(doc.get("date")),
                 })
@@ -839,7 +859,7 @@ async def _migrate_image_cache(db, sf, ICRow, ins, batch_size, dry_run) -> _Tabl
                     await session.execute(
                         stmt.on_conflict_do_update(
                             index_elements=["cq_code"],
-                            set_={f: getattr(stmt.excluded, f) for f in ("base64_data", "ref_times", "date")},
+                            set_={f: getattr(stmt.excluded, f) for f in ("blob_data", "ref_times", "date")},
                         )
                     )
                 await _set_state(session, "imagecache", str(batch[-1]["_id"]))
@@ -937,7 +957,7 @@ async def migrate(
 
     await engine.dispose()
 
-# 汇总
+    # 汇总
     print("\n========== 迁移摘要 ==========")
     total_failed = 0
     for name, s in summaries:


### PR DESCRIPTION
修两个关联问题（issue #223 / #224）：

#223：原 ImageCache.base64_data 用 base64 字符串存在 PG TEXT 列，效率低
- pallas/core/foundation/db/modules.py: 字段 base64_data: str → blob_data: bytes
- pallas/core/foundation/db/repository_pg.py: ImageCacheRow.base64_data Text → LargeBinary，DDL 变 BYTEA
- tools/migrate_image_cache_to_bytea.py (新): 独立 dry-run 迁移脚本 两阶段 ADD COLUMN → UPDATE decode → DROP COLUMN 避免大表 ALTER 触发的长 ACCESS EXCLUSIVE 锁阻塞写入
- tools/migrate_mongo_to_pg.py: mongo → pg 时把历史 base64 字符串 decode 成 bytes 写入新列；兼容旧字段名 + 新 Binary 字段

#224：原 _insert_image_io 在「第一次见」时直接写 base64_data=None 的占位行，等「第三次见」才下载——结果单/两次出现的图永远 NULL，
99.5% 行 base64_data 为 NULL，浪费空间
- pallas/core/shared/utils/media_cache/__init__.py: 重写 _insert_image_io 第一次见 → 尝试下载，下载成功才落盘；下载失败不缓存 后续见 → ref_times++ + 刷日期
- get_image: 去掉 base64.b64decode，直接返回 bytes

测试：
- tests/common/test_image_cache_repository.py: 6 个 Mongo 契约测试通过
- tests/common/test_media_cache_async.py: 2 个 async 队列测试通过
- tests/common/test_repository_pg.py: 2 个 PG 集成测试（无 PG_TEST_DSN 自动 skip，代码 ruff 静态过）
- tests/common/test_migrate_robustness.py: 1 个 mongo→pg 端到端测试 （无 PG_TEST_DSN 自动 skip，代码 ruff 静态过）

Ruff: 本 PR 新增/修改文件 0 error。
migrate_mongo_to_pg.py 上有 17 个 pre-existing dev-v2 风格问题 （lowercase import alias / 大写参数名），不在本 PR 范围。

Refs: #223, #224

## Summary by Sourcery

将缓存的图像以二进制 blob 而不是 base64 字符串存储，并清理图像缓存行为以避免出现 NULL 占位行。

New Features:
- 引入专用迁移脚本，将 PostgreSQL 的 `image_cache` 表从 base64 `TEXT` 字段转换为 `BYTEA` 类型的 `blob_data`，并支持 dry-run 模式和结果验证。

Enhancements:
- 修改 `ImageCache` 模型及其 PostgreSQL ORM 映射，使用由 `BYTEA` 支持的二进制字段 `blob_data`，替代原来的 base64_data `TEXT` 列。
- 更新媒体缓存工具，使图像在首次成功获取时以二进制数据下载并缓存，后续访问仅更新计数器和日期。
- 扩展 Mongo→PostgreSQL 迁移逻辑，在填充 `image_cache` 表时同时处理旧的 base64_data 字符串和新的 blob_data 二进制值。
- 整理 `migrate_mongo_to_pg` 中的注释和部分查询构造，以提高一致性和可读性。

Tests:
- 调整并扩展 PostgreSQL 仓库和迁移健壮性测试，以覆盖 `blob_data` 字段、upsert 语义，以及历史 base64 图像载荷的正确解码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Store cached images as binary blobs instead of base64 strings and clean up image caching behavior to avoid NULL placeholder rows.

New Features:
- Introduce a dedicated migration script to convert the PostgreSQL image_cache table from base64 TEXT to BYTEA blob_data with a dry-run mode and verification support.

Enhancements:
- Change the ImageCache model and PostgreSQL ORM mapping to use a blob_data binary field backed by BYTEA instead of a base64_data TEXT column.
- Update the media cache utilities so images are downloaded and cached as binary data on first successful fetch, and subsequent accesses only bump counters and dates.
- Extend the Mongo→PostgreSQL migration to handle both legacy base64_data strings and new blob_data Binary values when populating the image_cache table.
- Tidy migrate_mongo_to_pg comments and a few query constructions for consistency and readability.

Tests:
- Adjust and extend PostgreSQL repository and migration robustness tests to cover the blob_data field, upsert semantics, and correct decoding of historical base64 image payloads.

</details>