### PR TITLE
fix(dev-v2): #227/#228 pick、ACL Sourcery 跟进与 CI 矩阵

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,16 @@ jobs:
 
       - name: Run core plugin matrix tests
         run: |
+          # registry / coord 与 loader 分进程：loader 会 nonebot.load_plugin，
+          # 同进程内再 import packages.* 或二次 load 易触发插件槽冲突
           uv run pytest \
             tests/common/test_plugin_matrix.py \
-            tests/common/test_plugin_loader_unified.py \
-            tests/common/test_plugin_coord.py \
             tests/common/test_plugin_registry.py \
+            tests/common/test_plugin_coord.py \
             tests/common/test_shard_coord_duel_group.py \
             tests/common/test_shard_coord_spy_group.py \
             -q
+          uv run pytest tests/common/test_plugin_loader_unified.py -q
 
       - name: Check console OpenAPI spec drift
         run: |

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v3.9.0-88-g01e4473d-dirty",
+    "version": "v3.9.0-156-gfcb29d6a",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -46,6 +46,682 @@
         }
       }
     },
+    "/pallas/api/acl/rules": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " List Acl Rules",
+        "operationId": "_list_acl_rules_pallas_api_acl_rules_get",
+        "parameters": [
+          {
+            "name": "action",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Action"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target"
+            }
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Role"
+            }
+          },
+          {
+            "name": "subject",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subject"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  List Acl Rules Pallas Api Acl Rules Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Create Acl Rule",
+        "operationId": "_create_acl_rule_pallas_api_acl_rules_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_AclRuleBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Create Acl Rule Pallas Api Acl Rules Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Delete Acl Rule",
+        "description": "按自然键或主键删除；推荐 ``by=signature`` 以保证跨后端一致。",
+        "operationId": "_delete_acl_rule_pallas_api_acl_rules_delete",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_AclRuleDeleteBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Delete Acl Rule Pallas Api Acl Rules Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/acl/rules/{rule_id}": {
+      "delete": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Delete Acl Rule By Id",
+        "operationId": "_delete_acl_rule_by_id_pallas_api_acl_rules__rule_id__delete",
+        "parameters": [
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Rule Id"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Delete Acl Rule By Id Pallas Api Acl Rules  Rule Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/acl/summary": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Acl Summary",
+        "operationId": "_acl_summary_pallas_api_acl_summary_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Acl Summary Pallas Api Acl Summary Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/admin_members": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " List Admin Members",
+        "operationId": "_list_admin_members_pallas_api_admin_members_get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "bot_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Bot Id"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  List Admin Members Pallas Api Admin Members Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Create Admin Member",
+        "operationId": "_create_admin_member_pallas_api_admin_members_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_AdminMemberBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Create Admin Member Pallas Api Admin Members Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/admin_members/{member_id}": {
+      "delete": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Delete Admin Member",
+        "description": "按主键直删，避免 list 后再按 scope/bot_id 删除的竞态。",
+        "operationId": "_delete_admin_member_pallas_api_admin_members__member_id__delete",
+        "parameters": [
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Member Id"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response  Delete Admin Member Pallas Api Admin Members  Member Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pallas/api/system": {
       "get": {
         "tags": [
@@ -53,6 +729,69 @@
         ],
         "summary": " System",
         "operationId": "_system_pallas_api_system_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/home/overview": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Home Overview",
+        "operationId": "_home_overview_pallas_api_home_overview_get",
         "parameters": [
           {
             "name": "token",
@@ -971,6 +1710,133 @@
               "title": "Tb Limit"
             },
             "description": "log_error_log 单条 traceback 最大字符数，0 表示不截断"
+          },
+          {
+            "name": "view",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "log_errors 时仅返回 log_error_log 与来源元数据，跳过 Bot 统计聚合",
+              "title": "View"
+            },
+            "description": "log_errors 时仅返回 log_error_log 与来源元数据，跳过 Bot 统计聚合"
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/log-errors": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Log Errors",
+        "operationId": "_log_errors_pallas_api_log_errors_get",
+        "parameters": [
+          {
+            "name": "log_source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "报错来源筛选：all|hub|worker-N",
+              "title": "Log Source"
+            },
+            "description": "报错来源筛选：all|hub|worker-N"
+          },
+          {
+            "name": "tb_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200000,
+              "minimum": 0,
+              "description": "单条 traceback 最大字符数，0 表示不截断",
+              "default": 0,
+              "title": "Tb Limit"
+            },
+            "description": "单条 traceback 最大字符数，0 表示不截断"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "最多返回条数",
+              "default": 120,
+              "title": "Limit"
+            },
+            "description": "最多返回条数"
           },
           {
             "name": "token",
@@ -3432,7 +4298,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/_ApiOkResponse_PluginConfigData_"
+                }
               }
             }
           },
@@ -5657,6 +6525,81 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/llm/repeater-feedback/manage": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Llm Repeater Feedback Manage",
+        "operationId": "_llm_repeater_feedback_manage_pallas_api_llm_repeater_feedback_manage_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -10161,10 +11104,10 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "description": "Bot QQ（须当前在 NoneBot 已连接）",
+              "description": "Bot QQ（须当前在消息框架已连接）",
               "title": "Self Id"
             },
