### PR TITLE
fix(ci): docs 分支改为 tip 镜像，避免反复 merge 分叉

### DIFF
--- a/.github/workflows/sync-docs-to-web.yml
+++ b/.github/workflows/sync-docs-to-web.yml
@@ -86,22 +86,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Sync docs branch from main
+      - name: Mirror docs branch to main tip
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main docs
-          git switch -C docs origin/docs
-          if git merge origin/main -X theirs -m "chore(docs): 同步 main 文档变更 (${GITHUB_SHA:0:7})"; then
-            echo "merged main into docs (-X theirs)"
-          else
-            echo "merge conflict; fallback to checkout docs paths from main"
-            git merge --abort
-            git checkout origin/main -- docs/ tools/scripts/sync_docs_to_web.py .github/workflows/sync-docs-to-web.yml
-            if git diff --quiet && git diff --cached --quiet; then
-              echo "docs branch already up to date"
-              exit 0
-            fi
-            git commit -m "chore(docs): 同步 main 文档变更 (${GITHUB_SHA:0:7})"
+          if git rev-parse --verify origin/docs >/dev/null 2>&1 \
+            && [ "$(git rev-parse origin/docs)" = "$(git rev-parse origin/main)" ]; then
+            echo "docs branch already points at main (${GITHUB_SHA:0:7})"
+            exit 0
           fi
-          git push origin HEAD:refs/heads/docs
+          # Keep docs as a tip mirror of main — no merge commits / parallel history.
+          git push --force origin "refs/remotes/origin/main:refs/heads/docs"

--- a/.github/workflows/sync-docs-to-web.yml
+++ b/.github/workflows/sync-docs-to-web.yml
@@ -91,10 +91,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main docs
+          git switch -C main origin/main
+          main_sha="$(git rev-parse --short main)"
           if git rev-parse --verify origin/docs >/dev/null 2>&1 \
-            && [ "$(git rev-parse origin/docs)" = "$(git rev-parse origin/main)" ]; then
-            echo "docs branch already points at main (${GITHUB_SHA:0:7})"
+            && [ "$(git rev-parse origin/docs)" = "$(git rev-parse main)" ]; then
+            echo "docs branch already points at main (${main_sha})"
             exit 0
           fi
           # Keep docs as a tip mirror of main — no merge commits / parallel history.
-          git push --force origin "refs/remotes/origin/main:refs/heads/docs"
+          git push --force origin main:docs


### PR DESCRIPTION
将 `update-docs-branch` 从反复 `merge main → docs` 改为 force tip 镜像 `main`，避免 `origin/docs` 上堆积 merge 分叉。远程 `docs` 已预先重置对齐 `main`。

## 由 Sourcery 提供的摘要

CI：
- 将文档同步任务改为对 docs 分支进行强制推送，使其与当前 main 分支最新提交保持一致，从而避免产生合并提交和分叉的历史记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change the docs synchronization job to force-push the docs branch to match the current main tip, avoiding merge commits and divergent history.

</details>