### PR TITLE
feat(git-mirror): 支持 GitHub 镜像源与控制台配置

### DIFF
--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.0.0-4-g0f6b25c7-dirty",
+    "version": "v4.0.0-7-gb4576d49",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -3802,6 +3802,350 @@
             }
           }
         },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/git-mirror/info": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Git Mirror Info",
+        "operationId": "_git_mirror_info_pallas_api_git_mirror_info_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/git-mirror/preferred": {
+      "put": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Git Mirror Preferred",
+        "operationId": "_git_mirror_preferred_pallas_api_git_mirror_preferred_put",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GitMirrorPreferredBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/git-mirror/apply-community": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Git Mirror Apply Community",
+        "operationId": "_git_mirror_apply_community_pallas_api_git_mirror_apply_community_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/git-mirror/apply-plugin/{plugin_id}": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Git Mirror Apply Plugin",
+        "operationId": "_git_mirror_apply_plugin_pallas_api_git_mirror_apply_plugin__plugin_id__post",
+        "parameters": [
+          {
+            "name": "plugin_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Plugin Id"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GitMirrorApplyPluginBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/git-mirror/probe": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Git Mirror Probe",
+        "operationId": "_git_mirror_probe_pallas_api_git_mirror_probe_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12895,6 +13239,47 @@
   },
   "components": {
     "schemas": {
+      "GitMirrorApplyPluginBody": {
+        "properties": {
+          "preferred_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "GitMirrorApplyPluginBody"
+      },
+      "GitMirrorPreferredBody": {
+        "properties": {
+          "preferred_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Preferred Id"
+          },
+          "custom_proxy_prefix": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Custom Proxy Prefix",
+            "default": ""
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "preferred_id"
+        ],
+        "title": "GitMirrorPreferredBody"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -6063,6 +6063,18 @@ def register_extended_api(
             logger.exception("Pallas-Bot 控制台: 更新社区插件失败")
             raise HTTPException(status_code=500, detail=format_exception_for_log(e)) from e
 
+    from pallas.console.webui.git_mirror_api import register_git_mirror_router
+
+    register_git_mirror_router(
+        router,
+        x=x,
+        check_write_token=lambda *, x_pallas_token=None, token=None: _check_pallas_write_token(
+            plugin_config,
+            x_pallas_token=x_pallas_token,
+            token=token,
+        ),
+    )
+
     @router.get(f"{x}/plugins/help-menu-visibility", include_in_schema=True)
     async def _plugins_help_menu_visibility() -> JSONResponse:
         try:

--- a/packages/pb_webui/manager.py
+++ b/packages/pb_webui/manager.py
@@ -19,6 +19,12 @@ from pallas.core.foundation.bot_version import (
     pallas_bot_repo_root,
 )
 from pallas.core.shared.utils.format_exception import format_exception_for_log
+from pallas.core.shared.utils.git_mirror import (
+    MirrorSpec,
+    git_instead_of_args,
+    iter_mirrors_for_failover,
+    rewrite_github_url,
+)
 from pallas.core.shared.utils.github_release import (
     fetch_latest_release,
     fetch_latest_release_tag_via_github_web,
@@ -212,14 +218,36 @@ def _webui_download_progress_log(ev: StreamDownloadProgress) -> None:
             )
 
 
+def build_git_argv_with_mirror(mirror: MirrorSpec, *args: str) -> list[str]:
+    return [*git_instead_of_args(mirror), *args]
+
+
+def iter_failover_download_urls(url: str):
+    u = (url or "").strip()
+    if not u:
+        return
+    for mirror in iter_mirrors_for_failover():
+        yield rewrite_github_url(u, mirror)
+
+
 def _sync_download_webui_zip(url: str, dest: Path, *, follow_redirects: bool) -> None:
-    sync_stream_download_to_file(
-        url,
-        dest,
-        follow_redirects=follow_redirects,
-        timeout=httpx.Timeout(300.0, connect=60.0),
-        on_progress=_webui_download_progress_log,
-    )
+    last_exc: Exception | None = None
+    for attempt_url in iter_failover_download_urls(url):
+        try:
+            sync_stream_download_to_file(
+                attempt_url,
+                dest,
+                follow_redirects=follow_redirects,
+                timeout=httpx.Timeout(300.0, connect=60.0),
+                on_progress=_webui_download_progress_log,
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            last_exc = e
+            continue
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("无可用镜像源")
 
 
 async def download_and_extract_dist_zip(public_dir: Path, url: str, *, follow_redirects: bool = True) -> bool:
@@ -509,9 +537,15 @@ async def apply_bot_repository_update(
     root = _BOT_ROOT
     env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
-    async def git(*args: str, cmd_timeout_s: float = 180.0) -> tuple[int, str, str]:
+    async def git(
+        *args: str,
+        cmd_timeout_s: float = 180.0,
+        mirror: MirrorSpec | None = None,
+    ) -> tuple[int, str, str]:
+        prefix = git_instead_of_args(mirror) if mirror is not None else []
         proc = await asyncio.create_subprocess_exec(
             "git",
+            *prefix,
             *args,
             cwd=str(root),
             env=env,
@@ -529,6 +563,17 @@ async def apply_bot_repository_update(
         err = err_b.decode(errors="replace").strip() if err_b else ""
         code = int(proc.returncode or 0)
         return code, out, err
+
+    async def git_remote(*args: str, cmd_timeout_s: float = 180.0) -> tuple[int, str, str]:
+        last_code = 1
+        last_out = ""
+        last_err = ""
+        for mirror in iter_mirrors_for_failover():
+            code, out, err = await git(*args, cmd_timeout_s=cmd_timeout_s, mirror=mirror)
+            if code == 0:
+                return code, out, err
+            last_code, last_out, last_err = code, out, err
+        return last_code, last_out, last_err
 
     rc, out, err = await git("rev-parse", "--is-inside-work-tree")
     if rc != 0 or out != "true":
@@ -554,7 +599,7 @@ async def apply_bot_repository_update(
 
     logger.info("Pallas-Bot 控制台: Bot 仓库更新开始 repo={} target_tag={}", repo, latest_tag)
 
-    rc, _, fetch_err = await git("fetch", "origin", "--tags", cmd_timeout_s=300.0)
+    rc, _, fetch_err = await git_remote("fetch", "origin", "--tags", cmd_timeout_s=300.0)
     if rc != 0:
         detail = fetch_err or "(无 stderr)"
         raise BotGitUpdateError(f"git fetch 失败：{detail}", status_code=502)
@@ -625,7 +670,7 @@ async def apply_bot_repository_update(
     else:
         rc_u, upstream_out, _ = await git("rev-parse", "--abbrev-ref", "@{u}")
         if rc_u == 0 and upstream_out:
-            rc_p, _, err_p = await git("pull", "--ff-only", "--autostash")
+            rc_p, _, err_p = await git_remote("pull", "--ff-only", "--autostash")
             if rc_p != 0:
                 raise BotGitUpdateError(
                     f"git pull --ff-only 失败（已配置上游 {upstream_out}）：{err_p or '(无 stderr)'}",
@@ -643,7 +688,7 @@ async def apply_bot_repository_update(
                     if rc_ob == 0:
                         def_branch = cand
                         break
-            rc_p, _, err_p = await git("pull", "--ff-only", "--autostash", "origin", def_branch)
+            rc_p, _, err_p = await git_remote("pull", "--ff-only", "--autostash", "origin", def_branch)
             if rc_p != 0:
                 raise BotGitUpdateError(
                     f"git pull --ff-only --autostash origin {def_branch} 失败：{err_p or '(无 stderr)'}",

--- a/pallas/console/webui/community_plugin_install.py
+++ b/pallas/console/webui/community_plugin_install.py
@@ -11,6 +11,11 @@ from nonebot import logger
 
 from pallas.console.cli.bot_process import bot_lifecycle_available
 from pallas.core.foundation.paths import PROJECT_ROOT
+from pallas.core.shared.utils.git_mirror import (
+    git_instead_of_args,
+    iter_mirrors_for_failover,
+    rewrite_github_url,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -136,21 +141,32 @@ async def install_community_plugin(
         repo,
         branch,
     )
-    code, out, err = await run_git_command(
-        INSTALL_TIMEOUT_S,
-        "clone",
-        "--depth",
-        "1",
-        "--branch",
-        branch,
-        repo,
-        str(dest),
-    )
-    if code != 0:
+    last_detail = ""
+    clone_ok = False
+    out = ""
+    for mirror in iter_mirrors_for_failover():
+        clone_url = rewrite_github_url(repo, mirror)
+        code, out, err = await run_git_command(
+            INSTALL_TIMEOUT_S,
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            clone_url,
+            str(dest),
+        )
+        if code == 0:
+            clone_ok = True
+            break
+        last_detail = err or out or "(无输出)"
         if dest.exists():
             shutil.rmtree(dest, ignore_errors=True)
-        detail = err or out or "(无输出)"
-        raise CommunityPluginInstallError(f"git clone 失败：{tail_output(detail)}", status_code=502)
+    if not clone_ok:
+        raise CommunityPluginInstallError(
+            f"git clone 失败：{tail_output(last_detail)}",
+            status_code=502,
+        )
     if not (dest / "__init__.py").is_file():
         shutil.rmtree(dest, ignore_errors=True)
         raise CommunityPluginInstallError(
@@ -184,35 +200,57 @@ async def update_community_plugin(
     if not local_plugin_installed(pid):
         raise CommunityPluginInstallError(f"local/plugins/{pid} 未安装，无法更新")
     logger.info("Pallas-Bot 控制台: 更新社区插件 id={} ref={}", pid, branch)
-    code, out, err = await run_git_command(
-        INSTALL_TIMEOUT_S,
-        "fetch",
-        "origin",
-        branch,
-        cwd=str(dest),
-    )
-    if code != 0:
-        detail = err or out or "(无输出)"
-        raise CommunityPluginInstallError(f"git fetch 失败：{tail_output(detail)}", status_code=502)
-    code, out, err = await run_git_command(
-        INSTALL_TIMEOUT_S,
-        "reset",
-        "--hard",
-        f"origin/{branch}",
-        cwd=str(dest),
-    )
-    if code != 0:
+    last_detail = ""
+    last_stage = "fetch"
+    update_ok = False
+    out = ""
+    for mirror in iter_mirrors_for_failover():
+        extra = git_instead_of_args(mirror)
         code, out, err = await run_git_command(
             INSTALL_TIMEOUT_S,
-            "pull",
-            "--ff-only",
+            *extra,
+            "fetch",
             "origin",
             branch,
             cwd=str(dest),
         )
-    if code != 0:
-        detail = err or out or "(无输出)"
-        raise CommunityPluginInstallError(f"git 更新失败：{tail_output(detail)}", status_code=502)
+        if code != 0:
+            last_detail = err or out or "(无输出)"
+            last_stage = "fetch"
+            continue
+        code, out, err = await run_git_command(
+            INSTALL_TIMEOUT_S,
+            *extra,
+            "reset",
+            "--hard",
+            f"origin/{branch}",
+            cwd=str(dest),
+        )
+        if code != 0:
+            code, out, err = await run_git_command(
+                INSTALL_TIMEOUT_S,
+                *extra,
+                "pull",
+                "--ff-only",
+                "origin",
+                branch,
+                cwd=str(dest),
+            )
+        if code == 0:
+            update_ok = True
+            break
+        last_detail = err or out or "(无输出)"
+        last_stage = "update"
+    if not update_ok:
+        if last_stage == "fetch":
+            raise CommunityPluginInstallError(
+                f"git fetch 失败：{tail_output(last_detail)}",
+                status_code=502,
+            )
+        raise CommunityPluginInstallError(
+            f"git 更新失败：{tail_output(last_detail)}",
+            status_code=502,
+        )
     if not (dest / "__init__.py").is_file():
         raise CommunityPluginInstallError(
             "更新后目录缺少 __init__.py，不是有效 NoneBot 插件包",

--- a/pallas/console/webui/git_mirror_api.py
+++ b/pallas/console/webui/git_mirror_api.py
@@ -1,0 +1,122 @@
+"""控制台 Git 镜像源 API。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from pallas.core.shared.utils.git_mirror import (
+    apply_mirror_to_community_plugins,
+    apply_mirror_to_plugin,
+    build_git_mirror_info,
+    load_git_mirror_config,
+    mirror_by_id,
+    probe_preferred_mirror,
+    resolve_mirror_by_preferred_id,
+    save_git_mirror_config,
+    validate_custom_proxy_prefix,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class GitMirrorPreferredBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preferred_id: str = Field(min_length=1, max_length=64)
+    custom_proxy_prefix: str = Field(default="", max_length=512)
+
+
+class GitMirrorApplyPluginBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preferred_id: str | None = Field(default=None, max_length=64)
+
+
+def git_mirror_info_payload() -> dict[str, Any]:
+    return build_git_mirror_info()
+
+
+def save_git_mirror_preferred(body: GitMirrorPreferredBody) -> dict[str, Any]:
+    preferred_id = body.preferred_id.strip()
+    custom_prefix = (body.custom_proxy_prefix or "").strip()
+    if preferred_id == "custom":
+        if not custom_prefix:
+            raise HTTPException(status_code=400, detail="自定义镜像须填写 custom_proxy_prefix")
+        try:
+            validate_custom_proxy_prefix(custom_prefix)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+    elif mirror_by_id(preferred_id) is None:
+        raise HTTPException(status_code=400, detail=f"未知镜像 id: {preferred_id}")
+    save_git_mirror_config(preferred_id=preferred_id, custom_proxy_prefix=custom_prefix)
+    return git_mirror_info_payload()
+
+
+def apply_git_mirror_to_community() -> dict[str, Any]:
+    return apply_mirror_to_community_plugins()
+
+
+def apply_git_mirror_to_plugin(plugin_id: str, body: GitMirrorApplyPluginBody) -> dict[str, Any]:
+    mirror = None
+    if (body.preferred_id or "").strip():
+        cfg = load_git_mirror_config()
+        mirror = resolve_mirror_by_preferred_id(
+            body.preferred_id or "",
+            custom_proxy_prefix=cfg.get("custom_proxy_prefix", ""),
+        )
+    return apply_mirror_to_plugin(plugin_id, mirror=mirror)
+
+
+async def probe_git_mirror() -> dict[str, Any]:
+    return await probe_preferred_mirror()
+
+
+def register_git_mirror_router(
+    router: APIRouter,
+    *,
+    x: str,
+    check_write_token: Callable[..., None],
+) -> None:
+    @router.get(f"{x}/git-mirror/info", include_in_schema=True)
+    async def _git_mirror_info() -> JSONResponse:
+        return JSONResponse({"ok": True, "data": git_mirror_info_payload()})
+
+    @router.put(f"{x}/git-mirror/preferred", include_in_schema=True)
+    async def _git_mirror_preferred(
+        body: GitMirrorPreferredBody,
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        check_write_token(x_pallas_token=x_pallas_token, token=token)
+        data = save_git_mirror_preferred(body)
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.post(f"{x}/git-mirror/apply-community", include_in_schema=True)
+    async def _git_mirror_apply_community(
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        check_write_token(x_pallas_token=x_pallas_token, token=token)
+        data = apply_git_mirror_to_community()
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.post(f"{x}/git-mirror/apply-plugin/{{plugin_id}}", include_in_schema=True)
+    async def _git_mirror_apply_plugin(
+        plugin_id: str,
+        body: GitMirrorApplyPluginBody,
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        check_write_token(x_pallas_token=x_pallas_token, token=token)
+        data = apply_git_mirror_to_plugin(plugin_id, body)
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.post(f"{x}/git-mirror/probe", include_in_schema=True)
+    async def _git_mirror_probe() -> JSONResponse:
+        data = await probe_git_mirror()
+        return JSONResponse({"ok": True, "data": data})

--- a/pallas/console/webui/plugin_store_assets.py
+++ b/pallas/console/webui/plugin_store_assets.py
@@ -15,6 +15,7 @@ import httpx
 from nonebot import logger
 
 from pallas.core.foundation.paths import plugin_data_dir
+from pallas.core.shared.utils.git_mirror import iter_mirrors_for_failover, request_with_mirrors
 
 _SNAPSHOT_FILENAME = "plugin_store_assets_snapshot.json"
 _PUBLIC_PREFIX = "/pallas/store-assets"
@@ -341,23 +342,33 @@ def _github_changelog_urls(repository_url: str | None) -> list[str]:
 
 
 async def _download_binary(url: str) -> tuple[bytes, str]:
-    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
-        resp = await client.get(url)
-        resp.raise_for_status()
-        return resp.content, str(resp.headers.get("content-type") or "")
+    mirrors = list(iter_mirrors_for_failover())
+
+    async def getter(rewritten_url: str) -> tuple[bytes, str]:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
+            resp = await client.get(rewritten_url)
+            resp.raise_for_status()
+            return resp.content, str(resp.headers.get("content-type") or "")
+
+    return await request_with_mirrors(url, mirrors, getter)
 
 
 async def _download_text_first(urls: list[str]) -> tuple[str, str]:
     last_exc: Exception | None = None
+    mirrors = list(iter_mirrors_for_failover())
     for url in urls:
         raw = str(url or "").strip()
         if not raw:
             continue
         try:
-            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
-                resp = await client.get(raw)
-                resp.raise_for_status()
-                return resp.text, raw
+
+            async def getter(rewritten_url: str, *, source_url: str = raw) -> tuple[str, str]:
+                async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
+                    resp = await client.get(rewritten_url)
+                    resp.raise_for_status()
+                    return resp.text, source_url
+
+            return await request_with_mirrors(raw, mirrors, getter)
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
             continue

--- a/pallas/core/shared/utils/git_mirror.py
+++ b/pallas/core/shared/utils/git_mirror.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from ipaddress import ip_address
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from pallas.core.foundation.config.repo_settings import (
+    _atomic_write_text,
+    repo_webui_settings_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
+
+_DEFAULT_GIT_MIRROR_CONFIG = {"preferred_id": "github", "custom_proxy_prefix": ""}
+
+
+@dataclass(frozen=True, slots=True)
+class MirrorSpec:
+    id: str
+    label: str
+    type: str  # default | proxy
+    clone_prefix: str
+    raw_prefix: str
+    api_prefix: str
+
+
+BUILTIN_MIRRORS: tuple[MirrorSpec, ...] = (
+    MirrorSpec(
+        id="github",
+        label="GitHub 官方",
+        type="default",
+        clone_prefix="https://github.com",
+        raw_prefix="https://raw.githubusercontent.com",
+        api_prefix="https://api.github.com",
+    ),
+    MirrorSpec(
+        id="ghproxy-vip",
+        label="ghproxy.vip",
+        type="proxy",
+        clone_prefix="https://ghproxy.vip/https://github.com",
+        raw_prefix="https://ghproxy.vip/https://raw.githubusercontent.com",
+        api_prefix="https://ghproxy.vip/https://api.github.com",
+    ),
+)
+
+
+def validate_custom_proxy_prefix(prefix: str) -> str:
+    raw = (prefix or "").strip().rstrip("/") + "/"
+    parsed = urlparse(raw)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("自定义前缀须为 https:// 公网地址")
+    host = (parsed.hostname or "").lower()
+    if host in {"localhost", "metadata.google.internal"} or host.endswith(".local"):
+        raise ValueError("自定义前缀禁止本地/内网主机")
+    try:
+        ip = ip_address(host)
+        if not ip.is_global:
+            raise ValueError("自定义前缀禁止私网 IP")
+    except ValueError as e:
+        if "私网" in str(e) or "禁止" in str(e):
+            raise
+        # hostname is a domain name — allow
+    return raw.rstrip("/")
+
+
+def rewrite_github_url(url: str, mirror: MirrorSpec) -> str:
+    u = (url or "").strip()
+    if not u or mirror.id == "github" or mirror.type == "default":
+        return u
+    for host, attr in (
+        ("https://raw.githubusercontent.com", "raw_prefix"),
+        ("https://api.github.com", "api_prefix"),
+        ("https://github.com", "clone_prefix"),
+    ):
+        if u.startswith(host + "/") or u == host:
+            rest = u[len(host) :]
+            prefix = getattr(mirror, attr).rstrip("/")
+            return prefix + rest
+    return u
+
+
+def load_git_mirror_config() -> dict[str, str]:
+    path = repo_webui_settings_path()
+    if not path.is_file():
+        return dict(_DEFAULT_GIT_MIRROR_CONFIG)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return dict(_DEFAULT_GIT_MIRROR_CONFIG)
+    if not isinstance(data, dict):
+        return dict(_DEFAULT_GIT_MIRROR_CONFIG)
+    section = data.get("git_mirror")
+    if not isinstance(section, dict):
+        return dict(_DEFAULT_GIT_MIRROR_CONFIG)
+    return {
+        "preferred_id": str(section.get("preferred_id") or _DEFAULT_GIT_MIRROR_CONFIG["preferred_id"]),
+        "custom_proxy_prefix": str(section.get("custom_proxy_prefix") or ""),
+    }
+
+
+def save_git_mirror_config(preferred_id: str, custom_proxy_prefix: str = "") -> None:
+    path = repo_webui_settings_path()
+    doc: dict = {"env": {}}
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                doc = data
+        except (json.JSONDecodeError, OSError):
+            pass
+    if not isinstance(doc.get("env"), dict):
+        doc["env"] = {}
+    doc["git_mirror"] = {
+        "preferred_id": preferred_id,
+        "custom_proxy_prefix": custom_proxy_prefix,
+    }
+    _atomic_write_text(path, json.dumps(doc, ensure_ascii=False, indent=2) + "\n")
+
+
+def mirror_by_id(mirror_id: str) -> MirrorSpec | None:
+    for mirror in BUILTIN_MIRRORS:
+        if mirror.id == mirror_id:
+            return mirror
+    return None
+
+
+def mirror_from_custom_prefix(prefix: str) -> MirrorSpec:
+    validated = validate_custom_proxy_prefix(prefix)
+    return MirrorSpec(
+        id="custom",
+        label="自定义代理",
+        type="proxy",
+        clone_prefix=f"{validated}/https://github.com",
+        raw_prefix=f"{validated}/https://raw.githubusercontent.com",
+        api_prefix=f"{validated}/https://api.github.com",
+    )
+
+
+def resolve_preferred_mirror() -> MirrorSpec:
+    cfg = load_git_mirror_config()
+    preferred_id = cfg["preferred_id"]
+    if preferred_id == "custom":
+        custom_prefix = cfg["custom_proxy_prefix"]
+        if custom_prefix.strip():
+            try:
+                return mirror_from_custom_prefix(custom_prefix)
+            except ValueError:
+                pass
+        return mirror_by_id("github") or BUILTIN_MIRRORS[0]
+    mirror = mirror_by_id(preferred_id)
+    if mirror is not None:
+        return mirror
+    return mirror_by_id("github") or BUILTIN_MIRRORS[0]
+
+
+def git_instead_of_args(mirror: MirrorSpec) -> list[str]:
+    if mirror.id == "github" or mirror.type == "default":
+        return []
+    prefix = mirror.clone_prefix.rstrip("/") + "/"
+    return ["-c", f"url.{prefix}.insteadOf=https://github.com/"]
+
+
+def iter_mirrors_for_failover() -> Iterator[MirrorSpec]:
+    seen: set[str] = set()
+    ordered: list[MirrorSpec] = []
+
+    def add(mirror: MirrorSpec) -> None:
+        if mirror.id in seen:
+            return
+        seen.add(mirror.id)
+        ordered.append(mirror)
+
+    add(resolve_preferred_mirror())
+
+    for mirror in BUILTIN_MIRRORS:
+        if mirror.type == "proxy" and mirror.id not in seen:
+            add(mirror)
+
+    github = mirror_by_id("github")
+    if github is not None and github.id not in seen:
+        add(github)
+
+    yield from ordered
+
+
+async def request_with_mirrors[T](
+    url: str,
+    mirrors: Sequence[MirrorSpec] | Iterable[MirrorSpec],
+    getter: Callable[[str], Awaitable[T]],
+) -> T:
+    last_exc: Exception | None = None
+    for mirror in mirrors:
+        rewritten = rewrite_github_url(url, mirror)
+        try:
+            return await getter(rewritten)
+        except Exception as e:  # noqa: BLE001
+            last_exc = e
+            continue
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("无可用镜像源")
+
+
+_GITHUB_HTTPS = "https://github.com/"
+_PROBE_RAW_URL = "https://raw.githubusercontent.com/PallasBot/Pallas-Bot/main/README.md"
+_GIT_CMD_TIMEOUT_S = 60.0
+
+
+def detect_mirror_id(remote_url: str) -> str:
+    u = (remote_url or "").strip()
+    if not u:
+        return "unknown"
+    if u.startswith("git@"):
+        return "ssh"
+    proxy_mirrors = [m for m in BUILTIN_MIRRORS if m.type == "proxy"]
+    for mirror in sorted(proxy_mirrors, key=lambda m: len(m.clone_prefix), reverse=True):
+        if u.startswith(mirror.clone_prefix):
+            return mirror.id
+    if u.startswith(("https://github.com/", "http://github.com/")):
+        return "github"
+    if "/https://github.com/" in u:
+        return "custom"
+    canonical = canonical_github_https_url(u)
+    if canonical and canonical.startswith(_GITHUB_HTTPS):
+        return "github"
+    return "unknown"
+
+
+def canonical_github_https_url(remote_url: str) -> str | None:
+    u = (remote_url or "").strip()
+    if not u:
+        return None
+    if u.startswith("git@"):
+        host_part, _, path = u.partition(":")
+        if host_part.lower() != "git@github.com" or not path:
+            return None
+        return f"{_GITHUB_HTTPS}{path.lstrip('/')}".rstrip("/")
+    if not u.startswith(("https://", "http://")):
+        return None
+    if u.startswith(("https://github.com/", "http://github.com/")):
+        return f"{_GITHUB_HTTPS}{u.split('github.com/', 1)[1]}".rstrip("/")
+    proxy_mirrors = [m for m in BUILTIN_MIRRORS if m.type == "proxy"]
+    for mirror in sorted(proxy_mirrors, key=lambda m: len(m.clone_prefix), reverse=True):
+        prefix = mirror.clone_prefix.rstrip("/") + "/"
+        if u.startswith(prefix):
+            rest = u[len(prefix) :].lstrip("/")
+            if rest.startswith("https://github.com/"):
+                return rest.rstrip("/")
+            return f"{_GITHUB_HTTPS}{rest}".rstrip("/")
+    marker = "/https://github.com/"
+    idx = u.find(marker)
+    if idx >= 0:
+        return u[idx + 1 :].rstrip("/")
+    return None
+
+
+def mirror_option_dict(mirror: MirrorSpec) -> dict[str, str]:
+    return {"id": mirror.id, "label": mirror.label, "type": mirror.type}
+
+
+def available_mirrors_for_config() -> list[dict[str, str]]:
+    cfg = load_git_mirror_config()
+    options = [mirror_option_dict(mirror) for mirror in BUILTIN_MIRRORS]
+    custom_prefix = (cfg.get("custom_proxy_prefix") or "").strip()
+    if custom_prefix:
+        try:
+            options.append(mirror_option_dict(mirror_from_custom_prefix(custom_prefix)))
+        except ValueError:
+            pass
+    return options
+
+
+def build_git_mirror_info() -> dict[str, object]:
+    cfg = load_git_mirror_config()
+    return {
+        "preferred_id": cfg["preferred_id"],
+        "custom_proxy_prefix": cfg["custom_proxy_prefix"],
+        "available_mirrors": available_mirrors_for_config(),
+        "plugins": list_community_plugin_git_info(),
+    }
+
+
+def resolve_mirror_by_preferred_id(preferred_id: str, custom_proxy_prefix: str = "") -> MirrorSpec:
+    pid = (preferred_id or "").strip()
+    if pid == "custom":
+        prefix = (custom_proxy_prefix or "").strip()
+        if prefix:
+            try:
+                return mirror_from_custom_prefix(prefix)
+            except ValueError:
+                pass
+        return mirror_by_id("github") or BUILTIN_MIRRORS[0]
+    mirror = mirror_by_id(pid)
+    if mirror is not None:
+        return mirror
+    return mirror_by_id("github") or BUILTIN_MIRRORS[0]
+
+
+def run_git_command_sync(*args: str, cwd: str | None = None) -> tuple[int, str, str]:
+    if shutil.which("git") is None:
+        return 127, "", "未找到 git 命令"
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_CMD_TIMEOUT_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", "git 命令超时"
+    out = (proc.stdout or "").strip()
+    err = (proc.stderr or "").strip()
+    return int(proc.returncode or 0), out, err
+
+
+def list_community_plugin_git_info() -> list[dict[str, object]]:
+    from pallas.console.webui.community_plugin_install import community_plugins_root
+
+    root = community_plugins_root()
+    if not root.is_dir() or shutil.which("git") is None:
+        return []
+
+    rows: list[dict[str, object]] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        plugin_id = entry.name
+        rel_path = f"local/plugins/{plugin_id}"
+        is_git_repo = False
+        remote_url = ""
+        code, out, _ = run_git_command_sync("rev-parse", "--is-inside-work-tree", cwd=str(entry))
+        if code == 0 and out.lower() == "true":
+            is_git_repo = True
+            code2, origin, _ = run_git_command_sync("remote", "get-url", "origin", cwd=str(entry))
+            if code2 == 0:
+                remote_url = origin
+        rows.append({
+            "id": plugin_id,
+            "path": rel_path,
+            "remote_url": remote_url,
+            "is_git_repo": is_git_repo,
+            "mirror": detect_mirror_id(remote_url) if remote_url else "unknown",
+        })
+    return rows
+
+
+def apply_mirror_to_plugin(plugin_id: str, mirror: MirrorSpec | None = None) -> dict[str, object]:
+    from pallas.console.webui.community_plugin_install import (
+        CommunityPluginInstallError,
+        community_plugins_root,
+        validate_plugin_id,
+    )
+
+    mirror = mirror or resolve_preferred_mirror()
+    try:
+        pid = validate_plugin_id(plugin_id)
+    except CommunityPluginInstallError as e:
+        return {"id": (plugin_id or "").strip(), "success": False, "message": e.detail}
+
+    plugin_path = community_plugins_root() / pid
+    if not plugin_path.is_dir():
+        return {"id": pid, "success": False, "message": f"local/plugins/{pid} 不存在"}
+
+    code, out, err = run_git_command_sync("rev-parse", "--is-inside-work-tree", cwd=str(plugin_path))
+    if code != 0 or out.lower() != "true":
+        return {"id": pid, "success": False, "message": "不是 git 仓库"}
+
+    code, remote_url, err = run_git_command_sync("remote", "get-url", "origin", cwd=str(plugin_path))
+    if code != 0 or not remote_url:
+        detail = err or out or "无法读取 origin remote"
+        return {"id": pid, "success": False, "message": detail}
+
+    canonical = canonical_github_https_url(remote_url)
+    if canonical is None:
+        return {"id": pid, "success": False, "message": "仅支持 GitHub 仓库的镜像切换"}
+
+    new_url = rewrite_github_url(canonical, mirror)
+    if new_url == remote_url:
+        return {
+            "id": pid,
+            "success": True,
+            "message": "remote 已是目标镜像",
+            "remote_url": remote_url,
+        }
+
+    code, out, err = run_git_command_sync("remote", "set-url", "origin", new_url, cwd=str(plugin_path))
+    if code != 0:
+        detail = err or out or "git remote set-url 失败"
+        return {"id": pid, "success": False, "message": detail}
+
+    return {"id": pid, "success": True, "message": "已更新 origin", "remote_url": new_url}
+
+
+def apply_mirror_to_community_plugins(mirror: MirrorSpec | None = None) -> dict[str, object]:
+    mirror = mirror or resolve_preferred_mirror()
+    plugins = list_community_plugin_git_info()
+    results: list[dict[str, object]] = []
+    for row in plugins:
+        if not row.get("is_git_repo"):
+            results.append({"id": row["id"], "success": False, "message": "不是 git 仓库"})
+            continue
+        results.append(apply_mirror_to_plugin(str(row["id"]), mirror=mirror))
+    success_count = sum(1 for item in results if item.get("success"))
+    return {
+        "results": results,
+        "summary": {
+            "total": len(results),
+            "success_count": success_count,
+            "fail_count": len(results) - success_count,
+        },
+    }
+
+
+async def probe_preferred_mirror() -> dict[str, object]:
+    import httpx
+
+    mirror = resolve_preferred_mirror()
+    url = rewrite_github_url(_PROBE_RAW_URL, mirror)
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(15.0, connect=10.0),
+            follow_redirects=True,
+        ) as client:
+            resp = await client.head(url)
+            if resp.status_code >= 400:
+                resp = await client.get(url)
+            resp.raise_for_status()
+        return {"ok": True, "mirror_id": mirror.id}
+    except Exception as e:  # noqa: BLE001
+        return {"ok": False, "mirror_id": mirror.id, "error": str(e)}

--- a/pallas/core/shared/utils/github_release.py
+++ b/pallas/core/shared/utils/github_release.py
@@ -20,6 +20,8 @@ from urllib.parse import quote, unquote, urlparse
 
 import httpx
 
+from pallas.core.shared.utils.git_mirror import iter_mirrors_for_failover, request_with_mirrors
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -145,16 +147,21 @@ async def fetch_latest_release_tag_via_github_web(
     eff_timeout = client_timeout or httpx.Timeout(15.0, connect=8.0)
     headers: dict[str, str] = {"User-Agent": user_agent}
     headers.update(github_auth_headers(token))
+    mirrors = list(iter_mirrors_for_failover())
+
+    async def getter(url: str) -> dict[str, str]:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        final_url = str(resp.url)
+        tag = release_tag_from_github_final_url(final_url)
+        if not tag:
+            msg = f"无法从 GitHub 网页解析 release tag: {final_url!r}"
+            raise ValueError(msg)
+        return {"tag": tag, "html_url": final_url}
+
     with github_request_ssl_env():
         async with httpx.AsyncClient(follow_redirects=True, timeout=eff_timeout, headers=headers) as client:
-            resp = await client.get(page_url)
-            resp.raise_for_status()
-            final_url = str(resp.url)
-    tag = release_tag_from_github_final_url(final_url)
-    if not tag:
-        msg = f"无法从 GitHub 网页解析 release tag: {final_url!r}"
-        raise ValueError(msg)
-    return {"tag": tag, "html_url": final_url}
+            return await request_with_mirrors(page_url, mirrors, getter)
 
 
 async def fetch_github_releases(
@@ -174,11 +181,17 @@ async def fetch_github_releases(
         return []
     api_url = f"https://api.github.com/repos/{owner}/{name}/releases?per_page={limit}"
     auth_headers = github_auth_headers(token)
+    mirrors = list(iter_mirrors_for_failover())
+
+    async def getter(url: str) -> httpx.Response:
+        resp = await client.get(url, headers=auth_headers)
+        if resp.status_code != 200:
+            resp.raise_for_status()
+        return resp
+
     try:
-        resp = await client.get(api_url, headers=auth_headers)
+        resp = await request_with_mirrors(api_url, mirrors, getter)
     except Exception:  # noqa: BLE001
-        return []
-    if resp.status_code != 200:
         return []
     data = resp.json()
     if not isinstance(data, list):
@@ -225,14 +238,20 @@ async def fetch_latest_release(
     api_url = github_release_api_url(repo)
     headers: dict[str, str] = {"User-Agent": user_agent}
     headers.update(github_auth_headers(token))
+    mirrors = list(iter_mirrors_for_failover())
+
+    async def getter(url: str) -> httpx.Response:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp
+
     with github_request_ssl_env():
         async with httpx.AsyncClient(
             follow_redirects=True,
             timeout=httpx.Timeout(15.0, connect=8.0),
             headers=headers,
         ) as client:
-            resp = await client.get(api_url)
-            resp.raise_for_status()
+            resp = await request_with_mirrors(api_url, mirrors, getter)
             data = resp.json()
     tag = str(data.get("tag_name") or "").strip()
     html_url = str(data.get("html_url") or "").strip()

--- a/tests/common/test_community_plugin_store.py
+++ b/tests/common/test_community_plugin_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from pallas.console.webui.community_plugin_registry import build_community_plugin_store
 
 
@@ -326,3 +328,83 @@ async def test_build_community_plugin_store_prefers_cached_asset_urls(monkeypatc
     row = store["plugins"][0]
 
     assert row["icon"] == "/pallas/store-assets/icon/community-demo.png"
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_uses_rewritten_clone_url(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as cpi
+    from pallas.core.shared.utils import git_mirror as gm
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+
+    monkeypatch.setattr(cpi, "iter_mirrors_for_failover", fake_iter_mirrors)
+    monkeypatch.setattr(cpi, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cpi, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(cpi, "bot_lifecycle_available", lambda: True)
+    monkeypatch.setattr(cpi.shutil, "which", lambda _cmd: "/usr/bin/git")
+
+    clone_urls: list[str] = []
+
+    async def fake_run_git_command(_timeout_s: float, *args: str, cwd: str | None = None):
+        if args and args[0] == "clone":
+            clone_urls.append(args[5])
+            dest = tmp_path / cpi.COMMUNITY_PLUGINS_DIR / "demo"
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "__init__.py").write_text("# demo\n", encoding="utf-8")
+            return 0, "cloned", ""
+        return 1, "", "unexpected git args"
+
+    monkeypatch.setattr(cpi, "run_git_command", fake_run_git_command)
+
+    result = await cpi.install_community_plugin(
+        "demo",
+        repository_url="https://github.com/acme/demo",
+        ref="main",
+    )
+
+    assert result["installed"] is True
+    assert len(clone_urls) == 1
+    assert clone_urls[0] == "https://ghproxy.vip/https://github.com/acme/demo"
+
+
+@pytest.mark.asyncio
+async def test_update_community_plugin_uses_git_instead_of_for_proxy(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as cpi
+    from pallas.core.shared.utils import git_mirror as gm
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+
+    monkeypatch.setattr(cpi, "iter_mirrors_for_failover", fake_iter_mirrors)
+    monkeypatch.setattr(cpi, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(cpi, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(cpi, "bot_lifecycle_available", lambda: True)
+
+    dest = tmp_path / cpi.COMMUNITY_PLUGINS_DIR / "demo"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "__init__.py").write_text("# demo\n", encoding="utf-8")
+
+    git_calls: list[tuple[str, ...]] = []
+
+    async def fake_run_git_command(_timeout_s: float, *args: str, cwd: str | None = None):
+        git_calls.append(args)
+        if args[-3:] == ("reset", "--hard", "origin/main"):
+            return 0, "reset ok", ""
+        if args[-3:] == ("fetch", "origin", "main"):
+            return 0, "fetched", ""
+        return 1, "", "fail"
+
+    monkeypatch.setattr(cpi, "run_git_command", fake_run_git_command)
+
+    result = await cpi.update_community_plugin("demo", ref="main")
+
+    assert result["installed"] is True
+    assert any(
+        args[:2] == ("-c", "url.https://ghproxy.vip/https://github.com/.insteadOf=https://github.com/")
+        for args in git_calls
+    )

--- a/tests/common/test_git_mirror.py
+++ b/tests/common/test_git_mirror.py
@@ -1,0 +1,255 @@
+import pytest
+
+from pallas.core.shared.utils.git_mirror import (
+    BUILTIN_MIRRORS,
+    MirrorSpec,
+    rewrite_github_url,
+    validate_custom_proxy_prefix,
+)
+
+
+def test_rewrite_github_clone_with_proxy_prefix():
+    m = MirrorSpec(
+        id="ghproxy-vip",
+        label="ghproxy.vip",
+        type="proxy",
+        clone_prefix="https://ghproxy.vip/https://github.com",
+        raw_prefix="https://ghproxy.vip/https://raw.githubusercontent.com",
+        api_prefix="https://ghproxy.vip/https://api.github.com",
+    )
+    assert (
+        rewrite_github_url("https://github.com/PallasBot/Pallas-Bot.git", m)
+        == "https://ghproxy.vip/https://github.com/PallasBot/Pallas-Bot.git"
+    )
+
+
+def test_rewrite_raw_and_api():
+    m = MirrorSpec(
+        id="ghproxy-vip",
+        label="x",
+        type="proxy",
+        clone_prefix="https://ghproxy.vip/https://github.com",
+        raw_prefix="https://ghproxy.vip/https://raw.githubusercontent.com",
+        api_prefix="https://ghproxy.vip/https://api.github.com",
+    )
+    assert rewrite_github_url("https://raw.githubusercontent.com/a/b/main/README.md", m).startswith(
+        "https://ghproxy.vip/https://raw.githubusercontent.com/"
+    )
+    assert rewrite_github_url("https://api.github.com/repos/a/b/releases/latest", m).startswith(
+        "https://ghproxy.vip/https://api.github.com/"
+    )
+
+
+def test_github_mirror_is_noop():
+    m = next(x for x in BUILTIN_MIRRORS if x.id == "github")
+    u = "https://github.com/a/b"
+    assert rewrite_github_url(u, m) == u
+
+
+def test_reject_private_custom_prefix():
+    import pytest
+
+    with pytest.raises(ValueError, match="私网"):
+        validate_custom_proxy_prefix("https://127.0.0.1/")
+    with pytest.raises(ValueError, match="https"):
+        validate_custom_proxy_prefix("http://example.com/")  # 仅允许 https
+
+
+def test_failover_order_preferred_then_others_then_github(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"ghproxy-vip","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    ids = [m.id for m in gm.iter_mirrors_for_failover()]
+    assert ids[0] == "ghproxy-vip"
+    assert ids[-1] == "github"
+    assert len(ids) == len(set(ids))
+
+
+def test_save_and_load_preferred(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text('{"env":{}}\n', encoding="utf-8")
+    gm.save_git_mirror_config(preferred_id="github", custom_proxy_prefix="")
+    cfg = gm.load_git_mirror_config()
+    assert cfg["preferred_id"] == "github"
+
+
+def test_missing_webui_json_defaults_to_github(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    cfg = gm.load_git_mirror_config()
+    assert cfg["preferred_id"] == "github"
+    assert cfg["custom_proxy_prefix"] == ""
+    assert gm.resolve_preferred_mirror().id == "github"
+
+
+def test_corrupt_webui_json_defaults_to_github(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    path = tmp_path / "webui.json"
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: path)
+    path.write_text("{not json", encoding="utf-8")
+    cfg = gm.load_git_mirror_config()
+    assert cfg["preferred_id"] == "github"
+    assert gm.resolve_preferred_mirror().id == "github"
+
+
+def test_unknown_preferred_id_falls_back_to_github(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"unknown-mirror","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    assert gm.resolve_preferred_mirror().id == "github"
+
+
+def test_custom_empty_prefix_falls_back_to_github(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"custom","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    assert gm.resolve_preferred_mirror().id == "github"
+
+
+def test_custom_invalid_prefix_falls_back_to_github_failover(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"custom","custom_proxy_prefix":"https://127.0.0.1/"}}\n',
+        encoding="utf-8",
+    )
+    assert gm.resolve_preferred_mirror().id == "github"
+    ids = [m.id for m in gm.iter_mirrors_for_failover()]
+    assert ids[0] == "github"
+    assert len(ids) >= 2
+
+
+def test_github_preferred_failover_order(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"github","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    ids = [m.id for m in gm.iter_mirrors_for_failover()]
+    assert ids == ["github", "ghproxy-vip"]
+
+
+def test_git_instead_of_args_github_is_empty():
+    from pallas.core.shared.utils.git_mirror import BUILTIN_MIRRORS, git_instead_of_args
+
+    github = next(m for m in BUILTIN_MIRRORS if m.id == "github")
+    assert git_instead_of_args(github) == []
+
+
+def test_git_instead_of_args_proxy_mirror():
+    from pallas.core.shared.utils.git_mirror import BUILTIN_MIRRORS, git_instead_of_args
+
+    proxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    assert git_instead_of_args(proxy) == [
+        "-c",
+        "url.https://ghproxy.vip/https://github.com/.insteadOf=https://github.com/",
+    ]
+
+
+def test_save_preserves_unrelated_top_level_keys(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    path = tmp_path / "webui.json"
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: path)
+    path.write_text('{"env":{},"other_section":{"keep":true}}\n', encoding="utf-8")
+    gm.save_git_mirror_config(preferred_id="github", custom_proxy_prefix="")
+    data = __import__("json").loads(path.read_text(encoding="utf-8"))
+    assert data["other_section"] == {"keep": True}
+    assert data["git_mirror"]["preferred_id"] == "github"
+
+
+def test_custom_mirror_rewrite_and_failover(monkeypatch, tmp_path):
+    from pallas.core.shared.utils import git_mirror as gm
+
+    prefix = "https://ghproxy.example/"
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text('{"env":{}}\n', encoding="utf-8")
+    gm.save_git_mirror_config(preferred_id="custom", custom_proxy_prefix=prefix)
+
+    preferred = gm.resolve_preferred_mirror()
+    assert preferred.id == "custom"
+    assert preferred.clone_prefix == "https://ghproxy.example/https://github.com"
+    assert preferred.raw_prefix == "https://ghproxy.example/https://raw.githubusercontent.com"
+    assert preferred.api_prefix == "https://ghproxy.example/https://api.github.com"
+
+    ids = [m.id for m in gm.iter_mirrors_for_failover()]
+    assert ids[0] == "custom"
+    assert "github" in ids
+    assert len(ids) == len(set(ids))
+
+    clone_url = "https://github.com/PallasBot/Pallas-Bot.git"
+    assert (
+        gm.rewrite_github_url(clone_url, preferred)
+        == "https://ghproxy.example/https://github.com/PallasBot/Pallas-Bot.git"
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_failover_skips_failing_mirror():
+    from pallas.core.shared.utils import git_mirror as gm
+
+    calls: list[str] = []
+
+    async def fake_get(url: str) -> str:
+        calls.append(url)
+        if "ghproxy.vip" in url:
+            raise RuntimeError("down")
+        return "ok"
+
+    mirrors = [
+        gm.MirrorSpec(
+            id="ghproxy-vip",
+            label="a",
+            type="proxy",
+            clone_prefix="https://ghproxy.vip/https://github.com",
+            raw_prefix="https://ghproxy.vip/https://raw.githubusercontent.com",
+            api_prefix="https://ghproxy.vip/https://api.github.com",
+        ),
+        next(m for m in gm.BUILTIN_MIRRORS if m.id == "github"),
+    ]
+    out = await gm.request_with_mirrors(
+        "https://api.github.com/repos/a/b/releases/latest",
+        mirrors,
+        fake_get,
+    )
+    assert out == "ok"
+    assert any("ghproxy.vip" in c for c in calls)
+    assert any(c.startswith("https://api.github.com/") for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_request_failover_reraises_last_exception():
+    from pallas.core.shared.utils import git_mirror as gm
+
+    async def always_fail(url: str) -> str:
+        raise RuntimeError(f"fail:{url}")
+
+    mirrors = [
+        next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip"),
+        next(m for m in gm.BUILTIN_MIRRORS if m.id == "github"),
+    ]
+    with pytest.raises(RuntimeError, match="fail:https://api.github.com/"):
+        await gm.request_with_mirrors(
+            "https://api.github.com/repos/a/b/releases/latest",
+            mirrors,
+            always_fail,
+        )

--- a/tests/common/test_git_mirror_apply.py
+++ b/tests/common/test_git_mirror_apply.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from pallas.core.shared.utils import git_mirror as gm
+from pallas.core.shared.utils.git_mirror import BUILTIN_MIRRORS
+
+
+def run_git(cwd, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def init_plugin_repo(root, plugin_id: str, remote_url: str) -> None:
+    plugin_dir = root / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text("# plugin\n", encoding="utf-8")
+    assert run_git(plugin_dir, "init").returncode == 0
+    assert run_git(plugin_dir, "remote", "add", "origin", remote_url).returncode == 0
+
+
+def get_origin_url(root, plugin_id: str) -> str:
+    proc = run_git(root / plugin_id, "remote", "get-url", "origin")
+    assert proc.returncode == 0
+    return proc.stdout.strip()
+
+
+@pytest.fixture
+def plugins_root(monkeypatch, tmp_path):
+    root = tmp_path / "local" / "plugins"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("pallas.console.webui.community_plugin_install.community_plugins_root", lambda: root)
+    return root
+
+
+def test_detect_mirror_id_variants():
+    ghproxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    proxied = f"{ghproxy.clone_prefix}/PallasBot/Pallas-Bot.git"
+    assert gm.detect_mirror_id("https://github.com/a/b.git") == "github"
+    assert gm.detect_mirror_id(proxied) == "ghproxy-vip"
+    assert gm.detect_mirror_id("https://proxy.example/https://github.com/a/b.git") == "custom"
+    assert gm.detect_mirror_id("git@github.com:a/b.git") == "ssh"
+    assert gm.detect_mirror_id("https://gitlab.com/a/b.git") == "unknown"
+
+
+def test_canonical_github_https_url_strips_proxy():
+    ghproxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    proxied = f"{ghproxy.clone_prefix}/owner/repo.git"
+    assert gm.canonical_github_https_url(proxied) == "https://github.com/owner/repo.git"
+    assert gm.canonical_github_https_url("git@github.com:owner/repo.git") == "https://github.com/owner/repo.git"
+    assert gm.canonical_github_https_url("https://gitlab.com/a/b.git") is None
+
+
+def test_apply_mirror_to_plugin_sets_proxy_then_github(plugins_root, monkeypatch, tmp_path):
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"ghproxy-vip","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    init_plugin_repo(plugins_root, "demo_plugin", "https://github.com/a/b.git")
+
+    result = gm.apply_mirror_to_plugin("demo_plugin")
+    assert result["success"] is True
+    origin = get_origin_url(plugins_root, "demo_plugin")
+    assert origin.startswith("https://ghproxy.vip/https://github.com/a/b")
+
+    monkeypatch.setattr(
+        gm,
+        "load_git_mirror_config",
+        lambda: {"preferred_id": "github", "custom_proxy_prefix": ""},
+    )
+    result2 = gm.apply_mirror_to_plugin("demo_plugin")
+    assert result2["success"] is True
+    assert get_origin_url(plugins_root, "demo_plugin") == "https://github.com/a/b.git"
+
+
+def test_apply_mirror_to_community_plugins_summary(plugins_root, monkeypatch, tmp_path):
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"ghproxy-vip","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    init_plugin_repo(plugins_root, "one", "https://github.com/a/one.git")
+    init_plugin_repo(plugins_root, "two", "https://github.com/a/two.git")
+    (plugins_root / "not_git").mkdir()
+    (plugins_root / "not_git" / "__init__.py").write_text("", encoding="utf-8")
+
+    payload = gm.apply_mirror_to_community_plugins()
+    summary = payload["summary"]
+    assert summary["total"] == 3
+    assert summary["success_count"] == 2
+    assert summary["fail_count"] == 1
+
+    info = gm.list_community_plugin_git_info()
+    by_id = {row["id"]: row for row in info}
+    assert by_id["one"]["is_git_repo"] is True
+    assert by_id["one"]["mirror"] == "ghproxy-vip"
+    assert by_id["not_git"]["is_git_repo"] is False
+
+
+def test_list_community_plugin_git_info_empty_when_root_missing(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    monkeypatch.setattr("pallas.console.webui.community_plugin_install.community_plugins_root", lambda: missing)
+    assert gm.list_community_plugin_git_info() == []

--- a/tests/common/test_github_release_mirror.py
+++ b/tests/common/test_github_release_mirror.py
@@ -1,0 +1,152 @@
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_release_tries_proxy_before_github(monkeypatch):
+    from pallas.core.shared.utils import git_mirror as gm
+    from pallas.core.shared.utils import github_release as gr
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    github_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "github")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+        yield github_mirror
+
+    monkeypatch.setattr(gr, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        calls.append(url)
+        if "ghproxy.vip" in url:
+            raise httpx.ConnectError("down", request=httpx.Request("GET", url))
+        return httpx.Response(
+            200,
+            json={
+                "tag_name": "v1.0.0",
+                "html_url": "https://github.com/a/b/releases/tag/v1.0.0",
+                "body": "notes",
+                "assets": [],
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    result = await gr.fetch_latest_release("a/b")
+    assert result["tag"] == "v1.0.0"
+    assert result["body"] == "notes"
+    assert any("ghproxy.vip" in u for u in calls)
+    assert any(u.startswith("https://api.github.com/") for u in calls)
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_releases_failover_proxy_then_github(monkeypatch):
+    from pallas.core.shared.utils import git_mirror as gm
+    from pallas.core.shared.utils import github_release as gr
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    github_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "github")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+        yield github_mirror
+
+    monkeypatch.setattr(gr, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        calls.append(url)
+        if "ghproxy.vip" in url:
+            raise httpx.ConnectError("down", request=httpx.Request("GET", url))
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "tag_name": "v2.0.0",
+                    "name": "v2.0.0",
+                    "prerelease": False,
+                    "published_at": "2026-01-01T00:00:00Z",
+                    "assets": [
+                        {
+                            "name": "app.zip",
+                            "browser_download_url": "https://github.com/a/b/releases/download/v2.0.0/app.zip",
+                        }
+                    ],
+                }
+            ],
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    async with httpx.AsyncClient() as client:
+        result = await gr.fetch_github_releases("a/b", client=client)
+
+    assert len(result) == 1
+    assert result[0]["tag"] == "v2.0.0"
+    assert result[0]["assets"][0]["name"] == "app.zip"
+    assert any("ghproxy.vip" in u for u in calls)
+    assert any(u.startswith("https://api.github.com/") for u in calls)
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_releases_all_mirrors_fail_returns_empty(monkeypatch):
+    from pallas.core.shared.utils import git_mirror as gm
+    from pallas.core.shared.utils import github_release as gr
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    github_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "github")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+        yield github_mirror
+
+    monkeypatch.setattr(gr, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    async def fake_get(self, url: str, **kwargs):
+        raise httpx.ConnectError("down", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    async with httpx.AsyncClient() as client:
+        result = await gr.fetch_github_releases("a/b", client=client)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_release_tag_via_github_web_failover(monkeypatch):
+    from pallas.core.shared.utils import git_mirror as gm
+    from pallas.core.shared.utils import github_release as gr
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    github_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "github")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+        yield github_mirror
+
+    monkeypatch.setattr(gr, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    final_url = "https://github.com/a/b/releases/tag/v3.1.0"
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        calls.append(url)
+        if "ghproxy.vip" in url:
+            raise httpx.ConnectError("down", request=httpx.Request("GET", url))
+        return httpx.Response(
+            200,
+            request=httpx.Request("GET", final_url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    result = await gr.fetch_latest_release_tag_via_github_web("a/b")
+    assert result == {"tag": "v3.1.0", "html_url": final_url}
+    assert any("ghproxy.vip" in u for u in calls)
+    assert any(u.startswith("https://github.com/a/b/releases/latest") for u in calls)

--- a/tests/common/test_plugin_store_assets.py
+++ b/tests/common/test_plugin_store_assets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from pallas.console.webui import plugin_store_assets as mod
 
 if TYPE_CHECKING:
@@ -156,3 +158,78 @@ def test_collect_store_asset_targets_uses_author_avatar_for_community(monkeypatc
     community = targets["community"][0]
 
     assert community["assets"]["avatar"] == "https://avatars.githubusercontent.com/acme?s=64"
+
+
+@pytest.mark.asyncio
+async def test_download_binary_uses_mirror_failover(monkeypatch) -> None:
+    import httpx
+
+    from pallas.core.shared.utils import git_mirror as gm
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+
+    monkeypatch.setattr(mod, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        calls.append(url)
+        return httpx.Response(
+            200,
+            content=b"png-bytes",
+            headers={"content-type": "image/png"},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    content, content_type = await mod._download_binary(
+        "https://raw.githubusercontent.com/acme/demo/main/icon.png",
+    )
+
+    assert content == b"png-bytes"
+    assert content_type == "image/png"
+    assert len(calls) == 1
+    assert calls[0].startswith("https://ghproxy.vip/https://raw.githubusercontent.com/")
+
+
+@pytest.mark.asyncio
+async def test_download_text_first_tries_mirrors_before_next_url(monkeypatch) -> None:
+    import httpx
+
+    from pallas.core.shared.utils import git_mirror as gm
+
+    ghproxy_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    github_mirror = next(m for m in gm.BUILTIN_MIRRORS if m.id == "github")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+        yield github_mirror
+
+    monkeypatch.setattr(mod, "iter_mirrors_for_failover", fake_iter_mirrors)
+
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **kwargs):
+        calls.append(url)
+        if "ghproxy.vip" in url:
+            raise httpx.ConnectError("down", request=httpx.Request("GET", url))
+        return httpx.Response(
+            200,
+            text="# Readme\n",
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    text, source_url = await mod._download_text_first([
+        "https://raw.githubusercontent.com/acme/demo/main/README.md",
+    ])
+
+    assert text == "# Readme\n"
+    assert source_url == "https://raw.githubusercontent.com/acme/demo/main/README.md"
+    assert any("ghproxy.vip" in u for u in calls)
+    assert any(u.startswith("https://raw.githubusercontent.com/") for u in calls)

--- a/tests/plugins/pb_webui/test_git_mirror_api.py
+++ b/tests/plugins/pb_webui/test_git_mirror_api.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from packages.pb_webui import extended_api as mod
+from packages.pb_webui.config import Config
+
+
+def _build_client(monkeypatch) -> TestClient:
+    monkeypatch.setattr(mod, "_check_pallas_write_token", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "_require_pallas_token_configured", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "ensure_console_metrics_hooks", lambda: None)
+    app = FastAPI()
+    mod.register_extended_api(app, api_base="/pallas/api", plugin_config=Config())
+    return TestClient(app)
+
+
+def test_git_mirror_info_returns_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pallas.console.webui.git_mirror_api.git_mirror_info_payload",
+        lambda: {
+            "preferred_id": "github",
+            "custom_proxy_prefix": "",
+            "available_mirrors": [{"id": "github", "label": "GitHub 官方", "type": "default"}],
+            "plugins": [],
+        },
+    )
+
+    client = _build_client(monkeypatch)
+    response = client.get("/pallas/api/git-mirror/info")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["data"]["preferred_id"] == "github"
+    assert payload["data"]["plugins"] == []
+
+
+def test_git_mirror_preferred_saves_and_returns_info(monkeypatch, tmp_path) -> None:
+    from pallas.core.shared.utils import git_mirror as gm
+
+    webui_path = tmp_path / "webui.json"
+    webui_path.write_text('{"env":{}}\n', encoding="utf-8")
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: webui_path)
+    monkeypatch.setattr("pallas.core.shared.utils.git_mirror.list_community_plugin_git_info", list)
+
+    client = _build_client(monkeypatch)
+    response = client.put(
+        "/pallas/api/git-mirror/preferred",
+        json={"preferred_id": "ghproxy-vip", "custom_proxy_prefix": ""},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["data"]["preferred_id"] == "ghproxy-vip"
+    assert gm.load_git_mirror_config()["preferred_id"] == "ghproxy-vip"
+
+
+def test_git_mirror_preferred_rejects_invalid_custom_prefix(monkeypatch) -> None:
+    client = _build_client(monkeypatch)
+    response = client.put(
+        "/pallas/api/git-mirror/preferred",
+        json={"preferred_id": "custom", "custom_proxy_prefix": "https://127.0.0.1/"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_git_mirror_apply_community_returns_summary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pallas.console.webui.git_mirror_api.apply_mirror_to_community_plugins",
+        lambda mirror=None: {
+            "results": [{"id": "demo", "success": True, "message": "ok"}],
+            "summary": {"total": 1, "success_count": 1, "fail_count": 0},
+        },
+    )
+
+    client = _build_client(monkeypatch)
+    response = client.post("/pallas/api/git-mirror/apply-community")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["data"]["summary"]["success_count"] == 1
+
+
+def test_git_mirror_apply_plugin_with_preferred_id(monkeypatch) -> None:
+    from pallas.core.shared.utils.git_mirror import BUILTIN_MIRRORS
+
+    captured: dict[str, str] = {}
+
+    def fake_apply(plugin_id: str, mirror=None):
+        captured["plugin_id"] = plugin_id
+        captured["mirror_id"] = mirror.id if mirror is not None else ""
+        return {"id": plugin_id, "success": True, "message": "done", "remote_url": "https://example.test/a/b.git"}
+
+    monkeypatch.setattr("pallas.console.webui.git_mirror_api.apply_mirror_to_plugin", fake_apply)
+    monkeypatch.setattr(
+        "pallas.core.shared.utils.git_mirror.load_git_mirror_config",
+        lambda: {"preferred_id": "github", "custom_proxy_prefix": ""},
+    )
+    ghproxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    monkeypatch.setattr(
+        "pallas.core.shared.utils.git_mirror.mirror_by_id",
+        lambda mirror_id: ghproxy if mirror_id == "ghproxy-vip" else BUILTIN_MIRRORS[0],
+    )
+
+    client = _build_client(monkeypatch)
+    response = client.post(
+        "/pallas/api/git-mirror/apply-plugin/demo_plugin",
+        json={"preferred_id": "ghproxy-vip"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["plugin_id"] == "demo_plugin"
+    assert captured["mirror_id"] == "ghproxy-vip"
+
+
+@pytest.mark.asyncio
+async def test_git_mirror_probe_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pallas.console.webui.git_mirror_api.probe_preferred_mirror",
+        AsyncMock(return_value={"ok": True, "mirror_id": "github"}),
+    )
+
+    client = _build_client(monkeypatch)
+    response = client.post("/pallas/api/git-mirror/probe")
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["data"]["ok"] is True
+    assert payload["data"]["mirror_id"] == "github"

--- a/tests/plugins/pb_webui/test_git_mirror_instead_of.py
+++ b/tests/plugins/pb_webui/test_git_mirror_instead_of.py
@@ -1,0 +1,110 @@
+"""Bot git 更新与 WebUI dist 下载的镜像 insteadOf / URL 改写。"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from packages.pb_webui.manager import (
+    apply_bot_repository_update,
+    build_git_argv_with_mirror,
+    iter_failover_download_urls,
+)
+from pallas.core.shared.utils import git_mirror as gm
+from pallas.core.shared.utils.git_mirror import BUILTIN_MIRRORS, git_instead_of_args
+
+
+def test_git_instead_of_args_proxy_mirror():
+    proxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    assert git_instead_of_args(proxy) == [
+        "-c",
+        "url.https://ghproxy.vip/https://github.com/.insteadOf=https://github.com/",
+    ]
+
+
+def test_build_git_argv_with_mirror_prepends_instead_of():
+    proxy = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+    assert build_git_argv_with_mirror(proxy, "fetch", "origin", "--tags") == [
+        "-c",
+        "url.https://ghproxy.vip/https://github.com/.insteadOf=https://github.com/",
+        "fetch",
+        "origin",
+        "--tags",
+    ]
+
+
+def test_build_git_argv_with_mirror_github_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    github = next(m for m in BUILTIN_MIRRORS if m.id == "github")
+    assert build_git_argv_with_mirror(github, "pull", "--ff-only") == ["pull", "--ff-only"]
+
+
+def test_iter_failover_download_urls_rewrites_release_asset(monkeypatch, tmp_path):
+    monkeypatch.setattr(gm, "repo_webui_settings_path", lambda: tmp_path / "webui.json")
+    (tmp_path / "webui.json").write_text(
+        '{"env":{},"git_mirror":{"preferred_id":"ghproxy-vip","custom_proxy_prefix":""}}\n',
+        encoding="utf-8",
+    )
+    url = "https://github.com/PallasBot/Pallas-Bot-WebUI/releases/download/v1.0.0/dist.zip"
+    urls = list(iter_failover_download_urls(url))
+    assert urls[0] == (
+        "https://ghproxy.vip/https://github.com/PallasBot/Pallas-Bot-WebUI/releases/download/v1.0.0/dist.zip"
+    )
+    assert urls[-1] == url
+    assert len(urls) == len(set(urls))
+
+
+@pytest.mark.asyncio
+async def test_apply_bot_repository_update_fetch_uses_instead_of(monkeypatch, tmp_path):
+    ghproxy_mirror = next(m for m in BUILTIN_MIRRORS if m.id == "ghproxy-vip")
+
+    def fake_iter_mirrors():
+        yield ghproxy_mirror
+
+    monkeypatch.setattr("packages.pb_webui.manager.iter_mirrors_for_failover", fake_iter_mirrors)
+    monkeypatch.setattr("packages.pb_webui.manager._BOT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        "packages.pb_webui.manager.fetch_latest_bot_release",
+        AsyncMock(return_value={"tag": "v9.9.9", "html_url": "", "body": ""}),
+    )
+    monkeypatch.setattr(
+        "packages.pb_webui.manager.get_bot_current_version",
+        lambda: {"tag": "v9.9.9", "commit": "abc1234"},
+    )
+
+    git_invocations: list[list[str]] = []
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        git_invocations.append(list(cmd))
+        proc = MagicMock()
+        if cmd == ("git", "rev-parse", "--is-inside-work-tree"):
+            proc.communicate = AsyncMock(return_value=(b"true\n", b""))
+            proc.returncode = 0
+        elif cmd[-3:] == ("fetch", "origin", "--tags"):
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+        elif cmd[-4:] == ("rev-parse", "-q", "--verify", "v9.9.9^{}"):
+            proc.communicate = AsyncMock(return_value=(b"deadbeef\n", b""))
+            proc.returncode = 0
+        elif cmd[-4:] == ("rev-parse", "-q", "--verify", "refs/tags/v9.9.9"):
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b"unexpected"))
+            proc.returncode = 1
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+        return proc
+
+    monkeypatch.setattr("packages.pb_webui.manager.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = await apply_bot_repository_update()
+
+    assert result["tag"] == "v9.9.9"
+    fetch_calls = [cmd for cmd in git_invocations if "fetch" in cmd and "origin" in cmd]
+    assert len(fetch_calls) == 1
+    assert fetch_calls[0][1:3] == [
+        "-c",
+        "url.https://ghproxy.vip/https://github.com/.insteadOf=https://github.com/",
+    ]


### PR DESCRIPTION
Fixes #236：为控制台提供可配置的 GitHub 镜像源与出站 failover。

## Summary by Sourcery

在控制台中添加可配置的 GitHub 镜像支持，并将基于镜像的故障切换应用到与 GitHub 资源相关的 Git 和 HTTP 交互。

新功能：
- 暴露控制台 API 端点，用于配置首选 Git 镜像，将镜像应用于社区插件，并探测镜像可用性。
- 引入共享的 Git 镜像工具，用于选择镜像、重写 GitHub URL，以及配置用于代理的 `git url.insteadOf`。
- 支持将已配置的镜像应用到现有社区插件的 git 远程，以在 GitHub 与代理源之间切换。

增强项：
- 更新社区插件的安装和更新流程，通过已配置的 GitHub 镜像进行克隆和拉取，并支持故障切换。
- 通过基于镜像的 URL 迭代，使 WebUI 的 dist zip 下载和插件商店资源下载在遇到 GitHub 访问问题时更加健壮。
- 确保机器人仓库更新操作通过 git 配置使用镜像进行 `fetch` 和 `pull`，而不是直接访问 GitHub。
- 对 GitHub 发布元数据和最新标签获取使用支持镜像的 HTTP 请求，以提升在受限网络环境下的可靠性。

测试：
- 添加全面测试，覆盖 Git 镜像 URL 重写、配置持久化、故障切换顺序，以及 `request_with_mirrors` 行为。
- 添加测试，验证在社区插件安装/更新、插件商店资源下载、GitHub 发布 API、机器人仓库更新，以及新的控制台 Git 镜像 API 端点中对镜像的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable GitHub mirror support in the console and apply mirror-aware failover to Git and HTTP interactions with GitHub resources.

New Features:
- Expose console API endpoints to configure preferred Git mirror, apply mirrors to community plugins, and probe mirror availability.
- Introduce shared Git mirror utilities for selecting mirrors, rewriting GitHub URLs, and configuring git url.insteadOf for proxy use.
- Support applying configured mirrors to existing community plugin git remotes to switch between GitHub and proxy origins.

Enhancements:
- Update community plugin install and update flows to clone and fetch via configured GitHub mirrors with failover.
- Make WebUI dist zip downloads and plugin store asset downloads resilient to GitHub access issues via mirror-based URL iteration.
- Ensure bot repository update operations fetch and pull through mirrors using git configuration instead of direct GitHub access.
- Use mirror-aware HTTP requests for GitHub release metadata and latest tag retrieval to improve reliability in constrained networks.

Tests:
- Add comprehensive tests covering Git mirror URL rewriting, configuration persistence, failover ordering, and request_with_mirrors behaviour.
- Add tests validating mirror usage in community plugin install/update, plugin store asset downloads, GitHub release APIs, bot repo updates, and new console Git mirror API endpoints.

</details>