### PR TITLE
feat(acl): 统一 ACL 权限系统（rebase + 阻塞修复）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && \
     pip install uv && \
     rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml LICENSE README.md ./
+COPY pyproject.toml LICENSE ./
+# .dockerignore 排除了 *.md；给 hatchling 提供最小 README 以满足 pyproject readme=
+RUN printf '%s\n' '# Pallas-Bot' > README.md
 
 # perf：jieba-next；pg：PostgreSQL 后端
 # deploy-shard：见 deploy/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     pip install uv && \
     rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml ./
+COPY pyproject.toml LICENSE ./
 
 # perf：jieba-next；pg：PostgreSQL 后端
 # deploy-shard：见 deploy/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     pip install uv && \
     rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml LICENSE ./
+COPY pyproject.toml LICENSE README.md ./
 
 # perf：jieba-next；pg：PostgreSQL 后端
 # deploy-shard：见 deploy/README.md

--- a/bot_hub.py
+++ b/bot_hub.py
@@ -59,6 +59,12 @@ register_onebot_v11_custom_events()
 @driver.on_startup
 async def startup():
     await init_db()
+    from pallas.core.perm.migration import run_acl_startup_migrations
+
+    try:
+        await run_acl_startup_migrations()
+    except Exception as e:
+        nonebot.logger.warning("bot_hub: ACL startup migration failed: {}", e)
     await start_ban_gate_snapshot()
     from pallas.core.platform.coord.redis_settings import ensure_coord_redis_ready_for_sharding
 

--- a/bot_worker.py
+++ b/bot_worker.py
@@ -91,6 +91,12 @@ async def _ensure_worker_voices_background() -> None:
 @driver.on_startup
 async def startup():
     await init_db()
+    from pallas.core.perm.migration import run_acl_startup_migrations
+
+    try:
+        await run_acl_startup_migrations()
+    except Exception as e:
+        nonebot.logger.warning("bot_worker: ACL startup migration failed: {}", e)
     await start_ban_gate_snapshot()
     from pallas.core.platform.coord.redis_settings import (
         coord_redis_enabled,

--- a/packages/blacklist/ban_gate.py
+++ b/packages/blacklist/ban_gate.py
@@ -131,23 +131,53 @@ async def _sync_acl_group_banned(group_id: int, banned: bool) -> None:
 
 
 async def _sync_acl_group_blocked_users(group_id: int, user_ids: list[int]) -> None:
+    """将 GroupConfig.blocked_user_ids 与 ACL 表 reconcile：
+    当前列表里的人在 ACL 中以 deny 形式存在；
+    不在列表里的历史 deny 行同步删除。
+    """
     try:
         from pallas.core.foundation.db import make_acl_repository
 
         repo = make_acl_repository()
     except Exception:
         return
+    target_prefix = f"group:{int(group_id)}"
+    new_uids = {int(u) for u in user_ids}
     try:
-        for uid in user_ids:
+        # 1) upsert 当前 uid 集合（命中即 priority=1000 deny）
+        for uid in new_uids:
             await repo.upsert_rule(
                 role="用户",
-                subject=f"u:{int(uid)}",
+                subject=f"u:{uid}",
                 action="event.receive",
                 target_scope="全局",
-                target=f"group:{int(group_id)}",
+                target=target_prefix,
                 effect="deny",
                 priority=1000,
                 source="system",
+            )
+        # 2) 列出该 group 全部历史 ACL 行，剔除仍存在于 new_uids 的，差集删除
+        all_rules = await repo.list_matching_rules(action="event.receive", target=target_prefix)
+        stale_uids: set[int] = set()
+        for r in all_rules:
+            if r.role != "用户":
+                continue
+            subj = getattr(r, "subject", "") or ""
+            if not subj.startswith("u:"):
+                continue
+            try:
+                rid = int(subj[2:])
+            except ValueError:
+                continue
+            if rid not in new_uids:
+                stale_uids.add(rid)
+        for rid in stale_uids:
+            await repo.delete_by_signature(
+                role="用户",
+                subject=f"u:{rid}",
+                action="event.receive",
+                target_scope="全局",
+                target=target_prefix,
             )
     except Exception:
         from nonebot import logger

--- a/packages/blacklist/ban_gate.py
+++ b/packages/blacklist/ban_gate.py
@@ -98,6 +98,7 @@ async def _sync_acl_user_banned(user_id: int, banned: bool) -> None:
 async def _sync_acl_group_banned(group_id: int, banned: bool) -> None:
     try:
         from pallas.core.foundation.db import make_acl_repository
+        from pallas.core.perm.acl import ACL_TARGET_GROUP_BAN
 
         repo = make_acl_repository()
     except Exception:
@@ -111,7 +112,7 @@ async def _sync_acl_group_banned(group_id: int, banned: bool) -> None:
                 subject=subj,
                 action="event.receive",
                 target_scope="全局",
-                target="*",
+                target=ACL_TARGET_GROUP_BAN,
                 effect="deny",
                 priority=2000,
                 source="system",
@@ -122,7 +123,7 @@ async def _sync_acl_group_banned(group_id: int, banned: bool) -> None:
                 subject=subj,
                 action="event.receive",
                 target_scope="全局",
-                target="*",
+                target=ACL_TARGET_GROUP_BAN,
             )
     except Exception:
         from nonebot import logger
@@ -137,11 +138,12 @@ async def _sync_acl_group_blocked_users(group_id: int, user_ids: list[int]) -> N
     """
     try:
         from pallas.core.foundation.db import make_acl_repository
+        from pallas.core.perm.acl import group_block_target
 
         repo = make_acl_repository()
     except Exception:
         return
-    target_prefix = f"group:{int(group_id)}"
+    target_prefix = group_block_target(group_id)
     new_uids = {int(u) for u in user_ids}
     try:
         # 1) upsert 当前 uid 集合（命中即 priority=1000 deny）

--- a/packages/blacklist/ban_gate.py
+++ b/packages/blacklist/ban_gate.py
@@ -42,19 +42,117 @@ _group_self_fetch_tasks_lock = asyncio.Lock()
 
 
 async def apply_user_banned_change(user_id: int, banned: bool) -> None:
-    """WebUI / 命令写入 user_config.banned 后同步本进程快照与门禁。"""
+    """WebUI / 命令写入 user_config.banned 后同步 ACL 行、本进程快照与门禁。"""
     await patch_user_banned(user_id, banned)
+    await _sync_acl_user_banned(user_id, banned)
     await invalidate_user_ban_gate_cache(user_id)
 
 
 async def apply_group_banned_change(group_id: int, banned: bool) -> None:
     await patch_group_banned(group_id, banned)
+    await _sync_acl_group_banned(group_id, banned)
     await invalidate_group_ban_gate_cache(group_id)
 
 
 async def apply_group_blocked_users_change(group_id: int, user_ids: list[int]) -> None:
     await patch_group_blocked_users(group_id, user_ids)
+    await _sync_acl_group_blocked_users(group_id, user_ids)
     await invalidate_group_ban_gate_cache(group_id)
+
+
+async def _sync_acl_user_banned(user_id: int, banned: bool) -> None:
+    try:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+    except Exception:
+        return
+    role = "用户"
+    subj = f"u:{int(user_id)}"
+    try:
+        if banned:
+            await repo.upsert_rule(
+                role=role,
+                subject=subj,
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+                effect="deny",
+                priority=2000,
+                source="system",
+            )
+        else:
+            await repo.delete_by_signature(
+                role=role,
+                subject=subj,
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+            )
+    except Exception:
+        from nonebot import logger
+
+        logger.exception("ban_gate: failed to mirror user ban into ACL uid={}", user_id)
+
+
+async def _sync_acl_group_banned(group_id: int, banned: bool) -> None:
+    try:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+    except Exception:
+        return
+    role = "群"
+    subj = f"g:{int(group_id)}"
+    try:
+        if banned:
+            await repo.upsert_rule(
+                role=role,
+                subject=subj,
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+                effect="deny",
+                priority=2000,
+                source="system",
+            )
+        else:
+            await repo.delete_by_signature(
+                role=role,
+                subject=subj,
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+            )
+    except Exception:
+        from nonebot import logger
+
+        logger.exception("ban_gate: failed to mirror group ban into ACL gid={}", group_id)
+
+
+async def _sync_acl_group_blocked_users(group_id: int, user_ids: list[int]) -> None:
+    try:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+    except Exception:
+        return
+    try:
+        for uid in user_ids:
+            await repo.upsert_rule(
+                role="用户",
+                subject=f"u:{int(uid)}",
+                action="event.receive",
+                target_scope="全局",
+                target=f"group:{int(group_id)}",
+                effect="deny",
+                priority=1000,
+                source="system",
+            )
+    except Exception:
+        from nonebot import logger
+
+        logger.exception("ban_gate: failed to mirror group blocked users into ACL gid={}", group_id)
 
 
 async def invalidate_user_ban_gate_cache(uids: int | Iterable[int]) -> None:

--- a/packages/blacklist/gate_block.py
+++ b/packages/blacklist/gate_block.py
@@ -1,13 +1,13 @@
 """ACL-driven ban gate preprocessor.
 
 策略：