-            "description": "Bot QQ（须当前在 NoneBot 已连接）"
+            "description": "Bot QQ（须当前在消息框架已连接）"
           },
           {
             "name": "limit",
@@ -10248,10 +11191,10 @@
             "required": true,
             "schema": {
               "type": "integer",
-              "description": "Bot QQ（须当前在 NoneBot 已连接）",
+              "description": "Bot QQ（须当前在消息框架已连接）",
               "title": "Self Id"
             },
-            "description": "Bot QQ（须当前在 NoneBot 已连接）"
+            "description": "Bot QQ（须当前在消息框架已连接）"
           },
           {
             "name": "limit",
@@ -11097,6 +12040,137 @@
           }
         }
       }
+    },
+    "/pallas/api/help/preview": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": "Help Preview",
+        "operationId": "help_preview_pallas_api_help_preview_get",
+        "parameters": [
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "menu",
+                "plugin",
+                "function"
+              ],
+              "type": "string",
+              "default": "menu",
+              "title": "Level"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "plugin",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Plugin"
+            }
+          },
+          {
+            "name": "function",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Function"
+            }
+          },
+          {
+            "name": "show_ignored",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Show Ignored"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -11266,13 +12340,102 @@
             },
             "type": "array",
             "title": "Unexpected Keys"
+          },
+          "field_groups": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Field Groups"
+          },
+          "hot_reload": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hot Reload"
+          },
+          "gateway_editor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Editor"
+          },
+          "supports_connectivity_check": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supports Connectivity Check"
+          },
+          "llm_model_admin": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Model Admin"
+          },
+          "dev_mode_hot_reload": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dev Mode Hot Reload"
+          },
+          "command_perm_ui": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Command Perm Ui"
+          },
+          "command_limits_ui": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Command Limits Ui"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "required": [
           "plugin"
         ],
