### PR TITLE
feat(community-stats): WebUI 社区中心连通检测 API

### DIFF
--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v3.9.0-215-gfb26dd7f",
+    "version": "v4.0.0-4-g0f6b25c7-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -1316,6 +1316,71 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/community-stats/connectivity-check": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Community Stats Connectivity Check",
+        "operationId": "_community_stats_connectivity_check_pallas_api_community_stats_connectivity_check_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_ApiOkResponse__CommunityConnectivityCheckData_"
+                }
               }
             }
           },
@@ -13887,6 +13952,24 @@
         ],
         "title": "_ApiOkResponse[_AiExtensionTestData]"
       },
+      "_ApiOkResponse__CommunityConnectivityCheckData_": {
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true,
+            "title": "Ok",
+            "default": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/_CommunityConnectivityCheckData"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "_ApiOkResponse[_CommunityConnectivityCheckData]"
+      },
       "_ApiOkResponse__ConsoleLoginChangeData_": {
         "properties": {
           "ok": {
@@ -14130,6 +14213,157 @@
           "new_password"
         ],
         "title": "_ChangeConsoleLoginBody"
+      },
+      "_CommunityConnectivityCheckData": {
+        "properties": {
+          "probes": {
+            "items": {
+              "$ref": "#/components/schemas/_CommunityConnectivityProbeRow"
+            },
+            "type": "array",
+            "title": "Probes"
+          },
+          "reporting": {
+            "$ref": "#/components/schemas/_CommunityConnectivityReporting"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/_CommunityConnectivitySummary"
+          }
+        },
+        "type": "object",
+        "required": [
+          "probes",
+          "reporting",
+          "summary"
+        ],
+        "title": "_CommunityConnectivityCheckData"
+      },
+      "_CommunityConnectivityProbeRow": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "ok": {
+            "type": "boolean",
+            "title": "Ok"
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Ms"
+          },
+          "http_status": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http Status"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "ok"
+        ],
+        "title": "_CommunityConnectivityProbeRow"
+      },
+      "_CommunityConnectivityReporting": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": true
+          },
+          "endpoint": {
+            "type": "string",
+            "title": "Endpoint",
+            "default": ""
+          },
+          "active_heartbeat_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Heartbeat Endpoint"
+          },
+          "deployment_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deployment Id"
+          },
+          "last_heartbeat_ok_unix": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Heartbeat Ok Unix"
+          },
+          "last_primary_probe_unix": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Primary Probe Unix"
+          }
+        },
+        "type": "object",
+        "title": "_CommunityConnectivityReporting"
+      },
+      "_CommunityConnectivitySummary": {
+        "properties": {
+          "any_ok": {
+            "type": "boolean",
+            "title": "Any Ok",
+            "default": false
+          },
+          "hint": {
+            "type": "string",
+            "title": "Hint",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "_CommunityConnectivitySummary"
       },
       "_CommunityPluginActionBody": {
         "properties": {

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -4393,9 +4393,9 @@ class _CommunityConnectivitySummary(BaseModel):
 
 
 class _CommunityConnectivityCheckData(BaseModel):
-    probes: list[_CommunityConnectivityProbeRow] = Field(default_factory=list)
-    reporting: _CommunityConnectivityReporting = Field(default_factory=_CommunityConnectivityReporting)
-    summary: _CommunityConnectivitySummary = Field(default_factory=_CommunityConnectivitySummary)
+    probes: list[_CommunityConnectivityProbeRow]
+    reporting: _CommunityConnectivityReporting
+    summary: _CommunityConnectivitySummary
 
 
 class _LlmProviderConfigRowData(BaseModel):
@@ -5194,7 +5194,8 @@ def register_extended_api(
         try:
             data = await probe_community_connectivity()
         except Exception as e:  # noqa: BLE001
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            logger.exception("Pallas-Bot 控制台: 社区连通检测失败")
+            raise HTTPException(status_code=500, detail="社区连通检测失败") from e
         return {"ok": True, "data": data}
 
     @router.get(f"{x}/community-corpus-hot", include_in_schema=True)

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -4370,6 +4370,34 @@ class _ServiceGatewaysConnectivityCheckData(BaseModel):
     results: list[_ServiceProbeResultData] = Field(default_factory=list)
 
 
+class _CommunityConnectivityProbeRow(BaseModel):
+    url: str
+    ok: bool
+    latency_ms: int | None = None
+    http_status: int | None = None
+    error: str | None = None
+
+
+class _CommunityConnectivityReporting(BaseModel):
+    enabled: bool = True
+    endpoint: str = ""
+    active_heartbeat_endpoint: str | None = None
+    deployment_id: str | None = None
+    last_heartbeat_ok_unix: int | None = None
+    last_primary_probe_unix: int | None = None
+
+
+class _CommunityConnectivitySummary(BaseModel):
+    any_ok: bool = False
+    hint: str = ""
+
+
+class _CommunityConnectivityCheckData(BaseModel):
+    probes: list[_CommunityConnectivityProbeRow] = Field(default_factory=list)
+    reporting: _CommunityConnectivityReporting = Field(default_factory=_CommunityConnectivityReporting)
+    summary: _CommunityConnectivitySummary = Field(default_factory=_CommunityConnectivitySummary)
+
+
 class _LlmProviderConfigRowData(BaseModel):
     id: str
     kind: str
@@ -5150,6 +5178,24 @@ def register_extended_api(
 
         data = await cached_read(key="community-stats", loader=_load, ttl_sec=30.0, stale_sec=120.0)
         return JSONResponse({"ok": True, "data": data})
+
+    @router.post(
+        f"{x}/community-stats/connectivity-check",
+        include_in_schema=True,
+        response_model=_ApiOkResponse[_CommunityConnectivityCheckData],
+    )
+    async def _community_stats_connectivity_check(
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> dict[str, Any]:
+        _check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        from pallas.product.community_stats.connectivity_probe import probe_community_connectivity
+
+        try:
+            data = await probe_community_connectivity()
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return {"ok": True, "data": data}
 
     @router.get(f"{x}/community-corpus-hot", include_in_schema=True)
     async def _community_corpus_hot(

--- a/pallas/product/community_stats/connectivity_probe.py
+++ b/pallas/product/community_stats/connectivity_probe.py
@@ -128,7 +128,11 @@ async def probe_community_connectivity() -> dict[str, Any]:
     last_probe = state.get("last_primary_probe_unix")
     try:
         deployment_id = load_or_create_deployment_id()
-    except Exception:  # noqa: BLE001
+    except OSError as e:
+        logger.warning(
+            "community_stats: load_or_create_deployment_id failed, fallback to state: {}",
+            e,
+        )
         deployment_id = str(state.get("deployment_id") or "").strip() or None
 
     any_ok = any(bool(p.get("ok")) for p in probes)

--- a/pallas/product/community_stats/connectivity_probe.py
+++ b/pallas/product/community_stats/connectivity_probe.py
@@ -1,0 +1,150 @@
+"""社区中心连通探测：HTTPS 探活 + 上报状态诊断包。"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+from nonebot import logger
+
+from pallas.product.community_stats.config import get_community_stats_config
+from pallas.product.community_stats.endpoints import (
+    FALLBACK_HEARTBEAT,
+    PRIMARY_HEARTBEAT,
+    custom_heartbeat_url,
+)
+from pallas.product.community_stats.stats_url import stats_url_from_endpoint
+from pallas.product.community_stats.store import load_community_stats_state, load_or_create_deployment_id
+from pallas.product.message_scrub.quiet_http_loggers import scrub_http_log_noise
+
+_PROBE_TIMEOUT_SEC = 8.0
+
+
+def connectivity_probe_urls() -> list[str]:
+    """自动模式固定主+备；自定义 endpoint 只测一条。"""
+    cfg = get_community_stats_config()
+    custom = custom_heartbeat_url(cfg)
+    if custom:
+        return [stats_url_from_endpoint(custom)]
+    return [
+        stats_url_from_endpoint(PRIMARY_HEARTBEAT),
+        stats_url_from_endpoint(FALLBACK_HEARTBEAT),
+    ]
+
+
+def _error_text(exc: BaseException) -> str:
+    name = type(exc).__name__
+    msg = str(exc).strip()
+    if not msg:
+        return name
+    return f"{name}: {msg[:160]}"
+
+
+async def _probe_one(client: httpx.AsyncClient, url: str) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        resp = await client.get(url)
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        if resp.status_code >= 200 and resp.status_code < 300:
+            try:
+                body = resp.json()
+            except ValueError:
+                return {
+                    "url": url,
+                    "ok": False,
+                    "latency_ms": latency_ms,
+                    "http_status": resp.status_code,
+                    "error": "响应不是合法 JSON",
+                }
+            if not isinstance(body, dict):
+                return {
+                    "url": url,
+                    "ok": False,
+                    "latency_ms": latency_ms,
+                    "http_status": resp.status_code,
+                    "error": "响应不是 JSON 对象",
+                }
+            return {
+                "url": url,
+                "ok": True,
+                "latency_ms": latency_ms,
+                "http_status": resp.status_code,
+                "error": None,
+            }
+        return {
+            "url": url,
+            "ok": False,
+            "latency_ms": latency_ms,
+            "http_status": resp.status_code,
+            "error": f"HTTP {resp.status_code}",
+        }
+    except httpx.HTTPError as e:
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        return {
+            "url": url,
+            "ok": False,
+            "latency_ms": latency_ms,
+            "http_status": None,
+            "error": _error_text(e),
+        }
+
+
+def _build_hint(*, any_ok: bool, enabled: bool, probes: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    if not probes:
+        parts.append("未配置探测地址")
+    elif any_ok:
+        ok_n = sum(1 for p in probes if p.get("ok"))
+        if ok_n == len(probes):
+            parts.append("社区中心可达")
+        else:
+            parts.append("部分入口可达")
+    else:
+        parts.append("社区中心不可达")
+    parts.append("上报已开启" if enabled else "上报已关闭")
+    return "；".join(parts)
+
+
+async def probe_community_connectivity() -> dict[str, Any]:
+    cfg = get_community_stats_config()
+    urls = connectivity_probe_urls()
+    probes: list[dict[str, Any]] = []
+    scrub_http_log_noise()
+    async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_SEC) as client:
+        for url in urls:
+            result = await _probe_one(client, url)
+            probes.append(result)
+            if not result["ok"]:
+                logger.debug(
+                    "community_stats: connectivity probe failed url={} err={}",
+                    url,
+                    result.get("error"),
+                )
+
+    state = load_community_stats_state()
+    active = str(state.get("heartbeat_endpoint") or "").strip() or None
+    last_ok = state.get("last_heartbeat_ok_unix")
+    last_probe = state.get("last_primary_probe_unix")
+    try:
+        deployment_id = load_or_create_deployment_id()
+    except Exception:  # noqa: BLE001
+        deployment_id = str(state.get("deployment_id") or "").strip() or None
+
+    any_ok = any(bool(p.get("ok")) for p in probes)
+    reporting = {
+        "enabled": bool(cfg.enabled),
+        "endpoint": (cfg.endpoint or "").strip() or PRIMARY_HEARTBEAT,
+        "active_heartbeat_endpoint": active,
+        "deployment_id": deployment_id,
+        "last_heartbeat_ok_unix": int(last_ok) if last_ok is not None else None,
+        "last_primary_probe_unix": int(last_probe) if last_probe is not None else None,
+    }
+    return {
+        "probes": probes,
+        "reporting": reporting,
+        "summary": {
+            "any_ok": any_ok,
+            "hint": _build_hint(any_ok=any_ok, enabled=bool(cfg.enabled), probes=probes),
+        },
+    }

--- a/pallas/product/community_stats/reporter.py
+++ b/pallas/product/community_stats/reporter.py
@@ -22,6 +22,7 @@ from pallas.product.community_stats.endpoints import (
 from pallas.product.community_stats.store import (
     load_or_create_deployment_id,
     save_heartbeat_endpoint,
+    touch_last_heartbeat_ok_unix,
     touch_primary_probe_unix,
 )
 from pallas.product.message_scrub.quiet_http_loggers import scrub_http_log_noise
@@ -109,6 +110,7 @@ async def _post_heartbeat(
     resp = await client.post(endpoint, json=payload, headers=_headers(cfg), timeout=timeout_sec)
     if resp.status_code == 200:
         save_heartbeat_endpoint(endpoint)
+        touch_last_heartbeat_ok_unix()
         logger.debug("community_stats: heartbeat ok deployment_id={} endpoint={}", payload["deployment_id"], endpoint)
         return True
     if resp.status_code == 429:

--- a/pallas/product/community_stats/store.py
+++ b/pallas/product/community_stats/store.py
@@ -93,6 +93,12 @@ def touch_primary_probe_unix() -> None:
     _write_state(data)
 
 
+def touch_last_heartbeat_ok_unix(seen_unix: int | None = None) -> None:
+    data = _read_state_raw()
+    data["last_heartbeat_ok_unix"] = int(time.time() if seen_unix is None else seen_unix)
+    _write_state(data)
+
+
 def _is_uuid(value: str) -> bool:
     try:
         uuid.UUID(value)

--- a/tests/common/test_community_connectivity_probe.py
+++ b/tests/common/test_community_connectivity_probe.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from pallas.product.community_stats import config as cfg_mod
+from pallas.product.community_stats import store as stats_store
+from pallas.product.community_stats.endpoints import PRIMARY_HEARTBEAT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache():
+    cfg_mod.clear_community_stats_config_cache()
+    yield
+    cfg_mod.clear_community_stats_config_cache()
+
+
+@pytest.fixture
+def community_state_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "community_stats.json"
+    monkeypatch.setattr(stats_store, "community_stats_state_path", lambda: path)
+    stats_store.reset_community_stats_state_cache_for_tests()
+    return path
+
+
+def test_touch_last_heartbeat_ok_unix(community_state_file: Path) -> None:
+    stats_store.touch_last_heartbeat_ok_unix(1_700_000_000)
+    data = json.loads(community_state_file.read_text(encoding="utf-8"))
+    assert data["last_heartbeat_ok_unix"] == 1_700_000_000
+
+
+def _seed_community_state(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    stats_store.reset_community_stats_state_cache_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_probe_community_connectivity_auto_mode_covers_primary_and_fallback(
+    community_state_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pallas.product.community_stats.connectivity_probe import probe_community_connectivity
+
+    _seed_community_state(
+        community_state_file,
+        {
+            "deployment_id": "123e4567-e89b-12d3-a456-426614174000",
+            "heartbeat_endpoint": PRIMARY_HEARTBEAT,
+            "last_heartbeat_ok_unix": 1_700_000_100,
+            "last_primary_probe_unix": 1_700_000_050,
+        },
+    )
+    monkeypatch.setattr(
+        "pallas.product.community_stats.config.repo_env_raw_value",
+        lambda _key: None,
+    )
+    cfg_mod.clear_community_stats_config_cache()
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001
+        _ = kwargs
+        if "stats.pallasbot.top" in str(url):
+            return httpx.Response(200, json={"deployments_total": 1, "deployments_online": 1, "bots_online_sum": 1})
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", str(url)))
+
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        payload = await probe_community_connectivity()
+
+    assert [p["url"] for p in payload["probes"]] == [
+        "https://stats.pallasbot.top/v1/stats",
+        "https://pallas.togetsudo.com/v1/stats",
+    ]
+    assert payload["probes"][0]["ok"] is True
+    assert payload["probes"][0]["http_status"] == 200
+    assert payload["probes"][1]["ok"] is False
+    assert payload["reporting"]["enabled"] is True
+    assert payload["reporting"]["deployment_id"] == "123e4567-e89b-12d3-a456-426614174000"
+    assert payload["reporting"]["last_heartbeat_ok_unix"] == 1_700_000_100
+    assert payload["summary"]["any_ok"] is True
+    assert "上报" in payload["summary"]["hint"]
+
+
+@pytest.mark.asyncio
+async def test_probe_community_connectivity_custom_endpoint_only(
+    community_state_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pallas.product.community_stats.connectivity_probe import probe_community_connectivity
+
+    _ = community_state_file
+    monkeypatch.setattr(
+        "pallas.product.community_stats.config.repo_env_raw_value",
+        lambda key: "https://stats.example/v1/heartbeat" if key == "PALLAS_COMMUNITY_STATS_ENDPOINT" else None,
+    )
+    cfg_mod.clear_community_stats_config_cache()
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001
+        _ = self, kwargs, url
+        return httpx.Response(200, json={"deployments_total": 0, "deployments_online": 0, "bots_online_sum": 0})
+
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        payload = await probe_community_connectivity()
+
+    assert len(payload["probes"]) == 1
+    assert payload["probes"][0]["url"] == "https://stats.example/v1/stats"
+    assert payload["probes"][0]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_success_records_last_ok_unix(
+    community_state_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pallas.product.community_stats.reporter import send_community_stats_heartbeat
+
+    _ = community_state_file
+    monkeypatch.setattr(
+        "pallas.product.community_stats.config.repo_env_raw_value",
+        lambda _key: None,
+    )
+    cfg_mod.clear_community_stats_config_cache()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = ""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with (
+        patch(
+            "pallas.product.community_stats.reporter.load_or_create_deployment_id",
+            return_value="123e4567-e89b-12d3-a456-426614174000",
+        ),
+        patch("pallas.product.community_stats.reporter.get_catalog_bot_ids", return_value=frozenset({1})),
+        patch(
+            "pallas.core.platform.shard.presence.count_connected_bots_for_reporting",
+            return_value=1,
+        ),
+        patch("pallas.product.community_stats.reporter.httpx.AsyncClient", return_value=mock_client),
+        patch("pallas.product.community_stats.reporter.is_sharded_worker", return_value=False),
+    ):
+        assert await send_community_stats_heartbeat() is True
+
+    state = stats_store.load_community_stats_state()
+    assert int(state.get("last_heartbeat_ok_unix") or 0) > 0
+
+
+def test_connectivity_check_api_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from packages.pb_webui import extended_api as mod
+    from packages.pb_webui.config import Config
+
+    async def fake_probe():
+        return {
+            "probes": [
+                {
+                    "url": "https://stats.pallasbot.top/v1/stats",
+                    "ok": True,
+                    "latency_ms": 12,
+                    "http_status": 200,
+                    "error": None,
+                }
+            ],
+            "reporting": {
+                "enabled": True,
+                "endpoint": PRIMARY_HEARTBEAT,
+                "active_heartbeat_endpoint": PRIMARY_HEARTBEAT,
+                "deployment_id": "123e4567-e89b-12d3-a456-426614174000",
+                "last_heartbeat_ok_unix": 1,
+                "last_primary_probe_unix": 2,
+            },
+            "summary": {"any_ok": True, "hint": "主站可达；上报已开启"},
+        }
+
+    monkeypatch.setattr(mod, "_check_pallas_write_token", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "_require_pallas_token_configured", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "ensure_console_metrics_hooks", lambda: None)
+    monkeypatch.setattr(
+        "pallas.product.community_stats.connectivity_probe.probe_community_connectivity",
+        fake_probe,
+    )
+
+    app = FastAPI()
+    mod.register_extended_api(app, api_base="/pallas/api", plugin_config=Config())
+    client = TestClient(app)
+
+    response = client.post("/pallas/api/community-stats/connectivity-check", json={})
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["data"]["summary"]["any_ok"] is True
+    assert payload["data"]["probes"][0]["ok"] is True


### PR DESCRIPTION
社区页可一键探测 Bot 到社区中心主/备站 HTTPS 可达性，并展示上报开关与最近 heartbeat 状态。

## Summary by Sourcery

在 WebUI 社区统计中新增社区连通性探测与上报功能，包括一个 API 端点以及心跳跟踪。

新功能：
- 引入社区连通性探测器，用于测试主社区统计端点和备用端点（或自定义端点）的 HTTPS 可达性，并对结果进行汇总。
- 提供一个 WebUI API 端点，用于触发社区连通性检查并返回探测结果、上报配置，以及给客户端使用的概要提示信息。

增强内容：
- 跟踪并持久化最近一次成功社区心跳的时间戳，用于连通性诊断。

测试：
- 新增测试，覆盖自动与自定义端点模式下的连通性探测行为、心跳成功时间戳记录，以及新的 `connectivity-check` API 路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add community connectivity probing and reporting to the WebUI community stats, including an API endpoint and heartbeat tracking.

New Features:
- Introduce a community connectivity probe that tests HTTPS reachability of primary and fallback community stats endpoints or a custom endpoint and summarizes results.
- Expose a WebUI API endpoint to trigger community connectivity checks and return probe results, reporting configuration, and a summary hint to the client.

Enhancements:
- Track and persist the timestamp of the last successful community heartbeat for use in connectivity diagnostics.

Tests:
- Add tests covering connectivity probing behavior for auto and custom endpoint modes, heartbeat success timestamp recording, and the new connectivity-check API route.

</details>