-- ACL 引擎评估 ``event.receive`` 行为，三种 target：
-    - ``"*"`` 普通群/私聊消息
-    - ``"group"`` group 自身封禁（group_id 维度评估）
-    - ``"friend_request"`` / ``"group_invite"`` / 群内消息的 group 编码
-- ACL 返回 ``allow=True`` → 放行。
-- ACL fallback → 回退查 legacy 列（user_config.banned / group_config.banned /
-  group_config.blocked_user_ids）。仅在此 fail-closed 短窗口兜底。
+- ACL 引擎评估 ``event.receive``：
+    - 群自身封禁：``target=ACL_TARGET_GROUP_BAN``（``"group"``）
+    - 群内黑名单用户：``target=group:{gid}``
+    - 好友/群邀请：``friend_request`` / ``group_invite``
+    - 其它：``"*"``
+- ACL 返回 decisive 决策 → 直接放行或拦截。
+- ACL fallback（无规则）→ 回退 legacy 列（含 group_blocked），与迁移窗口一致。
 """
 
 from nonebot import logger
@@ -17,9 +17,20 @@ from nonebot.exception import IgnoredException
 from nonebot.message import event_preprocessor
 from nonebot.utils import run_coro_with_shield
 
-from pallas.core.perm.acl import AclDecision, AclSubject, evaluate_acl
+from pallas.core.perm.acl import (
+    ACL_TARGET_ANY,
+    ACL_TARGET_GROUP_BAN,
+    AclDecision,
+    AclSubject,
+    evaluate_acl,
+    group_block_target,
+)
 
-from .ban_gate import query_group_ban_status_for_gate, query_user_ban_status_for_gate
+from .ban_gate import (
+    query_group_ban_status_for_gate,
+    query_group_blocked_for_gate,
+    query_user_ban_status_for_gate,
+)
 from .helpers import event_actor_user_id, event_group_id
 
 
@@ -28,17 +39,15 @@ def _is_acl_decisive(decision: AclDecision) -> bool:
     return decision.source != "fallback"
 
 
-def _event_action_target(event: Event, gid: int | None, uid: int | None) -> tuple[str, str]:
-    """把 event 投影到 (action, target) 二元组。
-
-    群维度评估 action='event.receive', target='group'。
-    用户维度评估：好友邀请走 'friend_request'/'group_invite'；群消息走 'group:<gid>'；其他走 '*'。
-    """
+def _event_user_target(event: Event, gid: int | None) -> str:
+    """用户维度评估的 target。"""
     if isinstance(event, FriendRequestEvent):
-        return "event.receive", "friend_request"
+        return "friend_request"
     if isinstance(event, GroupRequestEvent) and getattr(event, "sub_type", "") == "invite":
-        return "event.receive", "group_invite"
-    return "event.receive", "*"
+        return "group_invite"
+    if gid is not None:
+        return group_block_target(gid)
+    return ACL_TARGET_ANY
 
 
 @event_preprocessor
@@ -56,53 +65,64 @@ async def block_globally_banned_users(bot: Bot, event: Event):
     except Exception:
         bot_self_id = None
 
-    # 1. group 维度 ACL（仅在有 gid 时评估；target="group" 是约定的群维度 token）
+    # 1. 群自身封禁（target 与 ban_gate / migration 写入一致）
     if gid is not None:
         group_subject = AclSubject(group_id=gid, bot_id=bot_self_id)
         group_decision = await run_coro_with_shield(
-            evaluate_acl(action="event.receive", target="group", subject=group_subject)
+            evaluate_acl(
+                action="event.receive",
+                target=ACL_TARGET_GROUP_BAN,
+                subject=group_subject,
+            )
         )
-        if not group_decision.allow:
-            if _is_acl_decisive(group_decision):
+        if _is_acl_decisive(group_decision):
+            if not group_decision.allow:
                 logger.debug("drop event in group gid={} acl source={}", gid, group_decision.source)
                 raise IgnoredException("banned group by acl")
+        else:
             group_banned = await run_coro_with_shield(query_group_ban_status_for_gate(gid))
             if group_banned:
                 logger.debug("drop event in banned group gid={}", gid)
                 raise IgnoredException("banned group")
 
-    # 2. user 维度 ACL：用 group 编码 target 提高精度
+    # 2. 用户维度（全局封禁 / 群内黑名单）
     if uid is None:
         return
-    action, generic_target = _event_action_target(event, gid, uid)
-    user_action_target = (
-        f"group:{gid}" if gid is not None and generic_target == "*" else generic_target
-    )
+    user_target = _event_user_target(event, gid)
     user_subject = AclSubject(user_id=uid, group_id=gid, bot_id=bot_self_id)
     user_decision = await run_coro_with_shield(
-        evaluate_acl(action=action, target=user_action_target, subject=user_subject)
+        evaluate_acl(action="event.receive", target=user_target, subject=user_subject)
     )
     if _is_acl_decisive(user_decision):
         if user_decision.allow:
-            return  # ACL 显式 allow，直接放行，不再做 legacy 探测
-        # ACL 显式 deny，但需要区分 friend_request / group_invite 的 reject 处理
-        await _reject_or_ignore(event, bot, uid, allow=False, banned=True)
+            return
+        await _reject_or_ignore(event, bot, uid, global_banned=True)
         return
 
-    # fallback: ACL 无规则 → 走 legacy 列
+    # fallback: ACL 无规则 → legacy（必须仍查 group_blocked，避免迁移窗口漏拦）
     global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
-    if not global_banned:
+    group_blocked = False
+    if gid is not None:
+        group_blocked = await run_coro_with_shield(query_group_blocked_for_gate(gid, uid))
+    if not global_banned and not group_blocked:
         return
-    await _reject_or_ignore(event, bot, uid, allow=False, banned=True)
+    # 好友请求仅在全局封禁时拒绝（与改前一致）
+    if isinstance(event, FriendRequestEvent) and not global_banned:
+        return
+    await _reject_or_ignore(event, bot, uid, global_banned=global_banned)
 
 
-async def _reject_or_ignore(event: Event, bot: Bot, uid: int | None, *, allow: bool, banned: bool) -> None:
-    """friend_request → reject + Ignored；group_invite → 同；其它 → Ignored。"""
-    if allow:
-        return
-    if not banned:
-        return
+async def _reject_or_ignore(
+    event: Event,
+    bot: Bot,
+    uid: int | None,
+    *,
+    global_banned: bool,
+) -> None:
+    """friend_request / group_invite → reject + Ignored；其它 → Ignored。"""
     if isinstance(event, FriendRequestEvent):
+        if not global_banned:
+            return
         try:
             await event.reject(bot)
         except Exception as e:

--- a/packages/blacklist/gate_block.py
+++ b/packages/blacklist/gate_block.py
@@ -5,8 +5,14 @@ from nonebot.exception import IgnoredException
 from nonebot.message import event_preprocessor
 from nonebot.utils import run_coro_with_shield
 
+from pallas.core.perm.acl import AclDecision, AclSubject, evaluate_acl
+
 from .ban_gate import query_group_ban_status_for_gate, query_group_blocked_for_gate, query_user_ban_status_for_gate
 from .helpers import event_actor_user_id, event_group_id
+
+
+def _decision_to_ban_bool(decision: AclDecision) -> bool:
+    return not decision.allow
 
 
 @event_preprocessor
@@ -15,24 +21,65 @@ async def block_globally_banned_users(bot: Bot, event: Event):
         return
 
     gid = event_group_id(event)
-    if gid is not None:
-        group_banned = await run_coro_with_shield(query_group_ban_status_for_gate(gid))
-        if group_banned:
-            logger.debug(f"drop event in banned group [{gid}]")
-            raise IgnoredException("banned group")
-
     uid = event_actor_user_id(event)
+    if uid is not None and uid == int(bot.self_id):
+        uid = None
+
+    bot_self_id: int | None
+    try:
+        bot_self_id = int(bot.self_id)
+    except Exception:
+        bot_self_id = None
+
+    subject = AclSubject(user_id=uid, group_id=gid, bot_id=bot_self_id)
+
+    if gid is not None:
+        try:
+            event_action = "event.receive"
+            group_decision: AclDecision = await run_coro_with_shield(
+                evaluate_acl(action=event_action, target="*", subject=AclSubject(group_id=gid, bot_id=bot_self_id))
+            )
+            if not group_decision.allow:
+                if group_decision.source == "fallback":
+                    group_banned = await run_coro_with_shield(query_group_ban_status_for_gate(gid))
+                    if group_banned:
+                        logger.debug(f"drop event in banned group [{gid}]")
+                        raise IgnoredException("banned group")
+                else:
+                    logger.debug(f"drop event by ACL group rule gid=[{gid}] source={group_decision.source}")
+                    raise IgnoredException("banned group by acl")
+        except IgnoredException:
+            raise
+        except Exception:
+            pass
+
     if uid is None:
         return
-    if uid == int(bot.self_id):
-        return
 
-    async def resolve_ban_gate() -> tuple[bool, bool]:
-        global_banned = await query_user_ban_status_for_gate(uid)
-        group_blocked = await query_group_blocked_for_gate(gid, uid) if gid is not None else False
-        return global_banned, group_blocked
-
-    global_banned, group_blocked = await run_coro_with_shield(resolve_ban_gate())
+    user_action = "event.receive"
+    target_kind = (
+        "friend_request" if isinstance(event, FriendRequestEvent)
+        else "group_invite" if isinstance(event, GroupRequestEvent) and event.sub_type == "invite"
+        else "*"
+    )
+    user_decision: AclDecision = await run_coro_with_shield(
+        evaluate_acl(action=user_action, target=target_kind, subject=subject)
+    )
+    group_blocked = False
+    if gid is not None:
+        if user_decision.source == "fallback":
+            group_blocked = await run_coro_with_shield(query_group_blocked_for_gate(gid, uid))
+            if group_blocked:
+                global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
+            else:
+                global_banned = False
+        else:
+            global_banned = not user_decision.allow
+    else:
+        if user_decision.source == "fallback":
+            global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
+        else:
+            global_banned = not user_decision.allow
 
     if not global_banned and not group_blocked:
         return

--- a/packages/blacklist/gate_block.py
+++ b/packages/blacklist/gate_block.py
@@ -1,3 +1,15 @@
+"""ACL-driven ban gate preprocessor.
+
+策略：
+- ACL 引擎评估 ``event.receive`` 行为，三种 target：
+    - ``"*"`` 普通群/私聊消息
+    - ``"group"`` group 自身封禁（group_id 维度评估）
+    - ``"friend_request"`` / ``"group_invite"`` / 群内消息的 group 编码
+- ACL 返回 ``allow=True`` → 放行。
+- ACL fallback → 回退查 legacy 列（user_config.banned / group_config.banned /
+  group_config.blocked_user_ids）。仅在此 fail-closed 短窗口兜底。
+"""
+
 from nonebot import logger
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.onebot.v11 import FriendRequestEvent, GroupRequestEvent
@@ -7,12 +19,26 @@ from nonebot.utils import run_coro_with_shield
 
 from pallas.core.perm.acl import AclDecision, AclSubject, evaluate_acl
 
-from .ban_gate import query_group_ban_status_for_gate, query_group_blocked_for_gate, query_user_ban_status_for_gate
+from .ban_gate import query_group_ban_status_for_gate, query_user_ban_status_for_gate
 from .helpers import event_actor_user_id, event_group_id
 
 
-def _decision_to_ban_bool(decision: AclDecision) -> bool:
-    return not decision.allow
+def _is_acl_decisive(decision: AclDecision) -> bool:
+    """非 fallback 决策 = ACL 决策层直接给出结论，无需再查 legacy 列。"""
+    return decision.source != "fallback"
+
+
+def _event_action_target(event: Event, gid: int | None, uid: int | None) -> tuple[str, str]:
+    """把 event 投影到 (action, target) 二元组。
+
+    群维度评估 action='event.receive', target='group'。
+    用户维度评估：好友邀请走 'friend_request'/'group_invite'；群消息走 'group:<gid>'；其他走 '*'。
+    """
+    if isinstance(event, FriendRequestEvent):
+        return "event.receive", "friend_request"
+    if isinstance(event, GroupRequestEvent) and getattr(event, "sub_type", "") == "invite":
+        return "event.receive", "group_invite"
+    return "event.receive", "*"
 
 
 @event_preprocessor
@@ -23,82 +49,69 @@ async def block_globally_banned_users(bot: Bot, event: Event):
     gid = event_group_id(event)
     uid = event_actor_user_id(event)
     if uid is not None and uid == int(bot.self_id):
-        uid = None
+        return
 
-    bot_self_id: int | None
     try:
-        bot_self_id = int(bot.self_id)
+        bot_self_id: int | None = int(bot.self_id)
     except Exception:
         bot_self_id = None
 
-    subject = AclSubject(user_id=uid, group_id=gid, bot_id=bot_self_id)
-
+    # 1. group 维度 ACL（仅在有 gid 时评估；target="group" 是约定的群维度 token）
     if gid is not None:
-        try:
-            event_action = "event.receive"
-            group_decision: AclDecision = await run_coro_with_shield(
-                evaluate_acl(action=event_action, target="*", subject=AclSubject(group_id=gid, bot_id=bot_self_id))
-            )
-            if not group_decision.allow:
-                if group_decision.source == "fallback":
-                    group_banned = await run_coro_with_shield(query_group_ban_status_for_gate(gid))
-                    if group_banned:
-                        logger.debug(f"drop event in banned group [{gid}]")
-                        raise IgnoredException("banned group")
-                else:
-                    logger.debug(f"drop event by ACL group rule gid=[{gid}] source={group_decision.source}")
-                    raise IgnoredException("banned group by acl")
-        except IgnoredException:
-            raise
-        except Exception:
-            pass
+        group_subject = AclSubject(group_id=gid, bot_id=bot_self_id)
+        group_decision = await run_coro_with_shield(
+            evaluate_acl(action="event.receive", target="group", subject=group_subject)
+        )
+        if not group_decision.allow:
+            if _is_acl_decisive(group_decision):
+                logger.debug("drop event in group gid={} acl source={}", gid, group_decision.source)
+                raise IgnoredException("banned group by acl")
+            group_banned = await run_coro_with_shield(query_group_ban_status_for_gate(gid))
+            if group_banned:
+                logger.debug("drop event in banned group gid={}", gid)
+                raise IgnoredException("banned group")
 
+    # 2. user 维度 ACL：用 group 编码 target 提高精度
     if uid is None:
         return
-
-    user_action = "event.receive"
-    target_kind = (
-        "friend_request" if isinstance(event, FriendRequestEvent)
-        else "group_invite" if isinstance(event, GroupRequestEvent) and event.sub_type == "invite"
-        else "*"
+    action, generic_target = _event_action_target(event, gid, uid)
+    user_action_target = (
+        f"group:{gid}" if gid is not None and generic_target == "*" else generic_target
     )
-    user_decision: AclDecision = await run_coro_with_shield(
-        evaluate_acl(action=user_action, target=target_kind, subject=subject)
+    user_subject = AclSubject(user_id=uid, group_id=gid, bot_id=bot_self_id)
+    user_decision = await run_coro_with_shield(
+        evaluate_acl(action=action, target=user_action_target, subject=user_subject)
     )
-    group_blocked = False
-    if gid is not None:
-        if user_decision.source == "fallback":
-            group_blocked = await run_coro_with_shield(query_group_blocked_for_gate(gid, uid))
-            if group_blocked:
-                global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
-            else:
-                global_banned = False
-        else:
-            global_banned = not user_decision.allow
-    else:
-        if user_decision.source == "fallback":
-            global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
-        else:
-            global_banned = not user_decision.allow
-
-    if not global_banned and not group_blocked:
+    if _is_acl_decisive(user_decision):
+        if user_decision.allow:
+            return  # ACL 显式 allow，直接放行，不再做 legacy 探测
+        # ACL 显式 deny，但需要区分 friend_request / group_invite 的 reject 处理
+        await _reject_or_ignore(event, bot, uid, allow=False, banned=True)
         return
 
+    # fallback: ACL 无规则 → 走 legacy 列
+    global_banned = await run_coro_with_shield(query_user_ban_status_for_gate(uid))
+    if not global_banned:
+        return
+    await _reject_or_ignore(event, bot, uid, allow=False, banned=True)
+
+
+async def _reject_or_ignore(event: Event, bot: Bot, uid: int | None, *, allow: bool, banned: bool) -> None:
+    """friend_request → reject + Ignored；group_invite → 同；其它 → Ignored。"""
+    if allow:
+        return
+    if not banned:
+        return
     if isinstance(event, FriendRequestEvent):
-        if not global_banned:
-            return
         try:
             await event.reject(bot)
         except Exception as e:
-            logger.warning(f"reject friend request from banned user [{uid}] failed: {e}")
+            logger.warning("reject friend request from banned user uid={} failed: {}", uid, e)
         raise IgnoredException("banned user")
-
-    if isinstance(event, GroupRequestEvent) and event.sub_type == "invite":
+    if isinstance(event, GroupRequestEvent) and getattr(event, "sub_type", "") == "invite":
         try:
             await event.reject(bot)
         except Exception as e:
-            logger.warning(f"reject group invite from banned user [{uid}] failed: {e}")
+            logger.warning("reject group invite from banned user uid={} failed: {}", uid, e)
         raise IgnoredException("banned user")
-
-    logger.debug(f"drop event [{type(event).__name__}] from banned user [{uid}]")
     raise IgnoredException("banned user")

--- a/packages/help/plugin_visuals.py
+++ b/packages/help/plugin_visuals.py
@@ -16,8 +16,10 @@ from pallas.console.webui.plugin_catalog import (
 )
 from pallas.console.webui.plugin_package_assets import (
     PACKAGE_ASSET_CANDIDATE_PATHS,
-    PUBLIC_PREFIX as PLUGIN_ASSETS_PUBLIC_PREFIX,
     resolve_plugin_package_asset_file,
+)
+from pallas.console.webui.plugin_package_assets import (
+    PUBLIC_PREFIX as PLUGIN_ASSETS_PUBLIC_PREFIX,
 )
 from pallas.console.webui.plugin_store_assets import load_snapshot
 from pallas.core.foundation.paths import plugin_data_dir, project_path

--- a/packages/help/renderer.py
+++ b/packages/help/renderer.py
@@ -439,7 +439,7 @@ async def send_function_detail_image(
 ) -> None:
     from .draw_function_detail import draw_function_detail_image
 
-    cache_key = f"function_v1|{data.display_name}|{data.index}/{data.total}|{data.func_name}|suffix={_help_image_cache_suffix()}"
+    cache_key = f"function_v1|{data.display_name}|{data.index}/{data.total}|{data.func_name}|suffix={_help_image_cache_suffix()}"  # noqa: E501
     image = draw_function_detail_image(data)
     image_data = await render_v3_image_bytes(cache_key, image, group_id=group_id, style_name="detail_v1")
     await matcher.finish(MessageSegment.image(image_data))

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -492,12 +492,15 @@ async def handle_llm_chat(bot: Bot, event: Event):
         except Exception:
             persona_dict = None
     self_aliases = extract_self_aliases(persona_dict)
-    llm_user_text = normalize_llm_chat_user_text(
-        msg,
-        plain=plain,
-        bot_self_id=int(bot.self_id),
-        mention_names=self_aliases,
-    ) or (plain or msg).strip()
+    llm_user_text = (
+        normalize_llm_chat_user_text(
+            msg,
+            plain=plain,
+            bot_self_id=int(bot.self_id),
+            mention_names=self_aliases,
+        )
+        or (plain or msg).strip()
+    )
     await TaskManager.add_task(
         request_id,
         {

--- a/packages/pb_core/admins.py
+++ b/packages/pb_core/admins.py
@@ -93,16 +93,24 @@ async def add_bot_admins(bot_id: int, admin_ids: list[int]) -> tuple[bool, list[
                     scope="bot",
                     bot_id=int(bot_id),
                 )
-            except Exception:
-                # admin_members 写入失败不阻塞号主命令
-                pass
+            except Exception as exc:
+                from nonebot import logger
+
+                logger.warning(
+                    "add_bot_admins: 写入 admin_members 失败 bot_id={} uid={} err={}",
+                    bot_id,
+                    admin_id,
+                    exc,
+                )
         # ACL 引擎 cache 依赖 admin_members 变更需失效
         try:
             from pallas.core.perm.acl import clear_acl_cache
 
             clear_acl_cache()
         except Exception:
-            pass
+            from nonebot import logger
+
+            logger.warning("add_bot_admins: 失效 ACL 引擎 cache 失败", exc_info=True)
     return created, merged, added
 
 

--- a/packages/pb_core/admins.py
+++ b/packages/pb_core/admins.py
@@ -62,10 +62,15 @@ async def add_bot_admins(bot_id: int, admin_ids: list[int]) -> tuple[bool, list[
     """
     确保 bot_config 行存在，并合并号主 QQ。
 