-        "title": "PluginConfigData"
+        "title": "PluginConfigData",
+        "description": "插件 / 通用配置表单载荷。须声明 field_groups 等扩展键，否则 GET 的 response_model 会剥掉分组。"
       },
       "PluginConfigRawData": {
         "properties": {
@@ -11512,6 +12675,178 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "_AclRuleBody": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject"
+          },
+          "action": {
+            "type": "string",
+            "title": "Action"
+          },
+          "target_scope": {
+            "type": "string",
+            "title": "Target Scope"
+          },
+          "target": {
+            "type": "string",
+            "title": "Target"
+          },
+          "effect": {
+            "type": "string",
+            "title": "Effect"
+          },
+          "priority": {
+            "type": "integer",
+            "title": "Priority",
+            "default": 100
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "user"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "action",
+          "target_scope",
+          "target",
+          "effect"
+        ],
+        "title": "_AclRuleBody"
+      },
+      "_AclRuleDeleteBody": {
+        "properties": {
+          "by": {
+            "type": "string",
+            "title": "By",
+            "default": "signature"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "target_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Scope"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          }
+        },
+        "type": "object",
+        "title": "_AclRuleDeleteBody",
+        "description": "按自然键 (role, subject, action, target_scope, target) 删除，\n比主键删除跨后端一致（Mongo ObjectId / PG int）；同时支持按主键。"
+      },
+      "_AdminMemberBody": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope"
+          },
+          "bot_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bot Id"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id",
+          "scope"
+        ],
+        "title": "_AdminMemberBody"
       },
       "_AiExtensionConfigBody": {
         "properties": {
@@ -12927,6 +14262,11 @@
             "title": "Api Key Env",
             "default": ""
           },
+          "api_key_set": {
+            "type": "boolean",
+            "title": "Api Key Set",
+            "default": false
+          },
           "default_model": {
             "type": "string",
             "title": "Default Model",
@@ -12968,6 +14308,11 @@
           "base_url": {
             "type": "string",
             "title": "Base Url",
+            "default": ""
+          },
+          "api_key": {
+            "type": "string",
+            "title": "Api Key",
             "default": ""
           },
           "api_key_env": {
@@ -13013,7 +14358,7 @@
           "latency_ms": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -13079,7 +14424,6 @@
             "$ref": "#/components/schemas/_LlmProvidersRoutingBody"
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "title": "_LlmProvidersDocumentBody"
       },

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v3.9.0-156-gfcb29d6a",
+    "version": "v3.9.0-157-g9bc4beed-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {

--- a/pallas/console/webui/plugin_update_snapshot.py
+++ b/pallas/console/webui/plugin_update_snapshot.py
@@ -22,9 +22,11 @@ _SNAPSHOT_FILENAME = "plugin_update_snapshot.json"
 
 
 def _snapshot_path():
-    from packages.pb_webui.data_dir import pb_webui_data_dir
+    # 直接走 foundation 路径，避免 import packages.pb_webui
+    # （预导入会让后续 nonebot.load_plugin 报 already exists / not loaded as plugin）
+    from pallas.core.foundation.paths import plugin_data_dir
 
-    return pb_webui_data_dir() / _SNAPSHOT_FILENAME
+    return plugin_data_dir("pb_webui") / _SNAPSHOT_FILENAME
 
 
 def load_snapshot() -> dict[str, Any]:

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -231,18 +231,31 @@ class BotConfig(Config):
         返回在该群夺舍的账号
         """
         user_ids = await self._find("taken_name")
-        user_id = user_ids.get(self.group_id) if user_ids else None
-        return user_id
+        if not user_ids:
+            return None
+        gid = self.group_id
+        raw = user_ids.get(str(gid))
+        if raw is None:
+            raw = user_ids.get(gid)
+        try:
+            return int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            return None
 
     async def update_taken_name(self, user_id: int) -> None:
         """
-        更新夺舍的账号
+        更新夺舍的账号（Mongo 要求 dict key 为字符串）。
         """
         user_ids = await self._find("taken_name")
-        if user_ids is None:
-            user_ids = {}
-        user_ids[self.group_id] = user_id
-        await self._update("taken_name", user_ids)
+        normalized: dict[str, int] = {}
+        if user_ids:
+            for key, value in user_ids.items():
+                try:
+                    normalized[str(key)] = int(value)
+                except (TypeError, ValueError):
+                    continue
+        normalized[str(self.group_id)] = int(user_id)
+        await self._update("taken_name", normalized)
 
 
 async def get_bot_admins(bot_id: int) -> list[int]:

--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -25,7 +25,8 @@ class BotConfigModule(Document):
     auto_accept_friend: bool = Field(default=False)
     auto_accept_group: bool = Field(default=False)
     security: bool = Field(default=False)
-    taken_name: dict[int, int] = Field(default_factory=dict)
+    # BSON 要求 string key；读写侧统一 str(group_id)，兼容历史 int key
+    taken_name: dict[str, int] = Field(default_factory=dict)
     drunk: dict[int, float] = Field(default_factory=dict)
     disabled_plugins: list[str] = Field(default_factory=list)
     community_roster_show_qq: bool = Field(default=True)
@@ -175,12 +176,9 @@ class AdminMember(Document):
         collection = "admin_members"
         indexes = [
             IndexModel(
-                [
-                    ("scope", pymongo.HASHED),
-                    ("bot_id", pymongo.HASHED),
-                    ("user_id", pymongo.HASHED),
-                ],
+                [("scope", pymongo.ASCENDING), ("bot_id", pymongo.ASCENDING), ("user_id", pymongo.ASCENDING)],
                 name="scope_bot_user_unique",
+                unique=True,
             ),
         ]
 

--- a/pallas/core/perm/acl.py
+++ b/pallas/core/perm/acl.py
@@ -169,15 +169,22 @@ async def _load_rules_for(action: str, target: str | None) -> list[Any]:
 def _rule_matches(rule: Any, action: str, target: str, subject: AclSubject) -> bool:
     if rule.action != action:
         return False
-    if rule.target != "*" and rule.target != target:
-        return False
+    rule_target = getattr(rule, "target", None) or ""
+    if rule_target != "*" and rule_target != target:
+        # 兼容规则写裸 command_id、评估传 cmd./plugin. 前缀（或相反）
+        bare = target.split(".", 1)[-1] if "." in target else target
+        if rule_target not in {bare, f"cmd.{bare}", f"plugin.{bare}"}:
+            if target not in {rule_target, f"cmd.{rule_target}", f"plugin.{rule_target}"}:
+                return False
     scope = getattr(rule, "target_scope", "全局")
     if scope != "全局":
         prefix = "cmd" if scope == "指令" else "plugin" if scope == "插件" else None
         if prefix is None:
             return False
-        if target != "*" and not target.startswith(prefix + "."):
-            return False
+        if target != "*":
+            has_prefix = target.startswith(prefix + ".") or action.startswith(prefix + ".")
+            if not has_prefix:
+                return False
     if not _role_matches(rule.role, subject):
         return False
     rule_subject = getattr(rule, "subject", None)

--- a/pallas/core/perm/check.py
+++ b/pallas/core/perm/check.py
@@ -38,9 +38,11 @@ async def satisfies_command_permission(bot: Bot, event: Event, command_id: str) 
         gid = None
 
     action = f"cmd.{command_id}"
+    # 与 target_scope=指令 约定一致：target 带 cmd. 前缀
+    target = f"cmd.{command_id}"
     subject = AclSubject(user_id=uid, group_id=gid, bot_id=sid)
     try:
-        decision = await evaluate_acl(action=action, target=command_id, subject=subject)
+        decision = await evaluate_acl(action=action, target=target, subject=subject)
         if decision.source == "rule":
             return decision.allow
         if decision.source == "admin_bypass":

--- a/pallas/product/corpus/local_hot.py
+++ b/pallas/product/corpus/local_hot.py
@@ -149,9 +149,16 @@ async def aggregate_local_hot_keywords_mongo(
     limit: int,
     answers_per_keyword: int,
 ) -> list[dict[str, Any]]:
-    from pallas.core.foundation.db.modules import Context
+    from pydantic import BaseModel, Field
 
-    contexts = await Context.find_all().project(Context.keywords, Context.answers).to_list()
+    from pallas.core.foundation.db.modules import Answer, Context
+
+    # Beanie 2.x：project() 只接受单一 projection model，不能传多个字段表达式
+    class _ContextHotProjection(BaseModel):
+        keywords: str = ""
+        answers: list[Answer] = Field(default_factory=list)
+
+    contexts = await Context.find_all().project(_ContextHotProjection).to_list()
     buckets: dict[str, dict[str, Any]] = {}
     for ctx in contexts:
         label = plain_message_text(ctx.keywords)

--- a/tests/common/corpus/test_local_corpus_hot.py
+++ b/tests/common/corpus/test_local_corpus_hot.py
@@ -29,3 +29,39 @@ async def test_build_local_corpus_hot_payload_shape() -> None:
     assert payload["mode"] == "pool"
     assert payload["window_sec"] == 0
     assert payload["items"][0]["keywords"] == "你好"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_local_hot_keywords_mongo_uses_single_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Beanie 2.x project() 只接受一个 projection model（issue #227）。"""
+    import pallas.core.foundation.db.modules as modules
+    from pallas.product.corpus import local_hot as mod
+
+    calls: list[object] = []
+
+    class _FakeFind:
+        def project(self, projection_model):
+            calls.append(projection_model)
+            return self
+
+        async def to_list(self):
+            return []
+
+    class _FakeContext:
+        @staticmethod
+        def find_all():
+            return _FakeFind()
+
+    monkeypatch.setattr(modules, "Context", _FakeContext)
+
+    rows = await mod.aggregate_local_hot_keywords_mongo(
+        scope="global",
+        group_id=None,
+        limit=10,
+        answers_per_keyword=3,
+    )
+    assert rows == []
+    assert len(calls) == 1
+    assert getattr(calls[0], "__name__", "") == "_ContextHotProjection"

--- a/tests/common/test_plugin_coord.py
+++ b/tests/common/test_plugin_coord.py
@@ -30,6 +30,7 @@ def test_maa_coord_stub_without_plugin(monkeypatch) -> None:
 
 
 def test_dream_coord_roundtrip_with_plugin() -> None:
+    pytest.importorskip("packages.dream.payload")
     from packages.dream.payload import DriftPayload, drift_payload_from_dict, drift_payload_to_dict
 
     payload = DriftPayload(nickname="博士", text="梦话", image_bytes=b"\x89PNG")

--- a/tests/common/test_plugin_loader_unified.py
+++ b/tests/common/test_plugin_loader_unified.py
@@ -5,13 +5,17 @@ import sys
 import nonebot
 import pytest
 
+from pallas.core.foundation.paths import PROJECT_ROOT
 from pallas.core.platform.bot_runtime.plugin_loader import (
     _discover_plugin_modules,
     _short_name,
     load_plugins_for_role,
 )
+from pallas.core.platform.bot_runtime.plugin_matrix import CORE_PLUGIN_NAMES
 from pallas.core.platform.bot_runtime.roles import UNIFIED_SKIP_PLUGIN_NAMES
 from pallas.core.platform.shard.registry.config import get_shard_registry_settings
+
+_PACKAGES = PROJECT_ROOT / "packages"
 
 
 @pytest.fixture(autouse=True)
@@ -31,8 +35,13 @@ def test_unified_skip_plugin_names():
 def test_discover_plugin_modules_excludes_underscore_packages():
     names = {_short_name(m) for m in _discover_plugin_modules(load_bundled_extra=True)}
     assert "ingress_gate" not in names
-    assert "relogin_forward" in names
-    assert "maa_hub" in names
+    # 4.0 slim：核心插件在 packages/；分片/扩展插件已外置，仅在目录存在时断言
+    for core in ("repeater", "help", "pb_core"):
+        assert core in names
+    if (_PACKAGES / "relogin_forward").is_dir():
+        assert "relogin_forward" in names
+    if (_PACKAGES / "maa_hub").is_dir():
+        assert "maa_hub" in names
 
 
 def test_discover_plugin_modules_slim_skips_extra():
@@ -45,14 +54,18 @@ def test_discover_plugin_modules_slim_skips_extra():
     assert "pb_protocol" not in names
 
 
-def test_discover_plugin_modules_auto_includes_extra_without_pip(monkeypatch):
+def test_discover_plugin_modules_auto_respects_pip_extra(monkeypatch):
     monkeypatch.setattr(
         "pallas.core.platform.bot_runtime.plugin_matrix.pip_extra_installed_for_plugin",
         lambda _name: False,
     )
     names = {_short_name(m) for m in _discover_plugin_modules(load_bundled_extra="auto")}
-    assert "duel" in names
-    assert "draw" not in names  # pip 扩展，不在 packages/
+    # duel 仅当仍以 packages/duel 捆绑时才会出现
+    if (_PACKAGES / "duel").is_dir():
+        assert "duel" in names
+    else:
+        assert "duel" not in names
+    assert "draw" not in names
 
 
 def test_discover_plugin_modules_auto_skips_extra_when_pip_installed(monkeypatch):
@@ -64,7 +77,7 @@ def test_discover_plugin_modules_auto_skips_extra_when_pip_installed(monkeypatch
     assert "duel" not in names
 
 
-def test_unified_role_skips_shard_only_plugins(monkeypatch: pytest.MonkeyPatch):
+def test_unified_role_loads_core_and_skips_shard_only(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("PALLAS_SHARD_ENABLED", raising=False)
     monkeypatch.delenv("PALLAS_BOT_ROLE", raising=False)
     monkeypatch.setenv("PALLAS_LOAD_BUNDLED_EXTRA", "1")
@@ -76,8 +89,9 @@ def test_unified_role_skips_shard_only_plugins(monkeypatch: pytest.MonkeyPatch):
     loaded = {p.name for p in nonebot.get_loaded_plugins()}
     assert "relogin_forward" not in loaded
     assert "maa_hub" not in loaded
-    assert "relogin_bot" in loaded
-    assert "maa" in loaded
+    for name in CORE_PLUGIN_NAMES:
+        if (_PACKAGES / name).is_dir():
+            assert name in loaded
     assert "ingress_gate" not in loaded
 
 
@@ -90,6 +104,8 @@ def test_unified_role_slim_skips_bundled_extra(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_worker_role_skips_maa_hub(monkeypatch: pytest.MonkeyPatch):
+    if not (_PACKAGES / "maa").is_dir():
+        pytest.skip("maa 未捆绑于 4.0 slim packages/")
     monkeypatch.setenv("PALLAS_SHARD_ENABLED", "true")
     monkeypatch.setenv("PALLAS_BOT_ROLE", "worker")
     monkeypatch.setenv("PALLAS_LOAD_BUNDLED_EXTRA", "1")

--- a/tests/common/test_plugin_registry.py
+++ b/tests/common/test_plugin_registry.py
@@ -35,16 +35,9 @@ def test_build_official_extension_rows_include_visuals():
     rows = build_official_extension_rows()
     duel = next(r for r in rows if r["package"] == "pallas-plugin-duel")
     assert duel["icon"]
-    assert duel["icon"] in (
-        "/pallas/official-extensions/pallas-plugin-duel.svg",
-        "/pallas/store-assets/icon/official-pallas-plugin-duel.svg",
-        "/pallas/store-assets/cover/official-pallas-plugin-duel.png",
-    )
+    assert "pallas-plugin-duel" in duel["icon"]
     assert duel["cover"]
-    assert duel["cover"] in (
-        "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-duel/main/assets/brand-avatar.png",
-        "/pallas/store-assets/cover/official-pallas-plugin-duel.png",
-    )
+    assert "pallas-plugin-duel" in duel["cover"] or "brand-avatar" in duel["cover"]
     assert duel["description"] == "泰拉风味多幕决斗，带剧情事件、抢答和八角笼玩法。"
     assert duel["display_name"] == "牛牛决斗"
     assert duel["avatar"] is None

--- a/tests/common/test_plugin_registry.py
+++ b/tests/common/test_plugin_registry.py
@@ -34,7 +34,12 @@ def test_build_official_extension_rows_marks_bundled_duel():
 def test_build_official_extension_rows_include_visuals():
     rows = build_official_extension_rows()
     duel = next(r for r in rows if r["package"] == "pallas-plugin-duel")
-    assert duel["icon"] == "/pallas/official-extensions/pallas-plugin-duel.svg"
+    assert duel["icon"]
+    assert duel["icon"] in (
+        "/pallas/official-extensions/pallas-plugin-duel.svg",
+        "/pallas/store-assets/icon/official-pallas-plugin-duel.svg",
+        "/pallas/store-assets/cover/official-pallas-plugin-duel.png",
+    )
     assert duel["cover"]
     assert duel["cover"] in (
         "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-duel/main/assets/brand-avatar.png",

--- a/tests/common/test_shard_coord_spy_group.py
+++ b/tests/common/test_shard_coord_spy_group.py
@@ -63,6 +63,7 @@ async def test_reclaim_orphan_spy_group_without_session(fake_coord_redis, monkey
 
 
 def test_spy_prep_room_metadata(fake_coord_redis, monkeypatch) -> None:
+    pytest.importorskip("packages.who_is_spy.group_lock")
     from packages.who_is_spy.group_lock import mark_spy_prep_room, read_spy_prep_room
 
     monkeypatch.setattr(shard_ctx, "sharding_active", lambda: True)
@@ -81,6 +82,7 @@ def test_spy_prep_room_metadata(fake_coord_redis, monkeypatch) -> None:
 
 
 def test_spy_prep_players_and_snapshot(fake_coord_redis, monkeypatch) -> None:
+    pytest.importorskip("packages.who_is_spy.coord_store")
     from packages.who_is_spy.coord_store import read_prep_players, write_game_snapshot, write_prep_players
     from packages.who_is_spy.models import Game, Player
 

--- a/tests/common/test_taken_name_mongo_keys.py
+++ b/tests/common/test_taken_name_mongo_keys.py
@@ -1,0 +1,45 @@
+"""taken_name：Mongo BSON 要求 string key（issue #228）。"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_update_taken_name_uses_string_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.core.foundation.config import BotConfig
+
+    stored: dict[str, object] = {}
+
+    async def fake_find(self, key: str):  # noqa: ANN001
+        assert key == "taken_name"
+        return {568530739: 111, "999": 222}
+
+    async def fake_update(self, key: str, value):  # noqa: ANN001
+        assert key == "taken_name"
+        stored["value"] = value
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find)
+    monkeypatch.setattr(BotConfig, "_update", fake_update)
+
+    cfg = BotConfig(3791836305, 568530739)
+    await cfg.update_taken_name(3654501983)
+    assert stored["value"] == {"568530739": 3654501983, "999": 222}
+    assert all(isinstance(k, str) for k in stored["value"])
+
+
+@pytest.mark.asyncio
+async def test_taken_name_reads_str_or_int_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.core.foundation.config import BotConfig
+
+    async def fake_find_str(self, key: str):  # noqa: ANN001
+        return {"42": 1001}
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find_str)
+    assert await BotConfig(1, 42).taken_name() == 1001
+
+    async def fake_find_int(self, key: str):  # noqa: ANN001
+        return {42: 1002}
+
+    monkeypatch.setattr(BotConfig, "_find", fake_find_int)
+    assert await BotConfig(1, 42).taken_name() == 1002

--- a/tests/core/perm/test_acl_engine.py
+++ b/tests/core/perm/test_acl_engine.py
@@ -67,6 +67,12 @@ def test_target_scope_filter() -> None:
     assert _rule_matches(rule, "cmd.foo", "cmd.bar", AclSubject(user_id=1)) is False
 
 
+def test_target_scope_accepts_bare_command_id_with_cmd_action() -> None:
+    """evaluate 传 cmd. 前缀、规则写裸 id 时仍应命中（#229 Sourcery）。"""
+    rule = _FakeRule("用户", "u:1", "cmd.foo", "指令", "foo", "deny", 100)
+    assert _rule_matches(rule, "cmd.foo", "cmd.foo", AclSubject(user_id=1)) is True
+
+
 def test_role_all_matches() -> None:
     r = _FakeRule("所有", None, "event.receive", "全局", "*", "deny", 100)
     assert _rule_matches(r, "event.receive", "*", AclSubject(user_id=1, group_id=2)) is True

--- a/tools/check_console_openapi_drift.py
+++ b/tools/check_console_openapi_drift.py
@@ -3,11 +3,22 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from tools.export_pb_webui_openapi import export_console_openapi
+
+
+def _for_compare(spec: dict[str, Any]) -> dict[str, Any]:
+    """忽略随 git describe 变动的 info.version，避免每次提交后假漂移。"""
+    data = copy.deepcopy(spec)
+    info = data.get("info")
+    if isinstance(info, dict):
+        info.pop("version", None)
+    return data
 
 
 def main() -> int:
@@ -18,7 +29,7 @@ def main() -> int:
 
     committed = json.loads(spec_path.read_text(encoding="utf-8"))
     live = export_console_openapi(api_base="/pallas/api")
-    if committed == live:
+    if _for_compare(committed) == _for_compare(live):
         print("console OpenAPI spec is up to date")
         return 0
 


### PR DESCRIPTION
## Summary
- 从 main `v3.9.3` / #230 移植 #227（Beanie `project` 单参）与 #228（`taken_name` 字符串键）到 `pallas/` 路径，并补单测
- 跟进 #229 Sourcery：`cmd` ACL 的 `target`/`target_scope` 约定、`AdminMember` Mongo 唯一索引
- 修复 `dev-v2` CI 插件矩阵：4.0 slim `packages/` 断言、扩展插件 `importorskip`、registry 不再预导入 `packages.pb_webui`、loader 分进程跑

## Test plan
- [x] `pytest` matrix + loader + ACL + taken_name / local_hot
- [x] 本地 `docker build` 通过
- [ ] CI 全绿后合入 `dev-v2`

## Summary by Sourcery

将近期数据库和 ACL 修复移植到 `dev-v2` 分支，更新适配 4.0 精简布局的插件加载行为，并调整测试和 CI，以反映新的插件与资源打包约定。

Bug Fixes（错误修复）：
- 确保基于 Beanie 的本地热门关键词聚合使用单一的投影模型，并与 Beanie 2.x 兼容。
- 规范 bot 配置中的 `taken_name` 存储方式，改为使用字符串类型的 Mongo 键，同时仍能读取旧版的整型键。
- 将 ACL 规则匹配和命令权限检查与 `cmd./plugin.` 目标约定对齐，包括对裸命令 ID 的处理。

Enhancements（功能改进）：
- 在 `admin_members` 的 `scope/bot_id/user_id` 上强制唯一复合索引，以防止重复的管理员条目。
- 调整适用于 4.0 精简布局的插件加载器和注册表行为，更灵活地处理捆绑的核心插件和可选包。
- 在解析快照路径时避免预先导入 `pb_webui` 包，改为使用基础插件的数据目录辅助工具。

CI：
- 更新 CI 核心插件矩阵任务，将插件加载器测试放到独立进程中运行，以避免插件槽位冲突。

Tests（测试）：
- 增加测试，覆盖本地热门关键词聚合中 Beanie 单一投影模型的使用。
- 增加测试，验证 `taken_name` 的 Mongo 键规范化，以及同时兼容字符串键和整型键。
- 根据可选包和捆绑资源的存在情况，放宽并加上条件的插件加载器、协调组件和注册表断言。
- 在协调测试中对可选的游戏和梦境插件使用 `pytest.importorskip`，以保持不同布局下矩阵的稳健性。
- 扩展 ACL 引擎测试，将带有 `cmd` 前缀动作的裸命令 ID 处理纳入覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Port recent database and ACL fixes into the dev-v2 tree, update plugin loading behavior for the 4.0 slim layout, and adjust tests and CI to reflect the new plugin and asset packaging conventions.

Bug Fixes:
- Ensure Beanie-based aggregation for local hot keywords uses a single projection model compatible with Beanie 2.x.
- Normalize bot configuration taken_name storage to use string Mongo keys while still reading legacy integer keys.
- Align ACL rule matching and command permission checks with cmd./plugin. target conventions, including bare command IDs.

Enhancements:
- Enforce a unique compound index on admin_members scope/bot_id/user_id to prevent duplicate admin entries.
- Adjust plugin loader and registry behavior for 4.0 slim layouts, treating bundled core plugins and optional packages more flexibly.
- Avoid pre-importing pb_webui packages when resolving snapshot paths by using foundation plugin data directory helpers.

CI:
- Update CI core plugin matrix job to run plugin loader tests in a separate process to avoid plugin slot conflicts.

Tests:
- Add tests covering Beanie single-projection usage in local hot keyword aggregation.
- Add tests validating taken_name Mongo key normalization and compatibility with both string and integer keys.
- Relax and gate plugin loader, coord, and registry assertions based on the presence of optional packages and bundled assets.
- Use pytest.importorskip for optional game and dream plugins in coordination tests to keep the matrix robust across layouts.
- Extend ACL engine tests to cover bare command ID handling with cmd-prefixed actions.

</details>