### PR TITLE
fix(db): #227 Beanie project + #228 taken_name 字符串键

### DIFF
--- a/src/features/corpus/local_hot.py
+++ b/src/features/corpus/local_hot.py
@@ -149,9 +149,16 @@ async def aggregate_local_hot_keywords_mongo(
     limit: int,
     answers_per_keyword: int,
 ) -> list[dict[str, Any]]:
-    from src.foundation.db.modules import Context
+    from pydantic import BaseModel, Field
 
-    contexts = await Context.find_all().project(Context.keywords, Context.answers).to_list()
+    from src.foundation.db.modules import Answer, Context
+
+    # Beanie 2.x：project() 只接受单一 projection model，不能传多个字段表达式
+    class _ContextHotProjection(BaseModel):
+        keywords: str = ""
+        answers: list[Answer] = Field(default_factory=list)
+
+    contexts = await Context.find_all().project(_ContextHotProjection).to_list()
     buckets: dict[str, dict[str, Any]] = {}
     for ctx in contexts:
         label = plain_message_text(ctx.keywords)

--- a/src/foundation/config/__init__.py
+++ b/src/foundation/config/__init__.py
@@ -231,18 +231,31 @@ class BotConfig(Config):
         返回在该群夺舍的账号
         """
         user_ids = await self._find("taken_name")
-        user_id = user_ids.get(self.group_id) if user_ids else None
-        return user_id
+        if not user_ids:
+            return None
+        gid = self.group_id
+        raw = user_ids.get(str(gid))
+        if raw is None:
+            raw = user_ids.get(gid)
+        try:
+            return int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            return None
 
     async def update_taken_name(self, user_id: int) -> None:
         """
-        更新夺舍的账号
+        更新夺舍的账号（Mongo 要求 dict key 为字符串）。
         """
         user_ids = await self._find("taken_name")
-        if user_ids is None:
-            user_ids = {}
-        user_ids[self.group_id] = user_id
-        await self._update("taken_name", user_ids)
+        normalized: dict[str, int] = {}
+        if user_ids:
+            for key, value in user_ids.items():
+                try:
+                    normalized[str(key)] = int(value)
+                except (TypeError, ValueError):
+                    continue
+        normalized[str(self.group_id)] = int(user_id)
+        await self._update("taken_name", normalized)
 
 
 async def get_bot_admins(bot_id: int) -> list[int]:

--- a/src/foundation/db/modules.py
+++ b/src/foundation/db/modules.py
@@ -25,7 +25,8 @@ class BotConfigModule(Document):
     auto_accept_friend: bool = Field(default=False)
     auto_accept_group: bool = Field(default=False)
     security: bool = Field(default=False)
-    taken_name: dict[int, int] = Field(default_factory=dict)
+    # BSON 要求 string key；读写侧统一 str(group_id)，兼容历史 int key
+    taken_name: dict[str, int] = Field(default_factory=dict)
     drunk: dict[int, float] = Field(default_factory=dict)
     disabled_plugins: list[str] = Field(default_factory=list)
     community_roster_show_qq: bool = Field(default=True)

--- a/tests/common/corpus/test_local_corpus_hot.py
+++ b/tests/common/corpus/test_local_corpus_hot.py
@@ -29,3 +29,39 @@ async def test_build_local_corpus_hot_payload_shape() -> None:
     assert payload["mode"] == "pool"
     assert payload["window_sec"] == 0
     assert payload["items"][0]["keywords"] == "你好"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_local_hot_keywords_mongo_uses_single_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Beanie 2.x project() 只接受一个 projection model（issue #227）。"""
+    import src.foundation.db.modules as modules
+    from src.features.corpus import local_hot as mod
+
+    calls: list[object] = []
+
+    class _FakeFind:
+        def project(self, projection_model):
+            calls.append(projection_model)
+            return self
+
+        async def to_list(self):
+            return []
+
+    class _FakeContext:
+        @staticmethod
+        def find_all():
+            return _FakeFind()
+
+    monkeypatch.setattr(modules, "Context", _FakeContext)
+
+    rows = await mod.aggregate_local_hot_keywords_mongo(
+        scope="global",
+        group_id=None,
+        limit=10,
+        answers_per_keyword=3,
+    )
+    assert rows == []
+    assert len(calls) == 1
+    assert getattr(calls[0], "__name__", "") == "_ContextHotProjection"

--- a/tests/common/test_taken_name_mongo_keys.py
+++ b/tests/common/test_taken_name_mongo_keys.py
@@ -1,0 +1,45 @@
+"""taken_name：Mongo BSON 要求 string key（issue #228）。"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_update_taken_name_uses_string_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.foundation.config import BotConfig
+
+    stored: dict[str, object] = {}
+
+    async def fake_find(self, key: str):  # noqa: ANN001
+        assert key == "taken_name"
+        return {568530739: 111, "999": 222}
+
+    async def fake_update(self, key: str, value):  # noqa: ANN001
+        assert key == "taken_name"
+        stored["value"] = value
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find)
+    monkeypatch.setattr(BotConfig, "_update", fake_update)
+
+    cfg = BotConfig(3791836305, 568530739)
+    await cfg.update_taken_name(3654501983)
+    assert stored["value"] == {"568530739": 3654501983, "999": 222}
+    assert all(isinstance(k, str) for k in stored["value"])
+
+
+@pytest.mark.asyncio
+async def test_taken_name_reads_str_or_int_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.foundation.config import BotConfig
+
+    async def fake_find_str(self, key: str):  # noqa: ANN001
+        return {"42": 1001}
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find_str)
+    assert await BotConfig(1, 42).taken_name() == 1001
+
+    async def fake_find_int(self, key: str):  # noqa: ANN001
+        return {42: 1002}
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find_int)
+    assert await BotConfig(1, 42).taken_name() == 1002


### PR DESCRIPTION
修复 #227 / #228（现网 v3.9.2 Mongo）。

- local-corpus-hot：Beanie 2 `project()` 改为单一 projection model
- taken_name：读写统一 `str(group_id)`，兼容历史 int key

## Summary by Sourcery

使与 Mongo 相关的代码与 Beanie 2.x 以及 BSON 键的要求保持一致，以用于 `taken_name` 的存储。

Bug Fixes:
- 确保 Mongo 中的本地热门关键词聚合使用与 Beanie 2.x 兼容的单一投影模型。
- 规范 `taken_name` 的 Mongo 文档，使用字符串类型的 `group_id` 作为键，同时仍然能读取旧版的整型键。

Tests:
- 添加测试，断言本地热门关键词聚合在 Beanie 2.x 下使用单一投影模型。
- 添加测试，验证 `taken_name` 更新时仅存储字符串键，并能同时读取字符串键和整型键以保证向后兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Mongo-related code with Beanie 2.x and BSON key requirements for taken_name storage.

Bug Fixes:
- Ensure local hot keyword aggregation in Mongo uses a single projection model compatible with Beanie 2.x.
- Normalize taken_name Mongo documents to use string group_id keys while still reading legacy integer keys.

Tests:
- Add tests asserting local hot keyword aggregation uses a single projection model with Beanie 2.x.
- Add tests verifying taken_name updates store only string keys and reads both string and integer keys for backward compatibility.

</details>