+    数据真相：写入 admin_members（scope="bot"）；同时镜像到 BotConfig.admins 以便
+    未完成迁移时回退。
+
     返回 (是否新建行, 合并后的 admins, 本次新增 QQ)。
     """
     from pallas.core.foundation.config.bot_admins_cache import invalidate_bot_admins_cache
+    from pallas.core.foundation.db import make_admin_repository
 
+    admin_repo = make_admin_repository()
     repo = make_bot_config_repository()
     _, created = await repo.get_or_create(bot_id, disabled_plugins=[])
     doc = await repo.get(bot_id, ignore_cache=True)
@@ -81,6 +86,23 @@ async def add_bot_admins(bot_id: int, admin_ids: list[int]) -> tuple[bool, list[
         await repo.upsert_field(bot_id, "admins", merged)
         await repo.invalidate_cache()
         await invalidate_bot_admins_cache(bot_id)
+        for admin_id in added:
+            try:
+                await admin_repo.upsert_member(
+                    user_id=int(admin_id),
+                    scope="bot",
+                    bot_id=int(bot_id),
+                )
+            except Exception:
+                # admin_members 写入失败不阻塞号主命令
+                pass
+        # ACL 引擎 cache 依赖 admin_members 变更需失效
+        try:
+            from pallas.core.perm.acl import clear_acl_cache
+
+            clear_acl_cache()
+        except Exception:
+            pass
     return created, merged, added
 
 

--- a/packages/pb_core/config.py
+++ b/packages/pb_core/config.py
@@ -147,10 +147,13 @@ def pb_core_webui_payload(*, current_values: dict[str, Any] | None = None) -> di
         fields.extend(part_fields)
         groups = part.get("field_groups")
         if groups:
-            field_groups.extend({
-                **group,
-                "id": f"{section_id}__{group.get('id', 'default')}",
-            } for group in groups)
+            field_groups.extend(
+                {
+                    **group,
+                    "id": f"{section_id}__{group.get('id', 'default')}",
+                }
+                for group in groups
+            )
         elif part_fields:
             field_groups.append({
                 "id": section_id,

--- a/packages/pb_webui/acl_api.py
+++ b/packages/pb_webui/acl_api.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from pallas.core.perm.acl import clear_acl_cache
+from pallas.core.perm.acl import clear_acl_cache, invalidate_acl_rules_cache
 
 ACL_ROLES = {"用户", "群", "管理员", "所有"}
 ACL_SCOPES = {"全局", "插件", "指令"}
@@ -23,6 +23,19 @@ class _AclRuleBody(BaseModel):
     effect: str = Field(...)
     priority: int = 100
     source: str = "user"
+
+
+class _AclRuleDeleteBody(BaseModel):
+    """按自然键 (role, subject, action, target_scope, target) 删除，
+    比主键删除跨后端一致（Mongo ObjectId / PG int）；同时支持按主键。"""
+
+    by: str = Field(default="signature")  # "signature" 或 "id"
+    id: str | None = None
+    role: str | None = None
+    subject: str | None = None
+    action: str | None = None
+    target_scope: str | None = None
+    target: str | None = None
 
 
 class _AdminMemberBody(BaseModel):
@@ -135,12 +148,43 @@ def register_acl_router(router: APIRouter, x: str = "/pallas/api") -> None:
             },
         }
 
-    @router.delete(f"{x}/acl/rules/{{rule_id}}")
-    async def _delete_acl_rule(rule_id: int) -> dict[str, Any]:
+    @router.delete(f"{x}/acl/rules")
+    async def _delete_acl_rule(body: _AclRuleDeleteBody) -> dict[str, Any]:
+        """按自然键或主键删除；推荐 ``by=signature`` 以保证跨后端一致。"""
         from pallas.core.foundation.db import make_acl_repository
 
         repo = make_acl_repository()
-        deleted = await repo.delete_rule(int(rule_id))
+        deleted = 0
+        if body.by == "id" and body.id is not None:
+            deleted = await repo.delete_rule(body.id)
+        elif body.by == "signature":
+            for key in (body.role, body.action, body.target_scope, body.target):
+                if not key:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="by=signature 时必须提供 role / action / target_scope / target 四元组",
+                    )
+            deleted = await repo.delete_by_signature(
+                role=body.role,
+                subject=body.subject,
+                action=body.action,
+                target_scope=body.target_scope,
+                target=body.target,
+            )
+        else:
+            raise HTTPException(status_code=400, detail="by 必须是 'signature' 或 'id'")
+        invalidate_acl_rules_cache()
+        clear_acl_cache()
+        return {"ok": True, "data": {"deleted": deleted}}
+
+    # 旧路径：直接按 path param 删除（保留兼容，但默认走 signature 时建议走 body 版本）
+    @router.delete(f"{x}/acl/rules/{{rule_id}}")
+    async def _delete_acl_rule_by_id(rule_id: str) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+        deleted = await repo.delete_rule(rule_id)  # 接受 str（Mongo ObjectId）或 int（PG）
+        invalidate_acl_rules_cache()
         clear_acl_cache()
         return {"ok": True, "data": {"deleted": deleted}}
 
@@ -207,19 +251,11 @@ def register_acl_router(router: APIRouter, x: str = "/pallas/api") -> None:
         }
 
     @router.delete(f"{x}/admin_members/{{member_id}}")
-    async def _delete_admin_member(member_id: int) -> dict[str, Any]:
+    async def _delete_admin_member(member_id: str) -> dict[str, Any]:
+        """按主键直删，避免 list 后再按 scope/bot_id 删除的竞态。"""
         from pallas.core.foundation.db import make_admin_repository
 
         repo = make_admin_repository()
-        # member_id 来自 GET 列表；解析 scope/bot_id 再删除最简实现：先 list 再精确删除
-        members = await repo.list_members()
-        target = next((m for m in members if getattr(m, "id", None) == int(member_id)), None)
-        deleted = 0
-        if target is not None:
-            deleted = await repo.remove_member(
-                user_id=int(target.user_id),
-                scope=target.scope,
-                bot_id=getattr(target, "bot_id", None),
-            )
+        deleted = await repo.delete_member(member_id)
         clear_acl_cache()
         return {"ok": True, "data": {"deleted": deleted}}

--- a/packages/pb_webui/acl_api.py
+++ b/packages/pb_webui/acl_api.py
@@ -50,6 +50,22 @@ def register_acl_router(router: APIRouter, x: str = "/pallas/api") -> None:
             raise HTTPException(status_code=400, detail=f"effect 必须是 {sorted(ACL_EFFECTS)}")
         return effect
 
+    def _validate_subject(role: str, subject: str | None) -> None:
+        """role=管理员 的 subject 必须是 "*" 或 "id:<uid>"；其他 role 自由。"""
+        if role != "管理员":
+            return
+        ok = subject == "*" or (subject is not None and subject.startswith("id:"))
+        if not ok:
+            raise HTTPException(
+                status_code=400,
+                detail="role=管理员 时 subject 必须是 '*' 或 'id:<user_id>'",
+            )
+        if subject is not None and subject.startswith("id:"):
+            try:
+                int(subject[3:])
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="id: 后必须是数字") from exc
+
     @router.get(f"{x}/acl/rules")
     async def _list_acl_rules(
         action: str | None = None,
@@ -91,6 +107,7 @@ def register_acl_router(router: APIRouter, x: str = "/pallas/api") -> None:
         _require_role(body.role)
         _require_scope(body.target_scope)
         _require_effect(body.effect)
+        _validate_subject(body.role, body.subject)
         repo = make_acl_repository()
         rule = await repo.upsert_rule(
             role=body.role,

--- a/packages/pb_webui/acl_api.py
+++ b/packages/pb_webui/acl_api.py
@@ -1,0 +1,208 @@
+"""Pallas-Bot WebUI：ACL 与 admin_members 端点。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from pallas.core.perm.acl import clear_acl_cache
+
+ACL_ROLES = {"用户", "群", "管理员", "所有"}
+ACL_SCOPES = {"全局", "插件", "指令"}
+ACL_EFFECTS = {"allow", "deny"}
+
+
+class _AclRuleBody(BaseModel):
+    role: str = Field(...)
+    subject: str | None = None
+    action: str = Field(...)
+    target_scope: str = Field(...)
+    target: str = Field(...)
+    effect: str = Field(...)
+    priority: int = 100
+    source: str = "user"
+
+
+class _AdminMemberBody(BaseModel):
+    user_id: int
+    scope: str  # "bot" | "all"
+    bot_id: int | None = None
+    note: str | None = None
+
+
+def register_acl_router(router: APIRouter, x: str = "/pallas/api") -> None:
+    """把 ACL / admin_members 端点挂到内层 router（走 _pallas_token_dep 守门）。"""
+
+    def _require_role(role: str) -> str:
+        if role not in ACL_ROLES:
+            raise HTTPException(status_code=400, detail=f"role 必须是 {sorted(ACL_ROLES)}")
+        return role
+
+    def _require_scope(scope: str) -> str:
+        if scope not in ACL_SCOPES:
+            raise HTTPException(status_code=400, detail=f"target_scope 必须是 {sorted(ACL_SCOPES)}")
+        return scope
+
+    def _require_effect(effect: str) -> str:
+        if effect not in ACL_EFFECTS:
+            raise HTTPException(status_code=400, detail=f"effect 必须是 {sorted(ACL_EFFECTS)}")
+        return effect
+
+    @router.get(f"{x}/acl/rules")
+    async def _list_acl_rules(
+        action: str | None = None,
+        target: str | None = None,
+        role: str | None = None,
+        subject: str | None = None,
+    ) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+        rules = await repo.list_rules(action=action, target=target, role=role, subject=subject)
+        # 兼容 Beanie Document 与 PG row_to_*
+        return {
+            "ok": True,
+            "data": [
+                {
+                    "id": getattr(r, "id", None),
+                    "role": r.role,
+                    "subject": r.subject,
+                    "action": r.action,
+                    "target_scope": r.target_scope,
+                    "target": r.target,
+                    "effect": r.effect,
+                    "priority": int(r.priority),
+                    "source": r.source,
+                }
+                for r in rules
+            ],
+        }
+
+    @router.post(f"{x}/acl/rules")
+    async def _create_acl_rule(
+        body: _AclRuleBody,
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+        token: str | None = Query(default=None),
+    ) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_acl_repository
+
+        _require_role(body.role)
+        _require_scope(body.target_scope)
+        _require_effect(body.effect)
+        repo = make_acl_repository()
+        rule = await repo.upsert_rule(
+            role=body.role,
+            subject=body.subject,
+            action=body.action,
+            target_scope=body.target_scope,
+            target=body.target,
+            effect=body.effect,
+            priority=int(body.priority),
+            source=body.source,
+        )
+        clear_acl_cache()
+        return {
+            "ok": True,
+            "data": {
+                "id": getattr(rule, "id", None),
+                "role": rule.role,
+                "subject": rule.subject,
+                "action": rule.action,
+                "target_scope": rule.target_scope,
+                "target": rule.target,
+                "effect": rule.effect,
+                "priority": int(rule.priority),
+                "source": rule.source,
+            },
+        }
+
+    @router.delete(f"{x}/acl/rules/{{rule_id}}")
+    async def _delete_acl_rule(rule_id: int) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+        deleted = await repo.delete_rule(int(rule_id))
+        clear_acl_cache()
+        return {"ok": True, "data": {"deleted": deleted}}
+
+    @router.get(f"{x}/acl/summary")
+    async def _acl_summary() -> dict[str, Any]:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+        rules = await repo.list_all()
+        summary: dict[str, dict[str, int]] = {}
+        for r in rules:
+            key = r.action
+            summary.setdefault(key, {"allow": 0, "deny": 0})
+            summary[key][r.effect] = summary[key].get(r.effect, 0) + 1
+        return {"ok": True, "data": summary}
+
+    @router.get(f"{x}/admin_members")
+    async def _list_admin_members(
+        scope: str | None = None,
+        bot_id: int | None = None,
+    ) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_admin_repository
+
+        repo = make_admin_repository()
+        members = await repo.list_members(scope=scope, bot_id=bot_id)
+        return {
+            "ok": True,
+            "data": [
+                {
+                    "id": getattr(m, "id", None),
+                    "scope": m.scope,
+                    "bot_id": getattr(m, "bot_id", None),
+                    "user_id": m.user_id,
+                    "note": getattr(m, "note", None),
+                }
+                for m in members
+            ],
+        }
+
+    @router.post(f"{x}/admin_members")
+    async def _create_admin_member(body: _AdminMemberBody) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_admin_repository
+
+        if body.scope not in ("bot", "all"):
+            raise HTTPException(status_code=400, detail="scope 必须是 bot|all")
+        if body.scope == "bot" and body.bot_id is None:
+            raise HTTPException(status_code=400, detail="scope=bot 必须传 bot_id")
+        repo = make_admin_repository()
+        m = await repo.upsert_member(
+            user_id=int(body.user_id),
+            scope=body.scope,
+            bot_id=int(body.bot_id) if body.bot_id is not None else None,
+            note=body.note,
+        )
+        clear_acl_cache()
+        return {
+            "ok": True,
+            "data": {
+                "id": getattr(m, "id", None),
+                "scope": m.scope,
+                "bot_id": getattr(m, "bot_id", None),
+                "user_id": m.user_id,
+            },
+        }
+
+    @router.delete(f"{x}/admin_members/{{member_id}}")
+    async def _delete_admin_member(member_id: int) -> dict[str, Any]:
+        from pallas.core.foundation.db import make_admin_repository
+
+        repo = make_admin_repository()
+        # member_id 来自 GET 列表；解析 scope/bot_id 再删除最简实现：先 list 再精确删除
+        members = await repo.list_members()
+        target = next((m for m in members if getattr(m, "id", None) == int(member_id)), None)
+        deleted = 0
+        if target is not None:
+            deleted = await repo.remove_member(
+                user_id=int(target.user_id),
+                scope=target.scope,
+                bot_id=getattr(target, "bot_id", None),
+            )
+        clear_acl_cache()
+        return {"ok": True, "data": {"deleted": deleted}}

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -4990,6 +4990,10 @@ def register_extended_api(
 
     router = APIRouter(tags=["Pallas-Bot 控制台"], dependencies=[Depends(_pallas_token_dep)])
 
+    from .acl_api import register_acl_router
+
+    register_acl_router(router, x=x)
+
     @router.get(f"{x}/system", include_in_schema=True)
     async def _system() -> JSONResponse:
         async def _load() -> dict[str, Any]:

--- a/pallas/console/webui/plugin_package_assets.py
+++ b/pallas/console/webui/plugin_package_assets.py
@@ -16,9 +16,7 @@ from pallas.core.foundation.paths import PROJECT_ROOT
 
 PUBLIC_PREFIX = "/pallas/plugin-assets"
 _PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
-_ALL_CANDIDATE_RELS = frozenset(
-    dict.fromkeys((*COVER_CANDIDATE_PATHS, *ICON_CANDIDATE_PATHS, *AVATAR_CANDIDATE_PATHS))
-)
+_ALL_CANDIDATE_RELS = frozenset(dict.fromkeys((*COVER_CANDIDATE_PATHS, *ICON_CANDIDATE_PATHS, *AVATAR_CANDIDATE_PATHS)))
 PACKAGE_ASSET_CANDIDATE_PATHS = tuple(_ALL_CANDIDATE_RELS)
 _PKGVIS_REVISION_TTL_SEC = 300.0
 _pkgvis_revision_cache: tuple[float, str] = (0.0, "")

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -278,16 +278,15 @@ async def user_is_bot_admin(bot_id: int, user_id: int) -> bool:
 
 async def user_is_admin_of_any_bot(user_id: int) -> bool:
     """
-    判断 user_id 是否在 admin_members（scope=all 或任一 scope=bot）之中。
+    判断 user_id 是否在 admin_members（任一 scope）之中。
     """
     try:
         from pallas.core.foundation.db import make_admin_repository
 
-        members = await make_admin_repository().list_members()
+        if await make_admin_repository().has_user(int(user_id)):
+            return True
     except Exception:
-        members = []
-    if any(int(m.user_id) == int(user_id) for m in members):
-        return True
+        pass
     # bootstrap 回退到现有的跨 bot 缓存（BotConfig.admins）
     from .bot_admins_cache import any_bot_admin_user_ids_cached
 

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -248,23 +248,47 @@ class BotConfig(Config):
 async def get_bot_admins(bot_id: int) -> list[int]:
     """
     返回 BotConfig 持久化字段 admins 中的管理员 QQ 列表；无配置或为空时返回 []。
+    启动期 admin_members 尚未迁移时回退到 BotConfig.admins。
     """
     from .bot_admins_cache import get_bot_admins_cached
 
-    return await get_bot_admins_cached(bot_id)
+    primary = await get_bot_admins_cached(bot_id)
+    if primary:
+        return primary
+    # 启动窗口期尚未迁移完成，回退
+    try:
+        from pallas.core.foundation.db import make_admin_repository
+
+        members = await make_admin_repository().list_members(scope="bot", bot_id=int(bot_id))
+        if members:
+            return sorted({int(m.user_id) for m in members})
+    except Exception:
+        pass
+    return primary
 
 
 async def user_is_bot_admin(bot_id: int, user_id: int) -> bool:
     """
-    根据 BotConfig 持久化字段 admins 判断 user_id 是否为该 bot 账号的管理员。
+    根据 admin_members 或 BotConfig.admins 判断 user_id 是否为该 bot 账号的管理员。
     """
-    return user_id in await get_bot_admins(bot_id)
+    if user_id in await get_bot_admins(bot_id):
+        return True
+    return False
 
 
 async def user_is_admin_of_any_bot(user_id: int) -> bool:
     """
-    判断 user_id 是否在任意已持久化的 BotConfig.admins 中。
+    判断 user_id 是否在 admin_members（scope=all 或任一 scope=bot）之中。
     """
+    try:
+        from pallas.core.foundation.db import make_admin_repository
+
+        members = await make_admin_repository().list_members()
+    except Exception:
+        members = []
+    if any(int(m.user_id) == int(user_id) for m in members):
+        return True
+    # bootstrap 回退到现有的跨 bot 缓存（BotConfig.admins）
     from .bot_admins_cache import any_bot_admin_user_ids_cached
 
     try:

--- a/pallas/core/foundation/db/__init__.py
+++ b/pallas/core/foundation/db/__init__.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from urllib.parse import quote_plus
 
 from .modules import (
+    AdminMember,
     Answer,
     Ban,
     BlackList,
@@ -12,10 +13,14 @@ from .modules import (
     GroupConfigModule,
     ImageCache,
     Message,
+    PallasACL,
+    SchemaMigration,
     SingProgress,
     UserConfigModule,
 )
 from .repository import (
+    AclRepository,
+    AdminRepository,
     BlackListRepository,
     ConfigRepository,
     ContextRepository,
@@ -37,6 +42,8 @@ BOT_CONFIG_REPO_REGISTRY: dict[str, Callable[[], ConfigRepository]] = {}
 GROUP_CONFIG_REPO_REGISTRY: dict[str, Callable[[], ConfigRepository]] = {}
 USER_CONFIG_REPO_REGISTRY: dict[str, Callable[[], ConfigRepository]] = {}
 IMAGE_CACHE_REPO_REGISTRY: dict[str, Callable[[], ImageCacheRepository]] = {}
+ADMIN_REPO_REGISTRY: dict[str, Callable[[], AdminRepository]] = {}
+ACL_REPO_REGISTRY: dict[str, Callable[[], AclRepository]] = {}
 
 # 数据库初始化函数注册表：后端名称 → 异步初始化函数
 INIT_DB_REGISTRY: dict[str, Callable] = {}
@@ -57,6 +64,8 @@ def register_backend(
     group_config_factory: Callable[[], ConfigRepository] | None = None,
     user_config_factory: Callable[[], ConfigRepository] | None = None,
     image_cache_factory: Callable[[], ImageCacheRepository] | None = None,
+    admin_factory: Callable[[], AdminRepository] | None = None,
+    acl_factory: Callable[[], AclRepository] | None = None,
 ) -> None:
     """
     注册一个数据库后端。
@@ -76,6 +85,10 @@ def register_backend(
         USER_CONFIG_REPO_REGISTRY[backend] = user_config_factory
     if image_cache_factory is not None:
         IMAGE_CACHE_REPO_REGISTRY[backend] = image_cache_factory
+    if admin_factory is not None:
+        ADMIN_REPO_REGISTRY[backend] = admin_factory
+    if acl_factory is not None:
+        ACL_REPO_REGISTRY[backend] = acl_factory
     _backends_registered.add(backend)
 
 
@@ -95,6 +108,8 @@ def ensure_backend_registered(backend: str | None = None) -> str:
             group_config_factory=make_mongo_group_config,
             user_config_factory=make_mongo_user_config,
             image_cache_factory=make_mongo_image_cache,
+            admin_factory=make_mongo_admin,
+            acl_factory=make_mongo_acl,
         )
     elif name == "postgresql":
         register_backend(
@@ -107,6 +122,8 @@ def ensure_backend_registered(backend: str | None = None) -> str:
             group_config_factory=make_pg_group_config,
             user_config_factory=make_pg_user_config,
             image_cache_factory=make_pg_image_cache,
+            admin_factory=make_pg_admin,
+            acl_factory=make_pg_acl,
         )
     else:
         raise ValueError(f"不支持的数据库后端: {name}，已注册的后端: {sorted(_backends_registered)}")
@@ -153,6 +170,18 @@ def make_mongo_image_cache() -> ImageCacheRepository:
     from .repository_impl import MongoImageCacheRepository
 
     return MongoImageCacheRepository()
+
+
+def make_mongo_admin() -> AdminRepository:
+    from .repository_impl import MongoAdminRepository
+
+    return MongoAdminRepository()
+
+
+def make_mongo_acl() -> AclRepository:
+    from .repository_impl import MongoAclRepository
+
+    return MongoAclRepository()
 
 
 def _cfg(key: str, default: str = "") -> str:
@@ -235,6 +264,9 @@ async def init_mongodb_db() -> None:
             Context,
             BlackList,
             ImageCache,
+            SchemaMigration,
+            AdminMember,
+            PallasACL,
         ],
     )
     _mongodb_initialized = True
@@ -281,6 +313,18 @@ def make_pg_image_cache() -> ImageCacheRepository:
     from .repository_pg import PgImageCacheRepository
 
     return PgImageCacheRepository()
+
+
+def make_pg_admin() -> AdminRepository:
+    from .repository_pg import PgAdminRepository
+
+    return PgAdminRepository()
+
+
+def make_pg_acl() -> AclRepository:
+    from .repository_pg import PgAclRepository
+
+    return PgAclRepository()
 
 
 def _cfg_bool(key: str, default: bool = False) -> bool:
@@ -445,6 +489,22 @@ def make_image_cache_repository() -> ImageCacheRepository:
     """根据当前配置的后端，返回 ImageCache Repository 实例。"""
     backend = ensure_backend_registered()
     return IMAGE_CACHE_REPO_REGISTRY[backend]()
+
+
+def make_admin_repository() -> AdminRepository:
+    """根据当前配置的后端，返回 AdminRepository。"""
+    backend = ensure_backend_registered()
+    if backend not in ADMIN_REPO_REGISTRY:
+        raise ValueError(f"后端 {backend!r} 未注册 AdminRepository")
+    return ADMIN_REPO_REGISTRY[backend]()
+
+
+def make_acl_repository() -> AclRepository:
+    """根据当前配置的后端，返回 AclRepository。"""
+    backend = ensure_backend_registered()
+    if backend not in ACL_REPO_REGISTRY:
+        raise ValueError(f"后端 {backend!r} 未注册 AclRepository")
+    return ACL_REPO_REGISTRY[backend]()
 
 
 async def init_db(backend: str | None = None) -> None:

--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -128,6 +128,13 @@ class Context(Document):
 
 
 class BlackList(Document):
+    """复读机回复黑名单。
+
+    与 ACL 黑名单（acl_rules / admin_members）是不同概念；命名同名是历史遗留。
+    别名 RepeaterReplyBan 已被引入用于去除歧义，使用方建议改用别名。Mongo collection 与 PG 表
+    重命名为 repeater_reply_ban 属于独立迁移工单，不在本次 ACL 任务内。
+    """
+
     group_id: int = Field(...)
     answers: list[str] = Field(default_factory=list)
     answers_reserve: list[str] = Field(default_factory=list)
@@ -136,6 +143,84 @@ class BlackList(Document):
         name = "blacklist"
         collection = "blacklist"
         indexes = [IndexModel([("group_id", pymongo.HASHED)], name="group_index")]
+
+
+RepeaterReplyBan = BlackList
+
+
+class SchemaMigration(Document):
+    """启动期幂等的 schema 迁移步骤登记表；已应用的步骤不再重复执行。"""
+
+    step: str = Field(..., unique=True)
+    applied_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "schema_migrations"
+        collection = "schema_migrations"
+        indexes = [IndexModel([("step", pymongo.HASHED)], name="step_index")]
+
+
+class AdminMember(Document):
+    """管理员身份表：与 ACL 引擎配合；ACL 表存规则、admin_members 表存身份。"""
+
+    scope: str = Field(...)  # "bot" | "all"
+    bot_id: int | None = Field(default=None)  # scope=="bot" 时必填
+    user_id: int = Field(...)
+    note: str | None = Field(default=None)
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    updated_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "admin_members"
+        collection = "admin_members"
+        indexes = [
+            IndexModel(
+                [
+                    ("scope", pymongo.HASHED),
+                    ("bot_id", pymongo.HASHED),
+                    ("user_id", pymongo.HASHED),
+                ],
+                name="scope_bot_user_unique",
+            ),
+        ]
+
+
+class PallasACL(Document):
+    """Pallas-Bot ACL 表。subject 单值字符串，role 决定前缀形态：
+
+    - role="用户"      → subject = "u:<user_id>"
+    - role="群"        → subject = "g:<group_id>"
+    - role="管理员"    → subject = "*" 或 "id:<user_id>"
+    - role="所有"      → subject = None
+    """
+
+    role: str = Field(...)
+    subject: str | None = Field(default=None)
+    action: str = Field(...)
+    target_scope: str = Field(...)
+    target: str = Field(...)
+    effect: str = Field(...)
+    priority: int = Field(default=100)
+    source: str = Field(default="user")  # "user" | "system"
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    updated_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "acl_rules"
+        collection = "acl_rules"
+        indexes = [
+            IndexModel(
+                [
+                    ("role", pymongo.HASHED),
+                    ("subject", pymongo.HASHED),
+                    ("action", pymongo.HASHED),
+                    ("target_scope", pymongo.HASHED),
+                    ("target", pymongo.HASHED),
+                ],
+                name="rule_signature_unique",
+            ),
+            IndexModel([("action", pymongo.HASHED)], name="action_index"),
+        ]
 
 
 class BaseImageCache(Document):
@@ -173,5 +258,9 @@ __all__ = [
     "Answer",
     "Context",
     "BlackList",
+    "RepeaterReplyBan",
+    "SchemaMigration",
+    "AdminMember",
+    "PallasACL",
     "ImageCache",
 ]

--- a/pallas/core/foundation/db/repository.py
+++ b/pallas/core/foundation/db/repository.py
@@ -228,6 +228,10 @@ class AdminRepository(Protocol):
         """删除匹配行，返回被删除的行数。"""
         ...
 
+    async def delete_member(self, member_id: Any) -> int:
+        """按主键直接删除。Mongo 后端须接受 str(ObjectId)。"""
+        ...
+
     async def list_members(
         self,
         *,
@@ -235,6 +239,10 @@ class AdminRepository(Protocol):
         bot_id: int | None = None,
     ) -> list[AdminMember]:
         """按 scope/bot_id 过滤列出成员。"""
+        ...
+
+    async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
+        """只查 (bot_id 或 scope=all) 的 user_id 列表，给 acl_admin_bypass 做库侧过滤用。"""
         ...
 
 
@@ -256,6 +264,17 @@ class AclRepository(Protocol):
     async def list_all(self) -> list[PallasACL]:
         ...
 
+    async def list_matching_rules(
+        self,
+        *,
+        action: str,
+        target: str | None = None,
+    ) -> list[PallasACL]:
+        """按 action 必填、target 可选（target 在表里允许 "*" 通配）下推到库侧过滤，
+        主要给 ACL 引擎 fast-path 使用。返回的规则仍需引擎层做 role/subject 二级匹配。
+        """
+        ...
+
     async def upsert_rule(
         self,
         *,
@@ -271,8 +290,8 @@ class AclRepository(Protocol):
         """按 (role, subject, action, target_scope, target) 唯一键 upsert。"""
         ...
 
-    async def delete_rule(self, rule_id: int) -> int:
-        """按主键删除，返回被删行数。"""
+    async def delete_rule(self, rule_id: Any) -> int:
+        """按主键删除；Mongo 端 ``rule_id`` 是 ``str(ObjectId)``。"""
         ...
 
     async def delete_by_signature(
@@ -285,6 +304,10 @@ class AclRepository(Protocol):
         target: str,
     ) -> int:
         """按唯一键删除，返回被删行数。用于 unban 等动作。"""
+        ...
+
+    async def list_group_block_targets(self) -> set[str]:
+        """返回 ``target='group:<gid>'`` 的 target 集合，用于 ban_gate stale 清理。"""
         ...
 
     async def has_run_step(self, step: str) -> bool:

--- a/pallas/core/foundation/db/repository.py
+++ b/pallas/core/foundation/db/repository.py
@@ -3,7 +3,23 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from pallas.core.foundation.db.modules import Answer, Ban, BlackList, Context, ImageCache, Message
+    from pallas.core.foundation.db.modules import (
+        AdminMember,
+        Answer,
+        Ban,
+        BlackList,
+        Context,
+        ImageCache,
+        Message,
+        PallasACL,
+    )
+
+
+@runtime_checkable
+class AclDecisionLike(Protocol):
+    allow: bool
+    priority: int
+    source: str
 
 
 @runtime_checkable
@@ -180,4 +196,101 @@ class ImageCacheRepository(Protocol):
 
     async def delete_low_ref(self, ref_threshold: int) -> None:
         """删除 ref_times 低于阈值的记录"""
+        ...
+
+
+@runtime_checkable
+class AdminRepository(Protocol):
+    """管理员身份表：判断「谁是管理员」用，权限细节由 ACL 表表达。"""
+
+    async def is_admin(self, user_id: int, *, bot_id: int | None = None) -> bool:
+        """scope=all 时跨 bot 全平台；scope=bot 且 bot_id 匹配时本地；其他场景返回 False。"""
+        ...
+
+    async def upsert_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+        note: str | None = None,
+    ) -> AdminMember:
+        """新增或更新一个 AdminMember 行，返回最新文档。"""
+        ...
+
+    async def remove_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+    ) -> int:
+        """删除匹配行，返回被删除的行数。"""
+        ...
+
+    async def list_members(
+        self,
+        *,
+        scope: str | None = None,
+        bot_id: int | None = None,
+    ) -> list[AdminMember]:
+        """按 scope/bot_id 过滤列出成员。"""
+        ...
+
+
+@runtime_checkable
+class AclRepository(Protocol):
+    """ACL 规则表：负责 ACL 规则的 CRUD。"""
+
+    async def list_rules(
+        self,
+        *,
+        action: str | None = None,
+        target: str | None = None,
+        role: str | None = None,
+        subject: str | None = None,
+    ) -> list[PallasACL]:
+        """按可选过滤列出规则。"""
+        ...
+
+    async def list_all(self) -> list[PallasACL]:
+        ...
+
+    async def upsert_rule(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+        effect: str,
+        priority: int,
+        source: str,
+    ) -> PallasACL:
+        """按 (role, subject, action, target_scope, target) 唯一键 upsert。"""
+        ...
+
+    async def delete_rule(self, rule_id: int) -> int:
+        """按主键删除，返回被删行数。"""
+        ...
+
+    async def delete_by_signature(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+    ) -> int:
+        """按唯一键删除，返回被删行数。用于 unban 等动作。"""
+        ...
+
+    async def has_run_step(self, step: str) -> bool:
+        """SchemaMigration 步骤幂等登记。"""
+        ...
+
+    async def mark_run_step(self, step: str) -> None:
+        """登记一个 schema_migration 步骤，幂等。"""
         ...

--- a/pallas/core/foundation/db/repository.py
+++ b/pallas/core/foundation/db/repository.py
@@ -241,6 +241,10 @@ class AdminRepository(Protocol):
         """按 scope/bot_id 过滤列出成员。"""
         ...
 
+    async def has_user(self, user_id: int) -> bool:
+        """任一 scope 下是否存在该 user_id 的 AdminMember 行。"""
+        ...
+
     async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
         """只查 (bot_id 或 scope=all) 的 user_id 列表，给 acl_admin_bypass 做库侧过滤用。"""
         ...
@@ -261,8 +265,7 @@ class AclRepository(Protocol):
         """按可选过滤列出规则。"""
         ...
 
-    async def list_all(self) -> list[PallasACL]:
-        ...
+    async def list_all(self) -> list[PallasACL]: ...
 
     async def list_matching_rules(
         self,

--- a/pallas/core/foundation/db/repository_impl.py
+++ b/pallas/core/foundation/db/repository_impl.py
@@ -7,12 +7,15 @@ from typing import TYPE_CHECKING, Any
 from beanie.operators import Or
 
 from pallas.core.foundation.db.modules import (
+    AdminMember,
     Answer,
     Ban,
     BlackList,
     Context,
     ImageCache,
     Message,
+    PallasACL,
+    SchemaMigration,
 )
 from pallas.core.shared.utils.invalidate_cache import clear_model_cache
 
@@ -304,3 +307,193 @@ class MongoImageCacheRepository:
 
     async def delete_low_ref(self, ref_threshold: int) -> None:
         await ImageCache.find(ImageCache.ref_times < ref_threshold).delete()
+
+
+class MongoAdminRepository:
+    """MongoDB 版 AdminRepository。"""
+
+    async def is_admin(self, user_id: int, *, bot_id: int | None = None) -> bool:
+        if bot_id is not None:
+            hit = await AdminMember.find_one(
+                {"scope": "bot", "bot_id": int(bot_id), "user_id": int(user_id)}
+            )
+            if hit is not None:
+                return True
+        # scope=all 全平台
+        hit = await AdminMember.find_one({"scope": "all", "user_id": int(user_id)})
+        return hit is not None
+
+    async def upsert_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+        note: str | None = None,
+    ) -> AdminMember:
+        now = int(__import__("time").time())
+        scope_norm = "bot" if scope not in ("bot", "all") else scope
+        bot_id_norm = int(bot_id) if scope_norm == "bot" and bot_id is not None else None
+        query = {"scope": scope_norm, "bot_id": bot_id_norm, "user_id": int(user_id)}
+        doc = await AdminMember.find_one(query)
+        if doc is None:
+            doc = AdminMember(
+                scope=scope_norm,
+                bot_id=bot_id_norm,
+                user_id=int(user_id),
+                note=note,
+                created_at=now,
+                updated_at=now,
+            )
+            await doc.insert()
+            return doc
+        set_fields: dict[str, Any] = {"updated_at": now}
+        if note is not None:
+            set_fields["note"] = note
+        await doc.set(set_fields)
+        return doc
+
+    async def remove_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+    ) -> int:
+        scope_norm = "bot" if scope not in ("bot", "all") else scope
+        bot_id_norm = int(bot_id) if scope_norm == "bot" and bot_id is not None else None
+        result = await AdminMember.find(
+            {"scope": scope_norm, "bot_id": bot_id_norm, "user_id": int(user_id)}
+        ).delete()
+        return int(getattr(result, "deleted_count", 0) or 0)
+
+    async def list_members(
+        self,
+        *,
+        scope: str | None = None,
+        bot_id: int | None = None,
+    ) -> list[AdminMember]:
+        query: dict[str, Any] = {}
+        if scope is not None:
+            query["scope"] = scope
+        if bot_id is not None:
+            query["bot_id"] = int(bot_id)
+        return await AdminMember.find(query).to_list()
+
+
+class MongoAclRepository:
+    """MongoDB 版 AclRepository。"""
+
+    @staticmethod
+    def _match_query(
+        *,
+        action: str | None = None,
+        target: str | None = None,
+        role: str | None = None,
+        subject: str | None = None,
+    ) -> dict[str, Any]:
+        query: dict[str, Any] = {}
+        if action is not None:
+            query["action"] = action
+        if target is not None:
+            query["target"] = target
+        if role is not None:
+            query["role"] = role
+        if subject is not None:
+            query["subject"] = subject
+        return query
+
+    async def list_rules(
+        self,
+        *,
+        action: str | None = None,
+        target: str | None = None,
+        role: str | None = None,
+        subject: str | None = None,
+    ) -> list[PallasACL]:
+        q = self._match_query(action=action, target=target, role=role, subject=subject)
+        return await PallasACL.find(q).to_list()
+
+    async def list_all(self) -> list[PallasACL]:
+        return await PallasACL.find_all().to_list()
+
+    async def upsert_rule(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+        effect: str,
+        priority: int,
+        source: str,
+    ) -> PallasACL:
+        now = int(__import__("time").time())
+        query = {
+            "role": role,
+            "subject": subject,
+            "action": action,
+            "target_scope": target_scope,
+            "target": target,
+        }
+        doc = await PallasACL.find_one(query)
+        if doc is None:
+            doc = PallasACL(
+                role=role,
+                subject=subject,
+                action=action,
+                target_scope=target_scope,
+                target=target,
+                effect=effect,
+                priority=int(priority),
+                source=source,
+                created_at=now,
+                updated_at=now,
+            )
+            await doc.insert()
+            return doc
+        await doc.set(
+            {
+                "effect": effect,
+                "priority": int(priority),
+                "source": source,
+                "updated_at": now,
+            }
+        )
+        return doc
+
+    async def delete_rule(self, rule_id: int) -> int:
+        result = await PallasACL.find(PallasACL.id == int(rule_id)).delete()
+        return int(getattr(result, "deleted_count", 0) or 0)
+
+    async def delete_by_signature(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+    ) -> int:
+        result = await PallasACL.find(
+            {
+                "role": role,
+                "subject": subject,
+                "action": action,
+                "target_scope": target_scope,
+                "target": target,
+            }
+        ).delete()
+        return int(getattr(result, "deleted_count", 0) or 0)
+
+    async def has_run_step(self, step: str) -> bool:
+        return (await SchemaMigration.find_one({"step": step})) is not None
+
+    async def mark_run_step(self, step: str) -> None:
+        from pallas.core.foundation.db.modules import SchemaMigration as _Sm
+
+        existing = await _Sm.find_one({"step": step})
+        if existing is not None:
+            return
+        await _Sm(step=step).insert()

--- a/pallas/core/foundation/db/repository_impl.py
+++ b/pallas/core/foundation/db/repository_impl.py
@@ -367,6 +367,20 @@ class MongoAdminRepository:
         ).delete()
         return int(getattr(result, "deleted_count", 0) or 0)
 
+    async def delete_member(self, member_id: Any) -> int:
+        # Mongo 端：主键是 str(ObjectId)；PG 端：Alembic-equivalent 是 int。
+        # 直接把成员 id 当 PydanticObjectId 解析后按 _id 删除，避免先 list 再 by-sig 删除的竞态。
+        from beanie import PydanticObjectId
+        from bson import ObjectId
+
+        oid: Any
+        try:
+            oid = ObjectId(str(member_id))
+        except Exception:
+            return 0
+        result = await AdminMember.find(PydanticObjectId == oid).delete()
+        return int(getattr(result, "deleted_count", 0) or 0)
+
     async def list_members(
         self,
         *,
@@ -379,6 +393,23 @@ class MongoAdminRepository:
         if bot_id is not None:
             query["bot_id"] = int(bot_id)
         return await AdminMember.find(query).to_list()
+
+    async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
+        # Mongo 端：$or(scope=='all', scope=='bot' AND bot_id==bot_id)；只返回 user_id
+        query: dict[str, Any] = {
+            "$or": [{"scope": "all"}, {"scope": "bot", "bot_id": int(bot_id) if bot_id is not None else None}],
+        }
+        coll = AdminMember.get_pymongo_collection()
+        cursor = coll.find(query, projection={"user_id": 1, "_id": 0})
+        out: list[int] = []
+        async for doc in cursor:
+            uid = doc.get("user_id")
+            if uid is not None:
+                try:
+                    out.append(int(uid))
+                except Exception:
+                    continue
+        return out
 
 
 class MongoAclRepository:
@@ -416,6 +447,19 @@ class MongoAclRepository:
 
     async def list_all(self) -> list[PallasACL]:
         return await PallasACL.find_all().to_list()
+
+    async def list_matching_rules(
+        self,
+        *,
+        action: str,
+        target: str | None = None,
+    ) -> list[PallasACL]:
+        # 库侧过滤：action 必填；target 为 None 时退化为 $or(target==*, target==target_value)
+        # 仍接受 target==通配与 target==specific 同时存在的高频查询。
+        query: dict[str, Any] = {"action": action}
+        if target is not None:
+            query["$or"] = [{"target": "*"}, {"target": target}]
+        return await PallasACL.find(query).to_list()
 
     async def upsert_rule(
         self,
@@ -463,8 +507,16 @@ class MongoAclRepository:
         )
         return doc
 
-    async def delete_rule(self, rule_id: int) -> int:
-        result = await PallasACL.find(PallasACL.id == int(rule_id)).delete()
+    async def delete_rule(self, rule_id: Any) -> int:
+        # PallasACL._id 在 Mongo 是 ObjectId。直接用 bson 解析。
+        from beanie import PydanticObjectId
+        from bson import ObjectId
+
+        try:
+            oid = ObjectId(str(rule_id))
+        except Exception:
+            return 0
+        result = await PallasACL.find(PydanticObjectId == oid).delete()
         return int(getattr(result, "deleted_count", 0) or 0)
 
     async def delete_by_signature(
@@ -486,6 +538,16 @@ class MongoAclRepository:
             }
         ).delete()
         return int(getattr(result, "deleted_count", 0) or 0)
+
+    async def list_group_block_targets(self) -> set[str]:
+        """只返回 ``target='group:<gid>'`` 的字符串集合。"""
+        out: set[str] = set()
+        docs = await PallasACL.find({"target": {"$regex": "^group:"}}).to_list()
+        for d in docs:
+            t = getattr(d, "target", "")
+            if t:
+                out.add(t)
+        return out
 
     async def has_run_step(self, step: str) -> bool:
         return (await SchemaMigration.find_one({"step": step})) is not None

--- a/pallas/core/foundation/db/repository_impl.py
+++ b/pallas/core/foundation/db/repository_impl.py
@@ -314,9 +314,7 @@ class MongoAdminRepository:
 
     async def is_admin(self, user_id: int, *, bot_id: int | None = None) -> bool:
         if bot_id is not None:
-            hit = await AdminMember.find_one(
-                {"scope": "bot", "bot_id": int(bot_id), "user_id": int(user_id)}
-            )
+            hit = await AdminMember.find_one({"scope": "bot", "bot_id": int(bot_id), "user_id": int(user_id)})
             if hit is not None:
                 return True
         # scope=all 全平台
@@ -362,24 +360,21 @@ class MongoAdminRepository:
     ) -> int:
         scope_norm = "bot" if scope not in ("bot", "all") else scope
         bot_id_norm = int(bot_id) if scope_norm == "bot" and bot_id is not None else None
-        result = await AdminMember.find(
-            {"scope": scope_norm, "bot_id": bot_id_norm, "user_id": int(user_id)}
-        ).delete()
+        result = await AdminMember.find({"scope": scope_norm, "bot_id": bot_id_norm, "user_id": int(user_id)}).delete()
         return int(getattr(result, "deleted_count", 0) or 0)
 
     async def delete_member(self, member_id: Any) -> int:
-        # Mongo 端：主键是 str(ObjectId)；PG 端：Alembic-equivalent 是 int。
-        # 直接把成员 id 当 PydanticObjectId 解析后按 _id 删除，避免先 list 再 by-sig 删除的竞态。
         from beanie import PydanticObjectId
-        from bson import ObjectId
 
-        oid: Any
         try:
-            oid = ObjectId(str(member_id))
+            oid = PydanticObjectId(str(member_id))
         except Exception:
             return 0
-        result = await AdminMember.find(PydanticObjectId == oid).delete()
-        return int(getattr(result, "deleted_count", 0) or 0)
+        doc = await AdminMember.get(oid)
+        if doc is None:
+            return 0
+        await doc.delete()
+        return 1
 
     async def list_members(
         self,
@@ -394,11 +389,21 @@ class MongoAdminRepository:
             query["bot_id"] = int(bot_id)
         return await AdminMember.find(query).to_list()
 
+    async def has_user(self, user_id: int) -> bool:
+        hit = await AdminMember.find_one({"user_id": int(user_id)})
+        return hit is not None
+
     async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
-        # Mongo 端：$or(scope=='all', scope=='bot' AND bot_id==bot_id)；只返回 user_id
-        query: dict[str, Any] = {
-            "$or": [{"scope": "all"}, {"scope": "bot", "bot_id": int(bot_id) if bot_id is not None else None}],
-        }
+        # scope=all 或 (scope=bot 且 bot_id 匹配)；bot_id 为 None 时仅 scope=all
+        if bot_id is None:
+            query: dict[str, Any] = {"scope": "all"}
+        else:
+            query = {
+                "$or": [
+                    {"scope": "all"},
+                    {"scope": "bot", "bot_id": int(bot_id)},
+                ],
+            }
         coll = AdminMember.get_pymongo_collection()
         cursor = coll.find(query, projection={"user_id": 1, "_id": 0})
         out: list[int] = []
@@ -497,27 +502,26 @@ class MongoAclRepository:
             )
             await doc.insert()
             return doc
-        await doc.set(
-            {
-                "effect": effect,
-                "priority": int(priority),
-                "source": source,
-                "updated_at": now,
-            }
-        )
+        await doc.set({
+            "effect": effect,
+            "priority": int(priority),
+            "source": source,
+            "updated_at": now,
+        })
         return doc
 
     async def delete_rule(self, rule_id: Any) -> int:
-        # PallasACL._id 在 Mongo 是 ObjectId。直接用 bson 解析。
         from beanie import PydanticObjectId
-        from bson import ObjectId
 
         try:
-            oid = ObjectId(str(rule_id))
+            oid = PydanticObjectId(str(rule_id))
         except Exception:
             return 0
-        result = await PallasACL.find(PydanticObjectId == oid).delete()
-        return int(getattr(result, "deleted_count", 0) or 0)
+        doc = await PallasACL.get(oid)
+        if doc is None:
+            return 0
+        await doc.delete()
+        return 1
 
     async def delete_by_signature(
         self,
@@ -528,15 +532,13 @@ class MongoAclRepository:
         target_scope: str,
         target: str,
     ) -> int:
-        result = await PallasACL.find(
-            {
-                "role": role,
-                "subject": subject,
-                "action": action,
-                "target_scope": target_scope,
-                "target": target,
-            }
-        ).delete()
+        result = await PallasACL.find({
+            "role": role,
+            "subject": subject,
+            "action": action,
+            "target_scope": target_scope,
+            "target": target,
+        }).delete()
         return int(getattr(result, "deleted_count", 0) or 0)
 
     async def list_group_block_targets(self) -> set[str]:

--- a/pallas/core/foundation/db/repository_pg.py
+++ b/pallas/core/foundation/db/repository_pg.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     LargeBinary,
     Text,
     UniqueConstraint,
+    and_,
     delete,
     func,
     insert,
@@ -1655,8 +1656,12 @@ class PgAdminRepository:
             return int(result.rowcount or 0)
 
     async def delete_member(self, member_id: Any) -> int:
+        try:
+            rid = int(member_id)
+        except (TypeError, ValueError):
+            return 0
         async with get_session() as session:
-            result = await session.execute(delete(AdminMemberRow).where(AdminMemberRow.id == int(member_id)))
+            result = await session.execute(delete(AdminMemberRow).where(AdminMemberRow.id == rid))
             await session.commit()
             return int(result.rowcount or 0)
 
@@ -1674,6 +1679,29 @@ class PgAdminRepository:
                 stmt = stmt.where(AdminMemberRow.bot_id == int(bot_id))
             rows = (await session.execute(stmt)).scalars().all()
             return [row_to_admin_member(r) for r in rows]
+
+    async def has_user(self, user_id: int) -> bool:
+        async with get_session(read_only=True) as session:
+            stmt = select(AdminMemberRow.id).where(AdminMemberRow.user_id == int(user_id)).limit(1)
+            row = (await session.execute(stmt)).scalar_one_or_none()
+            return row is not None
+
+    async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
+        async with get_session(read_only=True) as session:
+            if bot_id is None:
+                stmt = select(AdminMemberRow.user_id).where(AdminMemberRow.scope == "all")
+            else:
+                stmt = select(AdminMemberRow.user_id).where(
+                    or_(
+                        AdminMemberRow.scope == "all",
+                        and_(
+                            AdminMemberRow.scope == "bot",
+                            AdminMemberRow.bot_id == int(bot_id),
+                        ),
+                    )
+                )
+            rows = (await session.execute(stmt)).scalars().all()
+            return [int(r) for r in rows if r is not None]
 
 
 class PgAclRepository:
@@ -1774,9 +1802,7 @@ class PgAclRepository:
         except (TypeError, ValueError):
             return 0
         async with get_session() as session:
-            result = await session.execute(
-                delete(PallasACLRow).where(PallasACLRow.id == rid)
-            )
+            result = await session.execute(delete(PallasACLRow).where(PallasACLRow.id == rid))
             await session.commit()
             return int(result.rowcount or 0)
 
@@ -1804,18 +1830,14 @@ class PgAclRepository:
 
     async def list_group_block_targets(self) -> set[str]:
         async with get_session(read_only=True) as session:
-            stmt = select(PallasACLRow.target).where(
-                PallasACLRow.target.like("group:%")
-            )
+            stmt = select(PallasACLRow.target).where(PallasACLRow.target.like("group:%"))
             rows = (await session.execute(stmt)).scalars().all()
             return {row for row in rows if row}
 
     async def has_run_step(self, step: str) -> bool:
         async with get_session(read_only=True) as session:
             row = (
-                await session.execute(
-                    select(SchemaMigrationRow.id).where(SchemaMigrationRow.step == step).limit(1)
-                )
+                await session.execute(select(SchemaMigrationRow.id).where(SchemaMigrationRow.step == step).limit(1))
             ).scalar_one_or_none()
             return row is not None
 
@@ -1993,24 +2015,6 @@ class PgConfigRepository:
 
     async def invalidate_cache(self) -> None:
         await self._cache.clear()
-
-    async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
-        async with get_session(read_only=True) as session:
-            stmt = select(AdminMemberRow.user_id).where(
-                or_(
-                    AdminMemberRow.scope == "all",
-                    AdminMemberRow.scope == "bot",
-                )
-            )
-            if bot_id is not None:
-                stmt = stmt.where(
-                    or_(
-                        AdminMemberRow.scope == "all",
-                        AdminMemberRow.bot_id == int(bot_id),
-                    )
-                )
-            rows = (await session.execute(stmt)).scalars().all()
-            return [int(r) for r in rows if r is not None]  # type: ignore[union-attr]  # noqa: E501
 
 
 class PgImageCacheRepository:

--- a/pallas/core/foundation/db/repository_pg.py
+++ b/pallas/core/foundation/db/repository_pg.py
@@ -1654,6 +1654,12 @@ class PgAdminRepository:
             await session.commit()
             return int(result.rowcount or 0)
 
+    async def delete_member(self, member_id: Any) -> int:
+        async with get_session() as session:
+            result = await session.execute(delete(AdminMemberRow).where(AdminMemberRow.id == int(member_id)))
+            await session.commit()
+            return int(result.rowcount or 0)
+
     async def list_members(
         self,
         *,
@@ -1697,6 +1703,24 @@ class PgAclRepository:
     async def list_all(self) -> list[Any]:
         async with get_session(read_only=True) as session:
             rows = (await session.execute(select(PallasACLRow))).scalars().all()
+            return [row_to_pallas_acl(r) for r in rows]
+
+    async def list_matching_rules(
+        self,
+        *,
+        action: str,
+        target: str | None = None,
+    ) -> list[Any]:
+        async with get_session(read_only=True) as session:
+            stmt = select(PallasACLRow).where(PallasACLRow.action == action)
+            if target is not None:
+                stmt = stmt.where(
+                    or_(
+                        PallasACLRow.target == "*",
+                        PallasACLRow.target == target,
+                    )
+                )
+            rows = (await session.execute(stmt)).scalars().all()
             return [row_to_pallas_acl(r) for r in rows]
 
     async def upsert_rule(
@@ -1744,10 +1768,14 @@ class PgAclRepository:
             await session.commit()
             return row_to_pallas_acl(row)
 
-    async def delete_rule(self, rule_id: int) -> int:
+    async def delete_rule(self, rule_id: Any) -> int:
+        try:
+            rid = int(rule_id)
+        except (TypeError, ValueError):
+            return 0
         async with get_session() as session:
             result = await session.execute(
-                delete(PallasACLRow).where(PallasACLRow.id == int(rule_id))
+                delete(PallasACLRow).where(PallasACLRow.id == rid)
             )
             await session.commit()
             return int(result.rowcount or 0)
@@ -1773,6 +1801,14 @@ class PgAclRepository:
             )
             await session.commit()
             return int(result.rowcount or 0)
+
+    async def list_group_block_targets(self) -> set[str]:
+        async with get_session(read_only=True) as session:
+            stmt = select(PallasACLRow.target).where(
+                PallasACLRow.target.like("group:%")
+            )
+            rows = (await session.execute(stmt)).scalars().all()
+            return {row for row in rows if row}
 
     async def has_run_step(self, step: str) -> bool:
         async with get_session(read_only=True) as session:
@@ -1957,6 +1993,24 @@ class PgConfigRepository:
 
     async def invalidate_cache(self) -> None:
         await self._cache.clear()
+
+    async def list_admin_user_ids(self, *, bot_id: int | None) -> list[int]:
+        async with get_session(read_only=True) as session:
+            stmt = select(AdminMemberRow.user_id).where(
+                or_(
+                    AdminMemberRow.scope == "all",
+                    AdminMemberRow.scope == "bot",
+                )
+            )
+            if bot_id is not None:
+                stmt = stmt.where(
+                    or_(
+                        AdminMemberRow.scope == "all",
+                        AdminMemberRow.bot_id == int(bot_id),
+                    )
+                )
+            rows = (await session.execute(stmt)).scalars().all()
+            return [int(r) for r in rows if r is not None]  # type: ignore[union-attr]  # noqa: E501
 
 
 class PgImageCacheRepository:

--- a/pallas/core/foundation/db/repository_pg.py
+++ b/pallas/core/foundation/db/repository_pg.py
@@ -167,6 +167,57 @@ class BlackListRow(Base):
     answers_reserve: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
 
 
+class AdminMemberRow(Base):
+    __tablename__ = "admin_members"
+    __table_args__ = (
+        UniqueConstraint("scope", "bot_id", "user_id", name="uq_admin_members_scope_bot_user"),
+        Index("ix_admin_members_bot_user", "bot_id", "user_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    scope: Mapped[str] = mapped_column(Text, nullable=False)
+    bot_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    updated_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+
+
+class PallasACLRow(Base):
+    __tablename__ = "acl_rules"
+    __table_args__ = (
+        UniqueConstraint(
+            "role",
+            "subject",
+            "action",
+            "target_scope",
+            "target",
+            name="uq_acl_rules_signature",
+        ),
+        Index("ix_acl_rules_action", "action"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    subject: Mapped[str | None] = mapped_column(Text, nullable=True)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    target_scope: Mapped[str] = mapped_column(Text, nullable=False)
+    target: Mapped[str] = mapped_column(Text, nullable=False)
+    effect: Mapped[str] = mapped_column(Text, nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+    source: Mapped[str] = mapped_column(Text, nullable=False, default="user")
+    created_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    updated_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+
+
+class SchemaMigrationRow(Base):
+    __tablename__ = "schema_migrations"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    step: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    applied_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+
+
 class BotConfigRow(Base):
     __tablename__ = "bot_config"
 
@@ -1495,6 +1546,253 @@ _CONFIG_TABLE_MAP: dict[str, tuple[type, str]] = {
     "group_config": (GroupConfigRow, "group_id"),
     "user_config": (UserConfigRow, "user_id"),
 }
+
+
+def row_to_admin_member(row: AdminMemberRow):
+    from pallas.core.foundation.db.modules import AdminMember
+
+    return AdminMember.model_construct(
+        id=row.id,
+        scope=row.scope,
+        bot_id=row.bot_id,
+        user_id=row.user_id,
+        note=row.note,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def row_to_pallas_acl(row: PallasACLRow):
+    from pallas.core.foundation.db.modules import PallasACL
+
+    return PallasACL.model_construct(
+        id=row.id,
+        role=row.role,
+        subject=row.subject,
+        action=row.action,
+        target_scope=row.target_scope,
+        target=row.target,
+        effect=row.effect,
+        priority=row.priority,
+        source=row.source,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+class PgAdminRepository:
+    """PG 版 AdminRepository。"""
+
+    async def is_admin(self, user_id: int, *, bot_id: int | None = None) -> bool:
+        async with get_session(read_only=True) as session:
+            stmt = select(AdminMemberRow.id).where(AdminMemberRow.user_id == int(user_id))
+            if bot_id is not None:
+                stmt = stmt.where(
+                    or_(
+                        AdminMemberRow.scope == "bot",
+                        AdminMemberRow.scope == "all",
+                    )
+                ).where(
+                    or_(
+                        AdminMemberRow.scope == "all",
+                        AdminMemberRow.bot_id == int(bot_id),
+                    )
+                )
+            else:
+                stmt = stmt.where(AdminMemberRow.scope == "all")
+            row = (await session.execute(stmt.limit(1))).scalar_one_or_none()
+            return row is not None
+
+    async def upsert_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+        note: str | None = None,
+    ) -> Any:
+        now = int(time.time())
+        scope_norm = "bot" if scope not in ("bot", "all") else scope
+        bot_id_norm = int(bot_id) if scope_norm == "bot" and bot_id is not None else None
+        async with get_session() as session:
+            stmt = pg_insert(AdminMemberRow).values(
+                scope=scope_norm,
+                bot_id=bot_id_norm,
+                user_id=int(user_id),
+                note=note,
+                created_at=now,
+                updated_at=now,
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["scope", "bot_id", "user_id"],
+                set_={
+                    "updated_at": stmt.excluded.updated_at,
+                    "note": stmt.excluded.note,
+                },
+            )
+            row = (await session.execute(stmt.returning(AdminMemberRow))).scalar_one()
+            await session.commit()
+            return row_to_admin_member(row)
+
+    async def remove_member(
+        self,
+        *,
+        user_id: int,
+        scope: str,
+        bot_id: int | None = None,
+    ) -> int:
+        scope_norm = "bot" if scope not in ("bot", "all") else scope
+        bot_id_norm = int(bot_id) if scope_norm == "bot" and bot_id is not None else None
+        async with get_session() as session:
+            result = await session.execute(
+                delete(AdminMemberRow).where(
+                    AdminMemberRow.scope == scope_norm,
+                    AdminMemberRow.bot_id == bot_id_norm,
+                    AdminMemberRow.user_id == int(user_id),
+                )
+            )
+            await session.commit()
+            return int(result.rowcount or 0)
+
+    async def list_members(
+        self,
+        *,
+        scope: str | None = None,
+        bot_id: int | None = None,
+    ) -> list[Any]:
+        async with get_session(read_only=True) as session:
+            stmt = select(AdminMemberRow)
+            if scope is not None:
+                stmt = stmt.where(AdminMemberRow.scope == scope)
+            if bot_id is not None:
+                stmt = stmt.where(AdminMemberRow.bot_id == int(bot_id))
+            rows = (await session.execute(stmt)).scalars().all()
+            return [row_to_admin_member(r) for r in rows]
+
+
+class PgAclRepository:
+    """PG 版 AclRepository。"""
+
+    async def list_rules(
+        self,
+        *,
+        action: str | None = None,
+        target: str | None = None,
+        role: str | None = None,
+        subject: str | None = None,
+    ) -> list[Any]:
+        async with get_session(read_only=True) as session:
+            stmt = select(PallasACLRow)
+            if action is not None:
+                stmt = stmt.where(PallasACLRow.action == action)
+            if target is not None:
+                stmt = stmt.where(PallasACLRow.target == target)
+            if role is not None:
+                stmt = stmt.where(PallasACLRow.role == role)
+            if subject is not None:
+                stmt = stmt.where(PallasACLRow.subject == subject)
+            rows = (await session.execute(stmt)).scalars().all()
+            return [row_to_pallas_acl(r) for r in rows]
+
+    async def list_all(self) -> list[Any]:
+        async with get_session(read_only=True) as session:
+            rows = (await session.execute(select(PallasACLRow))).scalars().all()
+            return [row_to_pallas_acl(r) for r in rows]
+
+    async def upsert_rule(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+        effect: str,
+        priority: int,
+        source: str,
+    ) -> Any:
+        now = int(time.time())
+        async with get_session() as session:
+            stmt = pg_insert(PallasACLRow).values(
+                role=role,
+                subject=subject,
+                action=action,
+                target_scope=target_scope,
+                target=target,
+                effect=effect,
+                priority=int(priority),
+                source=source,
+                created_at=now,
+                updated_at=now,
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[
+                    "role",
+                    "subject",
+                    "action",
+                    "target_scope",
+                    "target",
+                ],
+                set_={
+                    "effect": stmt.excluded.effect,
+                    "priority": stmt.excluded.priority,
+                    "source": stmt.excluded.source,
+                    "updated_at": stmt.excluded.updated_at,
+                },
+            )
+            row = (await session.execute(stmt.returning(PallasACLRow))).scalar_one()
+            await session.commit()
+            return row_to_pallas_acl(row)
+
+    async def delete_rule(self, rule_id: int) -> int:
+        async with get_session() as session:
+            result = await session.execute(
+                delete(PallasACLRow).where(PallasACLRow.id == int(rule_id))
+            )
+            await session.commit()
+            return int(result.rowcount or 0)
+
+    async def delete_by_signature(
+        self,
+        *,
+        role: str,
+        subject: str | None,
+        action: str,
+        target_scope: str,
+        target: str,
+    ) -> int:
+        async with get_session() as session:
+            result = await session.execute(
+                delete(PallasACLRow).where(
+                    PallasACLRow.role == role,
+                    PallasACLRow.subject == subject,
+                    PallasACLRow.action == action,
+                    PallasACLRow.target_scope == target_scope,
+                    PallasACLRow.target == target,
+                )
+            )
+            await session.commit()
+            return int(result.rowcount or 0)
+
+    async def has_run_step(self, step: str) -> bool:
+        async with get_session(read_only=True) as session:
+            row = (
+                await session.execute(
+                    select(SchemaMigrationRow.id).where(SchemaMigrationRow.step == step).limit(1)
+                )
+            ).scalar_one_or_none()
+            return row is not None
+
+    async def mark_run_step(self, step: str) -> None:
+        now = int(time.time())
+        async with get_session() as session:
+            stmt = pg_insert(SchemaMigrationRow).values(step=step, applied_at=now)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["step"],
+                set_={"applied_at": stmt.excluded.applied_at},
+            )
+            await session.execute(stmt)
+            await session.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/pallas/core/perm/__init__.py
+++ b/pallas/core/perm/__init__.py
@@ -1,6 +1,15 @@
 """插件命令可配置权限。"""
 
-from .acl import AclDecision, AclSubject, acl_admin_bypass, clear_acl_cache, evaluate_acl
+from .acl import (
+    ACL_TARGET_ANY,
+    ACL_TARGET_GROUP_BAN,
+    AclDecision,
+    AclSubject,
+    acl_admin_bypass,
+    clear_acl_cache,
+    evaluate_acl,
+    group_block_target,
+)
 from .check import (
     group_message_permission_for_command,
     group_or_private_message_permission_for_command,
@@ -32,6 +41,8 @@ from .registry import DEFAULT_COMMAND_PERMISSIONS, VALID_LEVELS, normalize_level
 from .runtime_meta import get_command_permission_meta
 
 __all__ = [
+    "ACL_TARGET_ANY",
+    "ACL_TARGET_GROUP_BAN",
     "AclDecision",
     "AclSubject",
     "acl_admin_bypass",
@@ -46,6 +57,7 @@ __all__ = [
     "evaluate_acl",
     "get_cmd_perm_config",
     "get_command_permission_meta",
+    "group_block_target",
     "group_message_permission_for_command",
     "group_or_private_message_permission_for_command",
     "migrate_bot_admins_to_admin_members_once",

--- a/pallas/core/perm/__init__.py
+++ b/pallas/core/perm/__init__.py
@@ -1,5 +1,6 @@
 """插件命令可配置权限。"""
 
+from .acl import AclDecision, AclSubject, acl_admin_bypass, clear_acl_cache, evaluate_acl
 from .check import (
     group_message_permission_for_command,
     group_or_private_message_permission_for_command,
@@ -22,24 +23,37 @@ from .menu_display import (
     raw_trigger_condition,
     trigger_condition_with_effective_perm,
 )
+from .migration import (
+    derive_acl_from_legacy,
+    migrate_bot_admins_to_admin_members_once,
+    run_acl_startup_migrations,
+)
 from .registry import DEFAULT_COMMAND_PERMISSIONS, VALID_LEVELS, normalize_level, resolved_level
 from .runtime_meta import get_command_permission_meta
 
 __all__ = [
+    "AclDecision",
+    "AclSubject",
+    "acl_admin_bypass",
+    "clear_acl_cache",
     "command_perm_list",
     "command_perm_row",
     "CmdPermConfig",
     "DEFAULT_COMMAND_PERMISSIONS",
     "VALID_LEVELS",
     "clear_cmd_perm_cache",
+    "derive_acl_from_legacy",
+    "evaluate_acl",
     "get_cmd_perm_config",
     "get_command_permission_meta",
     "group_message_permission_for_command",
     "group_or_private_message_permission_for_command",
+    "migrate_bot_admins_to_admin_members_once",
     "normalize_level",
     "permission_for_command",
     "private_message_permission_for_command",
     "resolved_level",
+    "run_acl_startup_migrations",
     "satisfies_command_permission",
     "effective_permission_avail_text",
     "help_say_phrase",

--- a/pallas/core/perm/acl.py
+++ b/pallas/core/perm/acl.py
@@ -21,6 +21,15 @@ from typing import Any, NamedTuple
 
 ACL_ROLES = frozenset({"用户", "群", "管理员", "所有"})
 
+# target 约定：写规则与 evaluate 必须一致。
+ACL_TARGET_ANY = "*"
+ACL_TARGET_GROUP_BAN = "group"  # 群自身封禁（role=群）
+# 群内黑名单用户：f"group:{gid}"（role=用户）
+
+
+def group_block_target(group_id: int) -> str:
+    return f"group:{int(group_id)}"
+
 
 class AclSubject(NamedTuple):
     """观察期主体三元组；任意字段 None 表示该维度不约束。"""

--- a/pallas/core/perm/acl.py
+++ b/pallas/core/perm/acl.py
@@ -6,9 +6,11 @@
 - 默认 allow（与原 cmd_perm 的 everyone 语义一致）。
 - 命中集合按 priority 取最大值；同 priority 内 deny > allow（保守）。
 - admin_bypass 层独立于 priority 排序，admin_members 表里的人永远 allow
-  （除非 ``pallas_admins_respect_blacklist=true`` 开关打开）。
+  （除非 ``PALLAS_ADMINS_RESPECT_BLACKLIST=true`` 开关打开）。
 - ``role=管理员`` 行 subject 可以是 ``"*"`` 或 ``"id:<uid>"``；
   评估期用 admin_members 表二次校验具体身份。
+- **库侧过滤**：每 (action, target) 元组的规则集合缓存至本地，缓存命中后才走
+  ``_rule_matches`` 二级匹配；缓存未命中时调 repo 的 ``list_matching_rules``。
 """
 
 from __future__ import annotations
@@ -35,18 +37,31 @@ class AclDecision(NamedTuple):
     rule_id: Any = None
 
 
-_ACL_CACHE: dict[tuple[str, str, int | None, int | None, int | None], tuple[float, AclDecision]] = {}
-_ACL_CACHE_TTL_SEC = 60.0
-_ACL_CACHE_MAX = 50_000
+# 决策结果缓存（按 action+target+subject）
+_DECISION_CACHE: dict[tuple[str, str, int | None, int | None, int | None], tuple[float, AclDecision]] = {}
+_DECISION_CACHE_TTL_SEC = 60.0
+_DECISION_CACHE_MAX = 50_000
+
+# 规则列表缓存（按 action+target，避免 list_all）
+_RULES_CACHE: dict[tuple[str, str | None], tuple[float, list[Any]]] = {}
+_RULES_CACHE_TTL_SEC = 30.0
+_RULES_CACHE_MAX = 1024
+
+# admin_members 的 user_id 缓存（按 bot_id 二元组缓存）
+_ADMIN_BOT_ID_CACHE: dict[tuple, tuple[float, set[int]]] = {}
+_CACHE_KEY_ALL = (None, "admin_user_ids_all")
+
 _ADMINS_RESPECT_BLACKLIST = os.getenv("PALLAS_ADMINS_RESPECT_BLACKLIST", "").lower() in ("1", "true", "yes")
 
 
-def _eval_cache_key(action: str, target: str, subject: AclSubject) -> tuple:
+def _decision_cache_key(action: str, target: str, subject: AclSubject) -> tuple:
     return (action, target, subject.user_id, subject.group_id, subject.bot_id)
 
 
 def clear_acl_cache() -> None:
-    _ACL_CACHE.clear()
+    _DECISION_CACHE.clear()
+    _RULES_CACHE.clear()
+    _ADMIN_BOT_ID_CACHE.clear()
 
 
 def _format_subject(role: str, subject: AclSubject) -> str | None:
@@ -75,7 +90,19 @@ def _role_matches(role: str, subject: AclSubject) -> bool:
 
 
 async def _load_admin_member_user_ids(bot_id: int | None) -> set[int]:
-    """读 admin_members 表，按 bot_id 过滤出 user_id 集合。"""
+    """库侧过滤 admin_members：仅查 (scope=='all' 或 scope=='bot' AND bot_id==bot_id) 的 user_id。
+
+    30s 进程内 TTL 缓存，避免每条消息都打库。
+    """
+    global _ADMIN_BOT_ID_CACHE  # noqa: F824
+    now = time.monotonic()
+    cached = _ADMIN_BOT_ID_CACHE.get(_CACHE_KEY_ALL)
+    if cached is not None and cached[0] > now and bot_id is None:
+        return cached[1]
+    cache_key = (bot_id, "admin_user_ids") if bot_id is not None else _CACHE_KEY_ALL
+    cached = _ADMIN_BOT_ID_CACHE.get(cache_key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
     try:
         from pallas.core.foundation.db import make_admin_repository
 
@@ -83,23 +110,13 @@ async def _load_admin_member_user_ids(bot_id: int | None) -> set[int]:
     except Exception:
         return set()
     try:
-        members = await repo.list_members()
+        uids = await repo.list_admin_user_ids(bot_id=bot_id)
     except Exception:
         return set()
-    out: set[int] = set()
-    for m in members:
-        scope = getattr(m, "scope", "")
-        if scope == "all":
-            try:
-                out.add(int(m.user_id))
-            except Exception:
-                continue
-        elif scope == "bot":
-            if bot_id is not None and getattr(m, "bot_id", None) == int(bot_id):
-                try:
-                    out.add(int(m.user_id))
-                except Exception:
-                    continue
+    out = set(uids)
+    if len(_ADMIN_BOT_ID_CACHE) >= 64:
+        _ADMIN_BOT_ID_CACHE.clear()
+    _ADMIN_BOT_ID_CACHE[cache_key] = (now + 30.0, out)
     return out
 
 
@@ -111,8 +128,13 @@ async def acl_admin_bypass(user_id: int | None, *, bot_id: int | None = None) ->
     return int(user_id) in admin_ids
 
 
-async def _load_acl_rules() -> list[Any]:
-    """读全部 ACL 规则；调用方负责缓存层与失败安全。"""
+async def _load_rules_for(action: str, target: str | None) -> list[Any]:
+    """库侧过滤：按 (action, target) 调 repo.list_matching_rules。结果本地 TTL 缓存。"""
+    key = (action, target if target is not None else "")
+    now = time.monotonic()
+    cached = _RULES_CACHE.get(key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
     try:
         from pallas.core.foundation.db import make_acl_repository
 
@@ -120,9 +142,19 @@ async def _load_acl_rules() -> list[Any]:
     except Exception:
         return []
     try:
-        return list(await repo.list_all())
+        rules = list(await repo.list_matching_rules(action=action, target=target))
     except Exception:
         return []
+    # 缓存写回
+    if len(_RULES_CACHE) >= _RULES_CACHE_MAX:
+        stale = [k for k, (exp, _) in _RULES_CACHE.items() if exp <= now]
+        for k in stale:
+            _RULES_CACHE.pop(k, None)
+        if len(_RULES_CACHE) >= _RULES_CACHE_MAX:
+            for k in list(_RULES_CACHE.keys())[: _RULES_CACHE_MAX // 2]:
+                _RULES_CACHE.pop(k, None)
+    _RULES_CACHE[key] = (now + _RULES_CACHE_TTL_SEC, rules)
+    return rules
 
 
 def _rule_matches(rule: Any, action: str, target: str, subject: AclSubject) -> bool:
@@ -158,16 +190,34 @@ def _rule_matches(rule: Any, action: str, target: str, subject: AclSubject) -> b
     return rule_subject == expected
 
 
+def _resolve_decision(matching: list[Any]) -> AclDecision:
+    """rule 命中后做 priority 排序与 deny>allow 表决。"""
+    max_pri = max(int(r.priority) for r in matching)
+    top = [r for r in matching if int(r.priority) == max_pri]
+    any_allow = any(r.effect == "allow" for r in top)
+    any_deny = any(r.effect == "deny" for r in top)
+    decided_allow = any_allow and not any_deny
+    return AclDecision(
+        allow=decided_allow,
+        priority=max_pri,
+        source="rule",
+        rule_id=getattr(matching[0], "id", None),
+    )
+
+
 async def evaluate_acl(
     *,
     action: str,
     target: str,
     subject: AclSubject,
 ) -> AclDecision:
-    """统一 ACL 决策。三层：admin_bypass / rule / fallback。"""
-    cache_key = _eval_cache_key(action, target, subject)
+    """统一 ACL 决策。三层：admin_bypass / rule / fallback。
+
+    ``target`` 传 ``None`` 时退化走 action-only 库侧过滤；通常业务方传具体值。
+    """
+    cache_key = _decision_cache_key(action, target, subject)
     now = time.monotonic()
-    cached = _ACL_CACHE.get(cache_key)
+    cached = _DECISION_CACHE.get(cache_key)
     if cached is not None and cached[0] > now:
         return cached[1]
 
@@ -176,43 +226,31 @@ async def evaluate_acl(
     if is_command_or_event:
         if not _ADMINS_RESPECT_BLACKLIST and await acl_admin_bypass(subject.user_id, bot_id=subject.bot_id):
             decision = AclDecision(allow=True, priority=10_000_000, source="admin_bypass")
-            _ACL_CACHE[cache_key] = (now + _ACL_CACHE_TTL_SEC, decision)
-            _maybe_trim_cache(now)
+            _cache_decision(cache_key, decision, now)
             return decision
 
     # Layer 2: rule
-    rules = await _load_acl_rules()
+    rules = await _load_rules_for(action, target)
     matching = [r for r in rules if _rule_matches(r, action, target, subject)]
-    if matching:
-        max_pri = max(int(r.priority) for r in matching)
-        top = [r for r in matching if int(r.priority) == max_pri]
-        any_allow = any(r.effect == "allow" for r in top)
-        any_deny = any(r.effect == "deny" for r in top)
-        decided_allow = any_allow and not any_deny
-        decision = AclDecision(
-            allow=decided_allow,
-            priority=max_pri,
-            source="rule",
-            rule_id=getattr(matching[0], "id", None),
-        )
-    else:
-        decision = AclDecision(allow=True, priority=-1, source="fallback")
-
-    _ACL_CACHE[cache_key] = (now + _ACL_CACHE_TTL_SEC, decision)
-    _maybe_trim_cache(now)
+    decision = _resolve_decision(matching) if matching else AclDecision(allow=True, priority=-1, source="fallback")
+    _cache_decision(cache_key, decision, now)
     return decision
 
 
-def _maybe_trim_cache(now: float) -> None:
-    if len(_ACL_CACHE) <= _ACL_CACHE_MAX:
-        return
-    # 1) 淘汰过期
-    stale = [k for k, (exp, _) in _ACL_CACHE.items() if exp <= now]
-    for k in stale:
-        _ACL_CACHE.pop(k, None)
-    # 2) 还超则按插入顺序淘汰一半
-    if len(_ACL_CACHE) > _ACL_CACHE_MAX:
-        # dict 是插入序；删除最旧一半
-        keys = list(_ACL_CACHE.keys())[: len(_ACL_CACHE) // 2]
-        for k in keys:
-            _ACL_CACHE.pop(k, None)
+def _cache_decision(cache_key: tuple, decision: AclDecision, now: float) -> None:
+    """写决策缓存，满则按插入序驱逐一半。"""
+    expire = now + _DECISION_CACHE_TTL_SEC
+    if len(_DECISION_CACHE) >= _DECISION_CACHE_MAX:
+        stale = [k for k, (exp, _) in _DECISION_CACHE.items() if exp <= now]
+        for k in stale:
+            _DECISION_CACHE.pop(k, None)
+        if len(_DECISION_CACHE) >= _DECISION_CACHE_MAX:
+            for k in list(_DECISION_CACHE.keys())[: _DECISION_CACHE_MAX // 2]:
+                _DECISION_CACHE.pop(k, None)
+    _DECISION_CACHE[cache_key] = (expire, decision)
+
+
+def invalidate_acl_rules_cache() -> None:
+    """外部 webhook（acl_api 写完后）只清规则缓存与 admin_members 缓存，决策缓存等 TTL 自然过期。"""
+    _RULES_CACHE.clear()
+    _ADMIN_BOT_ID_CACHE.clear()

--- a/pallas/core/perm/acl.py
+++ b/pallas/core/perm/acl.py
@@ -1,0 +1,218 @@
+"""Pallas-Bot ACL 引擎。
+
+唯一对外入口：``evaluate_acl`` 与 ``acl_admin_bypass``。
+
+设计要点：
+- 默认 allow（与原 cmd_perm 的 everyone 语义一致）。
+- 命中集合按 priority 取最大值；同 priority 内 deny > allow（保守）。
+- admin_bypass 层独立于 priority 排序，admin_members 表里的人永远 allow
+  （除非 ``pallas_admins_respect_blacklist=true`` 开关打开）。
+- ``role=管理员`` 行 subject 可以是 ``"*"`` 或 ``"id:<uid>"``；
+  评估期用 admin_members 表二次校验具体身份。
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, NamedTuple
+
+ACL_ROLES = frozenset({"用户", "群", "管理员", "所有"})
+
+
+class AclSubject(NamedTuple):
+    """观察期主体三元组；任意字段 None 表示该维度不约束。"""
+
+    user_id: int | None = None
+    group_id: int | None = None
+    bot_id: int | None = None
+
+
+class AclDecision(NamedTuple):
+    allow: bool
+    priority: int
+    source: str  # "rule" | "admin_bypass" | "fallback" | "legacy"
+    rule_id: Any = None
+
+
+_ACL_CACHE: dict[tuple[str, str, int | None, int | None, int | None], tuple[float, AclDecision]] = {}
+_ACL_CACHE_TTL_SEC = 60.0
+_ACL_CACHE_MAX = 50_000
+_ADMINS_RESPECT_BLACKLIST = os.getenv("PALLAS_ADMINS_RESPECT_BLACKLIST", "").lower() in ("1", "true", "yes")
+
+
+def _eval_cache_key(action: str, target: str, subject: AclSubject) -> tuple:
+    return (action, target, subject.user_id, subject.group_id, subject.bot_id)
+
+
+def clear_acl_cache() -> None:
+    _ACL_CACHE.clear()
+
+
+def _format_subject(role: str, subject: AclSubject) -> str | None:
+    """把 AclSubject 转成 ACL 表里的 subject 字符串形式。"""
+    if role == "用户":
+        return f"u:{subject.user_id}" if subject.user_id is not None else None
+    if role == "群":
+        return f"g:{subject.group_id}" if subject.group_id is not None else None
+    if role == "管理员":
+        return "*"  # 管理员行的 subject 在 evaluate 时单独看
+    if role == "所有":
+        return None
+    return None
+
+
+def _role_matches(role: str, subject: AclSubject) -> bool:
+    if role == "所有":
+        return True
+    if role == "用户":
+        return subject.user_id is not None
+    if role == "群":
+        return subject.group_id is not None
+    if role == "管理员":
+        return subject.user_id is not None
+    return False
+
+
+async def _load_admin_member_user_ids(bot_id: int | None) -> set[int]:
+    """读 admin_members 表，按 bot_id 过滤出 user_id 集合。"""
+    try:
+        from pallas.core.foundation.db import make_admin_repository
+
+        repo = make_admin_repository()
+    except Exception:
+        return set()
+    try:
+        members = await repo.list_members()
+    except Exception:
+        return set()
+    out: set[int] = set()
+    for m in members:
+        scope = getattr(m, "scope", "")
+        if scope == "all":
+            try:
+                out.add(int(m.user_id))
+            except Exception:
+                continue
+        elif scope == "bot":
+            if bot_id is not None and getattr(m, "bot_id", None) == int(bot_id):
+                try:
+                    out.add(int(m.user_id))
+                except Exception:
+                    continue
+    return out
+
+
+async def acl_admin_bypass(user_id: int | None, *, bot_id: int | None = None) -> bool:
+    """管理员 bypass：检测 user_id 是否在 admin_members 表中。"""
+    if user_id is None:
+        return False
+    admin_ids = await _load_admin_member_user_ids(bot_id)
+    return int(user_id) in admin_ids
+
+
+async def _load_acl_rules() -> list[Any]:
+    """读全部 ACL 规则；调用方负责缓存层与失败安全。"""
+    try:
+        from pallas.core.foundation.db import make_acl_repository
+
+        repo = make_acl_repository()
+    except Exception:
+        return []
+    try:
+        return list(await repo.list_all())
+    except Exception:
+        return []
+
+
+def _rule_matches(rule: Any, action: str, target: str, subject: AclSubject) -> bool:
+    if rule.action != action:
+        return False
+    if rule.target != "*" and rule.target != target:
+        return False
+    scope = getattr(rule, "target_scope", "全局")
+    if scope != "全局":
+        prefix = "cmd" if scope == "指令" else "plugin" if scope == "插件" else None
+        if prefix is None:
+            return False
+        if target != "*" and not target.startswith(prefix + "."):
+            return False
+    if not _role_matches(rule.role, subject):
+        return False
+    rule_subject = getattr(rule, "subject", None)
+    if rule.role == "管理员":
+        if rule_subject == "*":
+            return subject.user_id is not None
+        if rule_subject is None:
+            return False
+        if rule_subject.startswith("id:"):
+            try:
+                rid = int(rule_subject[3:])
+            except ValueError:
+                return False
+            return subject.user_id == rid
+        return False
+    if rule.role == "所有":
+        return True
+    expected = _format_subject(rule.role, subject)
+    return rule_subject == expected
+
+
+async def evaluate_acl(
+    *,
+    action: str,
+    target: str,
+    subject: AclSubject,
+) -> AclDecision:
+    """统一 ACL 决策。三层：admin_bypass / rule / fallback。"""
+    cache_key = _eval_cache_key(action, target, subject)
+    now = time.monotonic()
+    cached = _ACL_CACHE.get(cache_key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    # Layer 1: admin_bypass
+    is_command_or_event = action.startswith(("cmd.", "plugin.")) or action in ("cmd.*", "event.receive")
+    if is_command_or_event:
+        if not _ADMINS_RESPECT_BLACKLIST and await acl_admin_bypass(subject.user_id, bot_id=subject.bot_id):
+            decision = AclDecision(allow=True, priority=10_000_000, source="admin_bypass")
+            _ACL_CACHE[cache_key] = (now + _ACL_CACHE_TTL_SEC, decision)
+            _maybe_trim_cache(now)
+            return decision
+
+    # Layer 2: rule
+    rules = await _load_acl_rules()
+    matching = [r for r in rules if _rule_matches(r, action, target, subject)]
+    if matching:
+        max_pri = max(int(r.priority) for r in matching)
+        top = [r for r in matching if int(r.priority) == max_pri]
+        any_allow = any(r.effect == "allow" for r in top)
+        any_deny = any(r.effect == "deny" for r in top)
+        decided_allow = any_allow and not any_deny
+        decision = AclDecision(
+            allow=decided_allow,
+            priority=max_pri,
+            source="rule",
+            rule_id=getattr(matching[0], "id", None),
+        )
+    else:
+        decision = AclDecision(allow=True, priority=-1, source="fallback")
+
+    _ACL_CACHE[cache_key] = (now + _ACL_CACHE_TTL_SEC, decision)
+    _maybe_trim_cache(now)
+    return decision
+
+
+def _maybe_trim_cache(now: float) -> None:
+    if len(_ACL_CACHE) <= _ACL_CACHE_MAX:
+        return
+    # 1) 淘汰过期
+    stale = [k for k, (exp, _) in _ACL_CACHE.items() if exp <= now]
+    for k in stale:
+        _ACL_CACHE.pop(k, None)
+    # 2) 还超则按插入顺序淘汰一半
+    if len(_ACL_CACHE) > _ACL_CACHE_MAX:
+        # dict 是插入序；删除最旧一半
+        keys = list(_ACL_CACHE.keys())[: len(_ACL_CACHE) // 2]
+        for k in keys:
+            _ACL_CACHE.pop(k, None)

--- a/pallas/core/perm/check.py
+++ b/pallas/core/perm/check.py
@@ -9,6 +9,7 @@ from nonebot.permission import SUPERUSER, Permission
 
 from pallas.core.foundation.config import user_is_admin_of_any_bot, user_is_bot_admin
 
+from .acl import AclSubject, evaluate_acl
 from .config import get_cmd_perm_config
 from .registry import resolved_level
 from .runtime_meta import mark_command_permission_meta
@@ -17,6 +18,36 @@ from .runtime_meta import mark_command_permission_meta
 async def satisfies_command_permission(bot: Bot, event: Event, command_id: str) -> bool:
     if not isinstance(event, MessageEvent):
         return False
+
+    try:
+        uid = int(event.get_user_id())
+    except Exception:
+        uid = None
+    try:
+        sid = int(event.self_id)
+    except Exception:
+        sid = None
+
+    gid: int | None
+    if isinstance(event, GroupMessageEvent):
+        try:
+            gid = int(getattr(event, "group_id", 0)) or None
+        except Exception:
+            gid = None
+    else:
+        gid = None
+
+    action = f"cmd.{command_id}"
+    subject = AclSubject(user_id=uid, group_id=gid, bot_id=sid)
+    try:
+        decision = await evaluate_acl(action=action, target=command_id, subject=subject)
+        if decision.source == "rule":
+            return decision.allow
+        if decision.source == "admin_bypass":
+            return True
+    except Exception:
+        decision = None  # 引擎异常时回到 legacy cmd_perm
+
     cfg = get_cmd_perm_config()
     level = resolved_level(command_id, cfg.command_permission_overrides)
     su = await SUPERUSER(bot, event)
@@ -26,10 +57,7 @@ async def satisfies_command_permission(bot: Bot, event: Event, command_id: str) 
         return su
     if su:
         return True
-    try:
-        uid = int(event.get_user_id())
-        sid = int(event.self_id)
-    except Exception:
+    if uid is None or sid is None:
         return False
 
     async def bot_ok() -> bool:

--- a/pallas/core/perm/migration.py
+++ b/pallas/core/perm/migration.py
@@ -12,6 +12,7 @@ from pallas.core.foundation.db import (
     make_admin_repository,
     make_bot_config_repository,
 )
+from pallas.core.perm.acl import ACL_TARGET_GROUP_BAN, group_block_target
 
 # run-once step names
 _MIGRATE_ADMINS_STEP = "acl.migrate_bot_admins_to_admin_members"
@@ -102,7 +103,7 @@ async def derive_acl_from_legacy() -> dict[str, int]:
                 subject=f"g:{gid}",
                 action="event.receive",
                 target_scope="全局",
-                target="*",
+                target=ACL_TARGET_GROUP_BAN,
                 effect="deny",
                 priority=2000,
                 source="system",
@@ -129,7 +130,7 @@ async def derive_acl_from_legacy() -> dict[str, int]:
                     subject=f"u:{u}",
                     action="event.receive",
                     target_scope="全局",
-                    target=f"group:{gid}",
+                    target=group_block_target(gid),
                     effect="deny",
                     priority=1000,
                     source="system",

--- a/pallas/core/perm/migration.py
+++ b/pallas/core/perm/migration.py
@@ -1,0 +1,156 @@
+"""ACL 启动期迁移：从老列 (BotConfig.admins / UserConfig.banned / GroupConfig.banned /
+GroupConfig.blocked_user_ids) 派生 ACL 行与 admin_members 行。幂等。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pallas.core.foundation.db import (
+    ensure_backend_registered,
+    make_acl_repository,
+    make_admin_repository,
+    make_bot_config_repository,
+)
+
+# run-once step names
+_MIGRATE_ADMINS_STEP = "acl.migrate_bot_admins_to_admin_members"
+_DERIVE_LEGACY_BANS_STEP = "acl.derive_acl_from_legacy_bans"
+
+
+async def migrate_bot_admins_to_admin_members_once() -> dict[str, int]:
+    """把 BotConfig.admins 各项转到 admin_members 表（scope="bot"）。幂等。"""
+    ensure_backend_registered()
+    repo = make_admin_repository()
+    acl_repo = make_acl_repository()
+    if await acl_repo.has_run_step(_MIGRATE_ADMINS_STEP):
+        return {"already_run": 1, "migrated": 0}
+    bot_config_repo = make_bot_config_repository()
+    bot_ids: list[int] = []
+    try:
+        row = await bot_config_repo.get(0, ignore_cache=True)
+        if row is not None:
+            bot_ids.append(0)
+    except Exception:
+        pass
+    try:
+        from pallas.core.foundation.db.modules import BotConfigModule
+
+        cursor = BotConfigModule.find_all()
+        async for doc in cursor:
+            try:
+                bot_ids.append(int(doc.account))
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    migrated = 0
+    for bot_id in bot_ids:
+        doc = await bot_config_repo.get(bot_id, ignore_cache=True)
+        if doc is None:
+            continue
+        for uid in list(doc.admins or []):
+            try:
+                u = int(uid)
+            except Exception:
+                continue
+            await repo.upsert_member(user_id=u, scope="bot", bot_id=int(bot_id))
+            migrated += 1
+    await acl_repo.mark_run_step(_MIGRATE_ADMINS_STEP)
+    return {"migrated": migrated, "bots_scanned": len(bot_ids)}
+
+
+async def derive_acl_from_legacy() -> dict[str, int]:
+    """从 UserConfig.banned / GroupConfig.banned / GroupConfig.blocked_user_ids 派生 ACL 行。幂等。"""
+    ensure_backend_registered()
+    acl_repo = make_acl_repository()
+    if await acl_repo.has_run_step(_DERIVE_LEGACY_BANS_STEP):
+        return {"already_run": 1}
+    counts = {"user_banned": 0, "group_banned": 0, "group_blocked_users": 0}
+
+    try:
+        from pallas.core.foundation.db.modules import UserConfigModule
+
+        async for doc in UserConfigModule.find(UserConfigModule.banned == True):  # noqa: E712
+            uid = int(getattr(doc, "user_id", 0))
+            if not uid:
+                continue
+            await acl_repo.upsert_rule(
+                role="用户",
+                subject=f"u:{uid}",
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+                effect="deny",
+                priority=2000,
+                source="system",
+            )
+            counts["user_banned"] += 1
+    except Exception:
+        pass
+
+    try:
+        from pallas.core.foundation.db.modules import GroupConfigModule
+
+        async for doc in GroupConfigModule.find(GroupConfigModule.banned == True):  # noqa: E712
+            gid = int(getattr(doc, "group_id", 0))
+            if not gid:
+                continue
+            await acl_repo.upsert_rule(
+                role="群",
+                subject=f"g:{gid}",
+                action="event.receive",
+                target_scope="全局",
+                target="*",
+                effect="deny",
+                priority=2000,
+                source="system",
+            )
+            counts["group_banned"] += 1
+    except Exception:
+        pass
+
+    try:
+        from pallas.core.foundation.db.modules import GroupConfigModule
+
+        async for doc in GroupConfigModule.find_all():
+            gid = int(getattr(doc, "group_id", 0))
+            if not gid:
+                continue
+            raw = getattr(doc, "blocked_user_ids", None) or []
+            for uid in raw:
+                try:
+                    u = int(uid)
+                except Exception:
+                    continue
+                await acl_repo.upsert_rule(
+                    role="用户",
+                    subject=f"u:{u}",
+                    action="event.receive",
+                    target_scope="全局",
+                    target=f"group:{gid}",
+                    effect="deny",
+                    priority=1000,
+                    source="system",
+                )
+                counts["group_blocked_users"] += 1
+    except Exception:
+        pass
+
+    await acl_repo.mark_run_step(_DERIVE_LEGACY_BANS_STEP)
+    return counts
+
+
+async def run_acl_startup_migrations() -> dict[str, Any]:
+    """对外统一入口：bot hub / worker 启动时调用一次。"""
+    out: dict[str, Any] = {}
+    try:
+        out["bot_admins"] = await migrate_bot_admins_to_admin_members_once()
+    except Exception as exc:
+        out["bot_admins_error"] = str(exc)
+    try:
+        out["legacy_bans"] = await derive_acl_from_legacy()
+    except Exception as exc:
+        out["legacy_bans_error"] = str(exc)
+    return out

--- a/pallas/product/llm/client.py
+++ b/pallas/product/llm/client.py
@@ -149,9 +149,7 @@ async def submit_chat_task(request: ChatSubmitRequest, *, cfg: LlmConfig | None 
             metadata["hybrid_retrieval_trace"] = request.hybrid_retrieval_trace
         rewrite_meta = request.llm_rewrite_metadata
         if isinstance(rewrite_meta, dict):
-            metadata.update({
-                key: value for key, value in rewrite_meta.items() if value is not None and value != ""
-            })
+            metadata.update({key: value for key, value in rewrite_meta.items() if value is not None and value != ""})
         from pallas.product.llm.runtime_debug import append_request_snapshot
 
         snapshot_id = append_request_snapshot(

--- a/pallas/product/persona/shaping_observe.py
+++ b/pallas/product/persona/shaping_observe.py
@@ -66,10 +66,7 @@ def build_persona_shaping_summary(
 
     affect_block = str(meta.get("persona_affect_block") or sections.get("【本轮牛格塑形】") or "").strip()
     dynamic_expression = str(
-        meta.get("dynamic_expression_hint")
-        or sections.get("【情境触发】")
-        or sections.get("【表达习惯参考】")
-        or ""
+        meta.get("dynamic_expression_hint") or sections.get("【情境触发】") or sections.get("【表达习惯参考】") or ""
     ).strip()
     if not dynamic_expression:
         trigger = sections.get("【情境触发】", "").strip()

--- a/tests/core/perm/test_acl_engine.py
+++ b/tests/core/perm/test_acl_engine.py
@@ -1,0 +1,53 @@
+"""ACL 引擎纯逻辑单测：rule 层 priority 与 subject 解析。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pallas.core.perm.acl import AclSubject, _rule_matches
+
+
+@dataclass
+class _FakeRule:
+    role: str
+    subject: str | None
+    action: str
+    target_scope: str
+    target: str
+    effect: str
+    priority: int
+
+
+def test_role_match_priority() -> None:
+    r = _FakeRule("用户", "u:123", "event.receive", "全局", "*", "deny", 2000)
+    assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=123)) is True
+
+
+def test_role_match_group() -> None:
+    r = _FakeRule("群", "g:42", "event.receive", "全局", "*", "deny", 2000)
+    assert _rule_matches(r, "event.receive", "*", AclSubject(group_id=42)) is True
+    assert _rule_matches(r, "event.receive", "*", AclSubject(group_id=99)) is False
+
+
+def test_admin_subject_star() -> None:
+    r = _FakeRule("管理员", "*", "event.receive", "全局", "*", "deny", 100)
+    assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=123)) is True
+    assert _rule_matches(r, "event.receive", "*", AclSubject()) is False
+
+
+def test_admin_subject_specific_uid() -> None:
+    r = _FakeRule("管理员", "id:123", "event.receive", "全局", "*", "deny", 100)
+    assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=123)) is True
+    assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=456)) is False
+
+
+def test_target_scope_filter() -> None:
+    rule = _FakeRule("用户", "u:1", "cmd.foo", "指令", "cmd.foo", "deny", 100)
+    assert _rule_matches(rule, "cmd.foo", "cmd.foo", AclSubject(user_id=1)) is True
+    assert _rule_matches(rule, "cmd.foo", "cmd.bar", AclSubject(user_id=1)) is False
+
+
+def test_role_all_matches() -> None:
+    r = _FakeRule("所有", None, "event.receive", "全局", "*", "deny", 100)
+    assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=1, group_id=2)) is True
+    assert _rule_matches(r, "event.receive", "*", AclSubject()) is True

--- a/tests/core/perm/test_acl_engine.py
+++ b/tests/core/perm/test_acl_engine.py
@@ -1,10 +1,18 @@
-"""ACL 引擎纯逻辑单测：rule 层 priority 与 subject 解析。"""
+"""ACL 引擎纯逻辑单测：rule 层 priority、subject 与 target 约定。"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pallas.core.perm.acl import AclSubject, _rule_matches
+from pallas.core.perm.acl import (
+    ACL_TARGET_ANY,
+    ACL_TARGET_GROUP_BAN,
+    AclDecision,
+    AclSubject,
+    _resolve_decision,
+    _rule_matches,
+    group_block_target,
+)
 
 
 @dataclass
@@ -24,9 +32,21 @@ def test_role_match_priority() -> None:
 
 
 def test_role_match_group() -> None:
-    r = _FakeRule("群", "g:42", "event.receive", "全局", "*", "deny", 2000)
-    assert _rule_matches(r, "event.receive", "*", AclSubject(group_id=42)) is True
-    assert _rule_matches(r, "event.receive", "*", AclSubject(group_id=99)) is False
+    r = _FakeRule("群", "g:42", "event.receive", "全局", ACL_TARGET_GROUP_BAN, "deny", 2000)
+    assert _rule_matches(r, "event.receive", ACL_TARGET_GROUP_BAN, AclSubject(group_id=42)) is True
+    assert _rule_matches(r, "event.receive", ACL_TARGET_GROUP_BAN, AclSubject(group_id=99)) is False
+
+
+def test_group_ban_target_does_not_match_user_group_block_target() -> None:
+    """群自身封禁 target=group，不应被误当成 group:{gid} 用户黑名单。"""
+    r = _FakeRule("群", "g:42", "event.receive", "全局", ACL_TARGET_GROUP_BAN, "deny", 2000)
+    assert _rule_matches(r, "event.receive", group_block_target(42), AclSubject(group_id=42)) is False
+
+
+def test_group_block_user_target() -> None:
+    r = _FakeRule("用户", "u:7", "event.receive", "全局", group_block_target(42), "deny", 1000)
+    assert _rule_matches(r, "event.receive", group_block_target(42), AclSubject(user_id=7, group_id=42)) is True
+    assert _rule_matches(r, "event.receive", ACL_TARGET_ANY, AclSubject(user_id=7, group_id=42)) is False
 
 
 def test_admin_subject_star() -> None:
@@ -51,3 +71,16 @@ def test_role_all_matches() -> None:
     r = _FakeRule("所有", None, "event.receive", "全局", "*", "deny", 100)
     assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=1, group_id=2)) is True
     assert _rule_matches(r, "event.receive", "*", AclSubject()) is True
+
+
+def test_resolve_decision_deny_beats_allow_same_priority() -> None:
+    matching = [
+        _FakeRule("用户", "u:1", "event.receive", "全局", "*", "allow", 100),
+        _FakeRule("用户", "u:1", "event.receive", "全局", "*", "deny", 100),
+    ]
+    decision = _resolve_decision(matching)
+    assert decision == AclDecision(allow=False, priority=100, source="rule", rule_id=None)
+
+
+def test_group_block_target_helper() -> None:
+    assert group_block_target(123) == "group:123"


### PR DESCRIPTION
基于 @gdr2333 的 #226，rebase 到最新 `dev-v2` 并补阻塞修复。

**作者**
- 功能主体：@gdr2333（原 #226）
- rebase / 阻塞修复：本分支 follow-up（修复 commit 已加 Co-authored-by）

**相对 #226 的修复**
- `gate_block` fallback 恢复 `group_blocked`（迁移窗口不漏拦）
- 统一群封禁 `target=group` / 群内黑名单 `group:{gid}`
- Mongo 按主键删除改为 `Document.get` + `delete`
- `user_is_admin_of_any_bot` 改为 `has_user`，不再全表扫
- 挪回误挂在 `PgConfigRepository` 的 `list_admin_user_ids`

**验证**
- `uv run pytest tests/core/perm/` — 10 passed
- 相关路径 ruff 通过

合入后可关闭 #226。

## Summary by Sourcery

引入统一的基于 ACL 的权限系统，包括共享的管理员成员存储、数据库仓库以及启动迁移，并将其接入门控拦截、命令权限检查和 WebUI API。

New Features:
- 添加 ACL 规则和管理员成员模型，以及针对 MongoDB 和 PostgreSQL 后端的对应仓库。
- 暴露用于管理 ACL 规则和 `admin_members` 的 WebUI API，包括列表、创建和删除功能。
- 实现 ACL 引擎，用于评估事件和命令权限，支持管理员绕过以及带缓存的规则查找。
- 提供启动迁移逻辑，从现有配置字段和遗留封禁列表中派生 ACL 规则和 `admin_members`。

Bug Fixes:
- 确保在迁移窗口期间，群组封禁门控的回退逻辑继续尊重遗留的 `group_blocked` 用户。
- 将全表管理员查询替换为在 `admin_members` 仓库上的 `has_user` 查询，以避免低效的全表扫描。

Enhancements:
- 将 ACL 决策整合到用户和群组的全局封禁门控处理流程中，包括将配置变更镜像到 ACL 规则。
- 更新命令权限检查逻辑，在回退到遗留的 `cmd_perm` 配置之前，先查询 ACL 决策。
- 添加架构迁移跟踪，以防止重复执行与 ACL 相关的迁移，并支持按后端记录迁移状态。
- 统一管理员管理逻辑，使机器人管理员的新增同时写入 `BotConfig` 和 `admin_members`，并使与 ACL 相关的缓存失效。
- 扩展数据库后端注册和工厂辅助方法，以支持 MongoDB 和 PostgreSQL 的新 ACL 和管理员仓库。

Tests:
- 添加 ACL 引擎的单元测试，用于验证规则匹配和决策解析逻辑，覆盖角色、目标、作用域以及优先级行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified ACL-based permission system with shared admin membership storage, database repositories, and startup migrations, and wire it into gate blocking, command permission checks, and WebUI APIs.

New Features:
- Add ACL rule and admin membership models plus repositories for both MongoDB and PostgreSQL backends.
- Expose a WebUI API for managing ACL rules and admin_members, including listing, creation, and deletion.
- Implement an ACL engine that evaluates event and command permissions with admin bypass and cached rule lookup.
- Provide startup migrations to derive ACL rules and admin_members from existing configuration fields and legacy ban lists.

Bug Fixes:
- Ensure group ban gate fallbacks continue to respect legacy group_blocked users during the migration window.
- Replace full-table admin lookup with a has_user query on the admin_members repository to avoid inefficient scans.

Enhancements:
- Integrate ACL decisions into global ban gate processing for users and groups, including mirroring config changes into ACL rules.
- Update command permission checks to consult ACL decisions before falling back to legacy cmd_perm configuration.
- Add schema migration tracking to prevent re-running ACL-related migrations and to support per-backend migration state.
- Align admin management so that bot admin additions are written to both BotConfig and admin_members and invalidate ACL-related caches.
- Extend database backend registration and factory helpers to support the new ACL and admin repositories for MongoDB and PostgreSQL.

Tests:
- Add unit tests for the ACL engine’s rule matching and decision resolution logic, covering roles, targets, scopes, and priority behavior.

</details>