### PR TITLE
feat(llm): Mongo 兼容会话、群记忆与关系便签

### DIFF
--- a/docs/maintainer/operate/llm-and-ai.md
+++ b/docs/maintainer/operate/llm-and-ai.md
@@ -84,7 +84,7 @@ flowchart TD
 
 | 层级 | 位置 | 用途 |
 |------|------|------|
-| 会话窗口 | Bot `session_store` + AI 回调 | 群内多轮可见历史 |
+| 会话窗口 | Bot `session_store`（PG / Mongo）+ AI 回调 | 群内多轮可见历史 |
 | 超长摘要 | metadata `session_summary` → AI | 窗口外压缩上下文 |
 | 群记忆（teach / auto_episode） | Bot PG `llm_memory_entry` | 「记住：」与启发式旧事；默认 **hybrid** 检索（`LLM_VECTOR_RETRIEVE`） |
 | 关系便签 | Bot PG | 对用户的稳定关系备注 |
@@ -104,7 +104,7 @@ flowchart TD
 
 模型也可通过 tools `memory.search` / `memory.save` 主动检索与写入。控制台：`GET/POST /pallas/api/llm/conversation-kernel/memory`、`GET /pallas/api/llm/knowledge/sources`。
 
-排障：会话「记不住」先查 AI 任务与 callback；群记忆不生效再查 PG、上述开关与 embeddings 连通性。
+排障：会话「记不住」先查 AI 任务与 callback；确认 `LLM_SESSION_ENABLED` 且数据库已初始化（PG 或 Mongo 均可；群记忆仍仅 PG）。群记忆不生效再查上述开关与 embeddings 连通性。
 
 ## callback
 

--- a/docs/maintainer/operate/llm-and-ai.md
+++ b/docs/maintainer/operate/llm-and-ai.md
@@ -86,8 +86,8 @@ flowchart TD
 |------|------|------|
 | 会话窗口 | Bot `session_store`（PG / Mongo）+ AI 回调 | 群内多轮可见历史 |
 | 超长摘要 | metadata `session_summary` → AI | 窗口外压缩上下文 |
-| 群记忆（teach / auto_episode） | Bot PG `llm_memory_entry` | 「记住：」与启发式旧事；默认 **hybrid** 检索（`LLM_VECTOR_RETRIEVE`） |
-| 关系便签 | Bot PG | 对用户的稳定关系备注 |
+| 群记忆（teach / auto_episode） | Bot PG / Mongo `llm_memory_entry` | 「记住：」与启发式旧事；默认 **hybrid** 检索（`LLM_VECTOR_RETRIEVE`；无向量时回落关键词） |
+| 关系便签 | Bot PG / Mongo | 对用户的稳定关系备注 |
 | 知识源 | 插件声明 + `data/pallas_knowledge/` | FAQ / 本地文档块注入 |
 
 ### 群记忆 / RAG 开关
@@ -104,7 +104,7 @@ flowchart TD
 
 模型也可通过 tools `memory.search` / `memory.save` 主动检索与写入。控制台：`GET/POST /pallas/api/llm/conversation-kernel/memory`、`GET /pallas/api/llm/knowledge/sources`。
 
-排障：会话「记不住」先查 AI 任务与 callback；确认 `LLM_SESSION_ENABLED` 且数据库已初始化（PG 或 Mongo 均可；群记忆仍仅 PG）。群记忆不生效再查上述开关与 embeddings 连通性。
+排障：会话「记不住」先查 AI 任务与 callback；确认 `LLM_SESSION_ENABLED` 且数据库已初始化（PG 或 Mongo）。群记忆 / 关系便签同需对应开关与存储就绪；向量检索不可用时回落关键词。
 
 ## callback
 

--- a/pallas/core/foundation/db/__init__.py
+++ b/pallas/core/foundation/db/__init__.py
@@ -13,6 +13,8 @@ from .modules import (
     GroupConfigModule,
     ImageCache,
     LlmChatMessage,
+    LlmMemoryEntry,
+    LlmRelationshipNote,
     Message,
     PallasACL,
     SchemaMigration,
@@ -269,6 +271,8 @@ async def init_mongodb_db() -> None:
             AdminMember,
             PallasACL,
             LlmChatMessage,
+            LlmMemoryEntry,
+            LlmRelationshipNote,
         ],
     )
     _mongodb_initialized = True

--- a/pallas/core/foundation/db/__init__.py
+++ b/pallas/core/foundation/db/__init__.py
@@ -12,6 +12,7 @@ from .modules import (
     Context,
     GroupConfigModule,
     ImageCache,
+    LlmChatMessage,
     Message,
     PallasACL,
     SchemaMigration,
@@ -267,6 +268,7 @@ async def init_mongodb_db() -> None:
             SchemaMigration,
             AdminMember,
             PallasACL,
+            LlmChatMessage,
         ],
     )
     _mongodb_initialized = True

--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -278,6 +278,62 @@ class LlmChatMessage(Document):
         ]
 
 
+class LlmMemoryEntry(Document):
+    entry_id: int = Field(...)
+    bot_id: int = Field(...)
+    group_id: int = Field(default=0)
+    keywords: str = Field(default="")
+    content: str = Field(...)
+    source: str = Field(default="teach")
+    embedding_json: str | None = Field(default=None)
+    embedding_model: str | None = Field(default=None)
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    updated_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "llm_memory_entry"
+        collection = "llm_memory_entry"
+        indexes = [
+            IndexModel([("entry_id", pymongo.ASCENDING)], name="entry_id_unique", unique=True),
+            IndexModel(
+                [
+                    ("bot_id", pymongo.ASCENDING),
+                    ("group_id", pymongo.ASCENDING),
+                    ("updated_at", pymongo.ASCENDING),
+                ],
+                name="bot_group_time",
+            ),
+        ]
+
+
+class LlmRelationshipNote(Document):
+    note_id: int = Field(...)
+    bot_id: int = Field(...)
+    group_id: int = Field(default=0)
+    user_id: int = Field(...)
+    content: str = Field(...)
+    source: str = Field(default="teach")
+    weight: float = Field(default=1.0)
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+    updated_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "llm_relationship_note"
+        collection = "llm_relationship_note"
+        indexes = [
+            IndexModel([("note_id", pymongo.ASCENDING)], name="note_id_unique", unique=True),
+            IndexModel(
+                [
+                    ("bot_id", pymongo.ASCENDING),
+                    ("group_id", pymongo.ASCENDING),
+                    ("user_id", pymongo.ASCENDING),
+                ],
+                name="scope_unique",
+                unique=True,
+            ),
+        ]
+
+
 __all__ = [
     "SingProgress",
     "BotConfigModule",
@@ -294,4 +350,6 @@ __all__ = [
     "PallasACL",
     "ImageCache",
     "LlmChatMessage",
+    "LlmMemoryEntry",
+    "LlmRelationshipNote",
 ]

--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -246,6 +246,38 @@ class ImageCache(BaseImageCache):
         indexes = [IndexModel([("cq_code", pymongo.HASHED)], name="cq_code_index")]
 
 
+class LlmChatMessage(Document):
+    bot_id: int = Field(...)
+    group_id: int = Field(default=0)
+    user_id: int = Field(...)
+    role: str = Field(...)
+    content: str = Field(...)
+    created_at: int = Field(default_factory=lambda: int(time.time()))
+
+    class Settings:
+        name = "llm_chat_message"
+        collection = "llm_chat_message"
+        indexes = [
+            IndexModel(
+                [
+                    ("bot_id", pymongo.ASCENDING),
+                    ("group_id", pymongo.ASCENDING),
+                    ("created_at", pymongo.ASCENDING),
+                ],
+                name="bot_group_time",
+            ),
+            IndexModel(
+                [
+                    ("bot_id", pymongo.ASCENDING),
+                    ("group_id", pymongo.ASCENDING),
+                    ("user_id", pymongo.ASCENDING),
+                    ("created_at", pymongo.ASCENDING),
+                ],
+                name="bot_group_user_time",
+            ),
+        ]
+
+
 __all__ = [
     "SingProgress",
     "BotConfigModule",
@@ -261,4 +293,5 @@ __all__ = [
     "AdminMember",
     "PallasACL",
     "ImageCache",
+    "LlmChatMessage",
 ]

--- a/pallas/product/llm/memory/relationship_store.py
+++ b/pallas/product/llm/memory/relationship_store.py
@@ -11,10 +11,10 @@ import time
 
 from sqlalchemy import delete, select
 
-from pallas.core.foundation.db.repository_pg import LlmRelationshipNoteRow, get_session, is_pg_initialized
-from pallas.core.foundation.db.runtime import is_postgresql_backend
+from pallas.core.foundation.db.repository_pg import LlmRelationshipNoteRow, get_session
 from pallas.product.llm.config import LlmConfig, get_llm_config
 from pallas.product.llm.memory.relationship import normalize_relationship_note
+from pallas.product.llm.session_backend import llm_product_storage_ready
 from pallas.product.llm.session_store import normalize_group_scope
 from pallas.product.persona.prompt_guard import sanitize_prompt_literal
 
@@ -23,7 +23,19 @@ _DAY_SEC = 86400.0
 
 def is_relationship_store_available() -> bool:
     cfg = get_llm_config()
-    return cfg.llm_relationship_notes_enabled and is_postgresql_backend() and is_pg_initialized()
+    return cfg.llm_relationship_notes_enabled and llm_product_storage_ready()
+
+
+def _use_mongodb_backend() -> bool:
+    from pallas.core.foundation.db.runtime import is_mongodb_backend
+
+    return is_mongodb_backend()
+
+
+def _use_postgresql_backend() -> bool:
+    from pallas.core.foundation.db.runtime import is_postgresql_backend
+
+    return is_postgresql_backend()
 
 
 def decayed_weight(weight: float, updated_at: int, *, half_life_days: float, now: int | None = None) -> float:
@@ -44,6 +56,12 @@ async def save_relationship_note(
     cfg: LlmConfig | None = None,
 ) -> bool:
     if not is_relationship_store_available() or not user_id:
+        return False
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.relationship_store_mongo import save_relationship_note_mongo
+
+        return await save_relationship_note_mongo(bot_id, group_id, user_id, content, source=source, cfg=cfg)
+    if not _use_postgresql_backend():
         return False
     c = cfg or get_llm_config()
     safe_content = normalize_relationship_note(content, max_len=c.llm_relationship_content_max_len)
@@ -94,6 +112,12 @@ async def retrieve_relationship_note(
     """取当前对象的关系备注；权重衰减到阈值以下则视为过期，返回 None。"""
     if not is_relationship_store_available() or not user_id:
         return None
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.relationship_store_mongo import retrieve_relationship_note_mongo
+
+        return await retrieve_relationship_note_mongo(bot_id, group_id, user_id, cfg=cfg)
+    if not _use_postgresql_backend():
+        return None
     c = cfg or get_llm_config()
     scope_gid = normalize_group_scope(group_id)
     now = int(time.time())
@@ -124,6 +148,12 @@ async def retrieve_relationship_note(
 async def trim_relationship_notes(bot_id: int, group_id: int | None, *, cfg: LlmConfig | None = None) -> int:
     """惰性裁剪：删除衰减到阈值以下的过期关系备注，返回删除条数。"""
     if not is_relationship_store_available():
+        return 0
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.relationship_store_mongo import trim_relationship_notes_mongo
+
+        return await trim_relationship_notes_mongo(bot_id, group_id, cfg=cfg)
+    if not _use_postgresql_backend():
         return 0
     c = cfg or get_llm_config()
     scope_gid = normalize_group_scope(group_id)
@@ -165,6 +195,12 @@ async def list_relationship_notes(
     limit: int = 50,
 ) -> list[dict[str, object]]:
     if not is_relationship_store_available():
+        return []
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.relationship_store_mongo import list_relationship_notes_mongo
+
+        return await list_relationship_notes_mongo(bot_id, group_id, query=query, limit=limit)
+    if not _use_postgresql_backend():
         return []
     max_limit = max(1, min(int(limit), 200))
     async with get_session(read_only=True) as session:
@@ -208,6 +244,12 @@ async def list_relationship_notes(
 
 async def delete_relationship_note(note_id: int, *, bot_id: int | None = None) -> bool:
     if not is_relationship_store_available():
+        return False
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.relationship_store_mongo import delete_relationship_note_mongo
+
+        return await delete_relationship_note_mongo(note_id, bot_id=bot_id)
+    if not _use_postgresql_backend():
         return False
     async with get_session() as session:
         row = (

--- a/pallas/product/llm/memory/relationship_store_mongo.py
+++ b/pallas/product/llm/memory/relationship_store_mongo.py
@@ -3,20 +3,29 @@ from __future__ import annotations
 import time
 
 from beanie import SortDirection
+from nonebot import logger
+from pymongo.errors import DuplicateKeyError
 
 from pallas.core.foundation.db.modules import LlmRelationshipNote
 from pallas.product.llm.config import LlmConfig, get_llm_config
 from pallas.product.llm.memory.relationship import normalize_relationship_note
 from pallas.product.llm.memory.relationship_store import decayed_weight
+from pallas.product.llm.mongo_id import allocate_mongo_int_id
 from pallas.product.llm.session_models import normalize_group_scope
 from pallas.product.persona.prompt_guard import sanitize_prompt_literal
 
+_RELATIONSHIP_ID_INSERT_RETRIES = 8
 
-async def next_relationship_note_id() -> int:
+
+async def _peek_max_relationship_note_id() -> int:
     rows = await LlmRelationshipNote.find_all().sort([("note_id", SortDirection.DESCENDING)]).limit(1).to_list()
     if not rows:
-        return 1
-    return int(rows[0].note_id) + 1
+        return 0
+    return int(rows[0].note_id or 0)
+
+
+async def next_relationship_note_id() -> int:
+    return await allocate_mongo_int_id("llm_relationship_note", peek_max=_peek_max_relationship_note_id)
 
 
 async def save_relationship_note_mongo(
@@ -49,17 +58,24 @@ async def save_relationship_note_mongo(
         existing.updated_at = now
         await existing.save()
     else:
-        await LlmRelationshipNote(
-            note_id=await next_relationship_note_id(),
-            bot_id=int(bot_id),
-            group_id=scope_gid,
-            user_id=int(user_id),
-            content=safe_content,
-            source=safe_source,
-            weight=1.0,
-            created_at=now,
-            updated_at=now,
-        ).insert()
+        for _ in range(_RELATIONSHIP_ID_INSERT_RETRIES):
+            try:
+                await LlmRelationshipNote(
+                    note_id=await next_relationship_note_id(),
+                    bot_id=int(bot_id),
+                    group_id=scope_gid,
+                    user_id=int(user_id),
+                    content=safe_content,
+                    source=safe_source,
+                    weight=1.0,
+                    created_at=now,
+                    updated_at=now,
+                ).insert()
+                return True
+            except DuplicateKeyError:
+                continue
+        logger.warning("llm relationship note insert failed after duplicate note_id retries")
+        return False
     return True
 
 

--- a/pallas/product/llm/memory/relationship_store_mongo.py
+++ b/pallas/product/llm/memory/relationship_store_mongo.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import time
+
+from beanie import SortDirection
+
+from pallas.core.foundation.db.modules import LlmRelationshipNote
+from pallas.product.llm.config import LlmConfig, get_llm_config
+from pallas.product.llm.memory.relationship import normalize_relationship_note
+from pallas.product.llm.memory.relationship_store import decayed_weight
+from pallas.product.llm.session_models import normalize_group_scope
+from pallas.product.persona.prompt_guard import sanitize_prompt_literal
+
+
+async def next_relationship_note_id() -> int:
+    rows = await LlmRelationshipNote.find_all().sort([("note_id", SortDirection.DESCENDING)]).limit(1).to_list()
+    if not rows:
+        return 1
+    return int(rows[0].note_id) + 1
+
+
+async def save_relationship_note_mongo(
+    bot_id: int,
+    group_id: int | None,
+    user_id: int,
+    content: str,
+    *,
+    source: str = "teach",
+    cfg: LlmConfig | None = None,
+) -> bool:
+    if not user_id:
+        return False
+    c = cfg or get_llm_config()
+    safe_content = normalize_relationship_note(content, max_len=c.llm_relationship_content_max_len)
+    if not safe_content:
+        return False
+    scope_gid = normalize_group_scope(group_id)
+    now = int(time.time())
+    safe_source = sanitize_prompt_literal(source, max_len=16) or "teach"
+    existing = await LlmRelationshipNote.find_one({
+        "bot_id": int(bot_id),
+        "group_id": scope_gid,
+        "user_id": int(user_id),
+    })
+    if existing is not None:
+        existing.content = safe_content
+        existing.source = safe_source
+        existing.weight = 1.0
+        existing.updated_at = now
+        await existing.save()
+    else:
+        await LlmRelationshipNote(
+            note_id=await next_relationship_note_id(),
+            bot_id=int(bot_id),
+            group_id=scope_gid,
+            user_id=int(user_id),
+            content=safe_content,
+            source=safe_source,
+            weight=1.0,
+            created_at=now,
+            updated_at=now,
+        ).insert()
+    return True
+
+
+async def retrieve_relationship_note_mongo(
+    bot_id: int,
+    group_id: int | None,
+    user_id: int,
+    *,
+    cfg: LlmConfig | None = None,
+) -> str | None:
+    if not user_id:
+        return None
+    c = cfg or get_llm_config()
+    scope_gid = normalize_group_scope(group_id)
+    now = int(time.time())
+    row = await LlmRelationshipNote.find_one({
+        "bot_id": int(bot_id),
+        "group_id": scope_gid,
+        "user_id": int(user_id),
+    })
+    if row is None:
+        return None
+    weight = decayed_weight(
+        float(row.weight or 0.0),
+        int(row.updated_at or 0),
+        half_life_days=c.llm_relationship_half_life_days,
+        now=now,
+    )
+    if weight < c.llm_relationship_min_weight:
+        return None
+    content = str(row.content or "").strip()
+    return content or None
+
+
+async def trim_relationship_notes_mongo(
+    bot_id: int,
+    group_id: int | None,
+    *,
+    cfg: LlmConfig | None = None,
+) -> int:
+    c = cfg or get_llm_config()
+    scope_gid = normalize_group_scope(group_id)
+    now = int(time.time())
+    rows = await LlmRelationshipNote.find({
+        "bot_id": int(bot_id),
+        "group_id": scope_gid,
+    }).to_list()
+    deleted = 0
+    for row in rows:
+        weight = decayed_weight(
+            float(row.weight or 0.0),
+            int(row.updated_at or 0),
+            half_life_days=c.llm_relationship_half_life_days,
+            now=now,
+        )
+        if weight < c.llm_relationship_min_weight:
+            await row.delete()
+            deleted += 1
+    return deleted
+
+
+async def list_relationship_notes_mongo(
+    bot_id: int,
+    group_id: int | None,
+    *,
+    query: str = "",
+    limit: int = 50,
+) -> list[dict[str, object]]:
+    max_limit = max(1, min(int(limit), 200))
+    filt: dict = {"bot_id": int(bot_id)}
+    if group_id is not None:
+        filt["group_id"] = normalize_group_scope(group_id)
+    rows = (
+        await LlmRelationshipNote
+        .find(filt)
+        .sort([("updated_at", SortDirection.DESCENDING), ("note_id", SortDirection.DESCENDING)])
+        .limit(max_limit * 4)
+        .to_list()
+    )
+    needle = str(query or "").strip().casefold()
+    items: list[dict[str, object]] = []
+    for row in rows:
+        content = str(row.content or "").strip()
+        source = str(row.source or "").strip() or "teach"
+        if needle and needle not in content.casefold() and needle not in source.casefold():
+            continue
+        items.append({
+            "id": int(row.note_id),
+            "bot_id": int(row.bot_id),
+            "group_id": int(row.group_id),
+            "user_id": int(row.user_id),
+            "content": content,
+            "source": source,
+            "weight": float(row.weight or 0.0),
+            "created_at": int(row.created_at or 0),
+            "updated_at": int(row.updated_at or 0),
+        })
+        if len(items) >= max_limit:
+            break
+    return items
+
+
+async def delete_relationship_note_mongo(note_id: int, *, bot_id: int | None = None) -> bool:
+    row = await LlmRelationshipNote.find_one({"note_id": int(note_id)})
+    if row is None:
+        return False
+    if bot_id is not None and int(row.bot_id or 0) != int(bot_id):
+        return False
+    await row.delete()
+    return True

--- a/pallas/product/llm/memory/store.py
+++ b/pallas/product/llm/memory/store.py
@@ -1,4 +1,4 @@
-"""群梗/教导记忆：PG 存储与检索。"""
+"""群梗/教导记忆：PG / Mongo 存储与检索。"""
 
 from __future__ import annotations
 
@@ -8,17 +8,29 @@ from typing import Any
 from nonebot import logger
 from sqlalchemy import delete, func, select
 
-from pallas.core.foundation.db.repository_pg import LlmMemoryEntryRow, get_session, is_pg_initialized
-from pallas.core.foundation.db.runtime import is_postgresql_backend
+from pallas.core.foundation.db.repository_pg import LlmMemoryEntryRow, get_session
 from pallas.product.llm.config import LlmConfig, get_llm_config
 from pallas.product.llm.memory.policy import classify_memory_candidate, normalize_episode_note
+from pallas.product.llm.session_backend import llm_product_storage_ready
 from pallas.product.llm.session_store import normalize_group_scope
 from pallas.product.persona.prompt_guard import sanitize_prompt_block, sanitize_prompt_literal
 
 
 def is_llm_memory_store_available() -> bool:
     cfg = get_llm_config()
-    return cfg.llm_memory_rag_enabled and is_postgresql_backend() and is_pg_initialized()
+    return cfg.llm_memory_rag_enabled and llm_product_storage_ready()
+
+
+def _use_mongodb_backend() -> bool:
+    from pallas.core.foundation.db.runtime import is_mongodb_backend
+
+    return is_mongodb_backend()
+
+
+def _use_postgresql_backend() -> bool:
+    from pallas.core.foundation.db.runtime import is_postgresql_backend
+
+    return is_postgresql_backend()
 
 
 def derive_memory_keywords(content: str, *, max_len: int = 120) -> str:
@@ -102,6 +114,12 @@ async def save_memory_entry(
     cfg: LlmConfig | None = None,
 ) -> bool:
     if not is_llm_memory_store_available():
+        return False
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.store_mongo import save_memory_entry_mongo
+
+        return await save_memory_entry_mongo(bot_id, group_id, content, source=source, cfg=cfg)
+    if not _use_postgresql_backend():
         return False
     c = cfg or get_llm_config()
     safe_content = sanitize_prompt_block(content, max_len=c.llm_memory_content_max_len)
@@ -237,6 +255,12 @@ async def retrieve_memory_hits(
 ) -> list[dict[str, Any]]:
     if not is_llm_memory_store_available():
         return []
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.store_mongo import retrieve_memory_hits_mongo
+
+        return await retrieve_memory_hits_mongo(bot_id, group_id, query_text, cfg=cfg)
+    if not _use_postgresql_backend():
+        return []
     c = cfg or get_llm_config()
     scope_gid = normalize_group_scope(group_id)
     top_k = max(1, min(int(c.llm_memory_rag_top_k), 8))
@@ -311,6 +335,12 @@ async def list_memory_entries(
 ) -> list[dict[str, Any]]:
     if not is_llm_memory_store_available():
         return []
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.store_mongo import list_memory_entries_mongo
+
+        return await list_memory_entries_mongo(bot_id, group_id, query=query, limit=limit)
+    if not _use_postgresql_backend():
+        return []
     max_limit = max(1, min(int(limit), 200))
     async with get_session(read_only=True) as session:
         stmt = select(LlmMemoryEntryRow).where(LlmMemoryEntryRow.bot_id == int(bot_id))
@@ -350,6 +380,12 @@ async def list_memory_entries(
 
 async def delete_memory_entry(entry_id: int, *, bot_id: int | None = None) -> bool:
     if not is_llm_memory_store_available():
+        return False
+    if _use_mongodb_backend():
+        from pallas.product.llm.memory.store_mongo import delete_memory_entry_mongo
+
+        return await delete_memory_entry_mongo(entry_id, bot_id=bot_id)
+    if not _use_postgresql_backend():
         return False
     async with get_session() as session:
         row = (

--- a/pallas/product/llm/memory/store_mongo.py
+++ b/pallas/product/llm/memory/store_mongo.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from beanie import SortDirection
 from nonebot import logger
+from pymongo.errors import DuplicateKeyError
 
 from pallas.core.foundation.db.modules import LlmMemoryEntry
 from pallas.product.llm.config import LlmConfig, get_llm_config
@@ -14,15 +15,22 @@ from pallas.product.llm.memory.store import (
     derive_memory_keywords,
     memory_entries_semantically_match,
 )
+from pallas.product.llm.mongo_id import allocate_mongo_int_id
 from pallas.product.llm.session_models import normalize_group_scope
 from pallas.product.persona.prompt_guard import sanitize_prompt_block, sanitize_prompt_literal
 
+_MEMORY_ID_INSERT_RETRIES = 8
 
-async def next_memory_entry_id() -> int:
+
+async def _peek_max_memory_entry_id() -> int:
     rows = await LlmMemoryEntry.find_all().sort([("entry_id", SortDirection.DESCENDING)]).limit(1).to_list()
     if not rows:
-        return 1
-    return int(rows[0].entry_id) + 1
+        return 0
+    return int(rows[0].entry_id or 0)
+
+
+async def next_memory_entry_id() -> int:
+    return await allocate_mongo_int_id("llm_memory_entry", peek_max=_peek_max_memory_entry_id)
 
 
 async def find_reusable_memory_entry_mongo(
@@ -133,18 +141,28 @@ async def save_memory_entry_mongo(
             existing.embedding_model = embedding_model
         await existing.save()
     else:
-        await LlmMemoryEntry(
-            entry_id=await next_memory_entry_id(),
-            bot_id=int(bot_id),
-            group_id=scope_gid,
-            keywords=keywords,
-            content=safe_content,
-            source=safe_source,
-            embedding_json=embedding_json,
-            embedding_model=embedding_model,
-            created_at=now,
-            updated_at=now,
-        ).insert()
+        inserted = False
+        for _ in range(_MEMORY_ID_INSERT_RETRIES):
+            try:
+                await LlmMemoryEntry(
+                    entry_id=await next_memory_entry_id(),
+                    bot_id=int(bot_id),
+                    group_id=scope_gid,
+                    keywords=keywords,
+                    content=safe_content,
+                    source=safe_source,
+                    embedding_json=embedding_json,
+                    embedding_model=embedding_model,
+                    created_at=now,
+                    updated_at=now,
+                ).insert()
+                inserted = True
+                break
+            except DuplicateKeyError:
+                continue
+        if not inserted:
+            logger.warning("llm memory insert failed after duplicate entry_id retries")
+            return False
     await trim_group_memory_entries_mongo(
         bot_id=int(bot_id),
         group_id=scope_gid,

--- a/pallas/product/llm/memory/store_mongo.py
+++ b/pallas/product/llm/memory/store_mongo.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from beanie import SortDirection
+from nonebot import logger
+
+from pallas.core.foundation.db.modules import LlmMemoryEntry
+from pallas.product.llm.config import LlmConfig, get_llm_config
+from pallas.product.llm.memory.policy import classify_memory_candidate, normalize_episode_note
+from pallas.product.llm.memory.store import (
+    canonicalize_memory_content,
+    derive_memory_keywords,
+    memory_entries_semantically_match,
+)
+from pallas.product.llm.session_models import normalize_group_scope
+from pallas.product.persona.prompt_guard import sanitize_prompt_block, sanitize_prompt_literal
+
+
+async def next_memory_entry_id() -> int:
+    rows = await LlmMemoryEntry.find_all().sort([("entry_id", SortDirection.DESCENDING)]).limit(1).to_list()
+    if not rows:
+        return 1
+    return int(rows[0].entry_id) + 1
+
+
+async def find_reusable_memory_entry_mongo(
+    *,
+    bot_id: int,
+    group_id: int,
+    safe_content: str,
+    keywords: str,
+) -> LlmMemoryEntry | None:
+    exact = await LlmMemoryEntry.find_one({
+        "bot_id": bot_id,
+        "group_id": group_id,
+        "content": safe_content,
+    })
+    if exact is not None:
+        return exact
+
+    rows = (
+        await LlmMemoryEntry
+        .find({"bot_id": bot_id, "group_id": group_id})
+        .sort([("updated_at", SortDirection.DESCENDING), ("entry_id", SortDirection.DESCENDING)])
+        .limit(32)
+        .to_list()
+    )
+    for row in rows:
+        if memory_entries_semantically_match(str(row.content or ""), safe_content):
+            return row
+        row_keywords = str(row.keywords or "")
+        row_content = canonicalize_memory_content(str(row.content or ""))
+        if keywords and row_keywords and row_keywords == keywords and row_content:
+            return row
+    return None
+
+
+async def trim_group_memory_entries_mongo(
+    *,
+    bot_id: int,
+    group_id: int,
+    max_entries: int,
+) -> None:
+    if max_entries <= 0:
+        return
+    query = {"bot_id": bot_id, "group_id": group_id}
+    count = await LlmMemoryEntry.find(query).count()
+    overflow = int(count) - max_entries
+    if overflow <= 0:
+        return
+    stale = (
+        await LlmMemoryEntry
+        .find(query)
+        .sort([("updated_at", SortDirection.ASCENDING), ("entry_id", SortDirection.ASCENDING)])
+        .limit(overflow)
+        .to_list()
+    )
+    for row in stale:
+        await row.delete()
+
+
+async def save_memory_entry_mongo(
+    bot_id: int,
+    group_id: int | None,
+    content: str,
+    *,
+    source: str = "teach",
+    cfg: LlmConfig | None = None,
+) -> bool:
+    c = cfg or get_llm_config()
+    safe_content = sanitize_prompt_block(content, max_len=c.llm_memory_content_max_len)
+    normalized_source = (source or "").strip()
+    if normalized_source in ("teach", "auto_episode", ""):
+        kind = classify_memory_candidate(safe_content)
+        if normalized_source in ("teach", ""):
+            normalized_source = kind or "teach"
+        safe_content = normalize_episode_note(safe_content, max_len=c.llm_memory_content_max_len)
+        if normalized_source == "auto_episode" and not kind:
+            return False
+    if not safe_content:
+        return False
+    scope_gid = normalize_group_scope(group_id)
+    now = int(time.time())
+    keywords = derive_memory_keywords(safe_content)
+    embedding_json: str | None = None
+    embedding_model: str | None = None
+    if c.llm_vector_retrieve != "keyword":
+        from pallas.product.llm.knowledge.embedding_client import embedding_model_name, fetch_embeddings_sync
+        from pallas.product.llm.memory.retrieve import dump_embedding_json, memory_embedding_text
+
+        text = memory_embedding_text(keywords=keywords, content=safe_content)
+        vectors = fetch_embeddings_sync([text]) if text.strip() else None
+        if vectors and len(vectors) == 1:
+            embedding_json = dump_embedding_json(vectors[0])
+            embedding_model = embedding_model_name(c)
+
+    safe_source = sanitize_prompt_literal(normalized_source, max_len=16) or "teach"
+    existing = await find_reusable_memory_entry_mongo(
+        bot_id=int(bot_id),
+        group_id=scope_gid,
+        safe_content=safe_content,
+        keywords=keywords,
+    )
+    if existing is not None:
+        existing.keywords = keywords
+        existing.content = safe_content
+        existing.source = safe_source
+        existing.updated_at = now
+        if embedding_json is not None:
+            existing.embedding_json = embedding_json
+            existing.embedding_model = embedding_model
+        await existing.save()
+    else:
+        await LlmMemoryEntry(
+            entry_id=await next_memory_entry_id(),
+            bot_id=int(bot_id),
+            group_id=scope_gid,
+            keywords=keywords,
+            content=safe_content,
+            source=safe_source,
+            embedding_json=embedding_json,
+            embedding_model=embedding_model,
+            created_at=now,
+            updated_at=now,
+        ).insert()
+    await trim_group_memory_entries_mongo(
+        bot_id=int(bot_id),
+        group_id=scope_gid,
+        max_entries=c.llm_memory_max_per_group,
+    )
+    return True
+
+
+async def retrieve_memory_hits_mongo(
+    bot_id: int,
+    group_id: int | None,
+    query_text: str,
+    *,
+    cfg: LlmConfig | None = None,
+) -> list[dict[str, Any]]:
+    c = cfg or get_llm_config()
+    scope_gid = normalize_group_scope(group_id)
+    top_k = max(1, min(int(c.llm_memory_rag_top_k), 8))
+    rows = (
+        await LlmMemoryEntry
+        .find({
+            "bot_id": int(bot_id),
+            "group_id": {"$in": [scope_gid, 0]},
+        })
+        .sort([("updated_at", SortDirection.DESCENDING), ("entry_id", SortDirection.DESCENDING)])
+        .limit(max(50, top_k * 10))
+        .to_list()
+    )
+    from pallas.product.llm.knowledge.embedding_client import embedding_model_name
+    from pallas.product.llm.memory.retrieve import dump_embedding_json, rank_memory_candidates
+
+    candidates = [
+        {
+            "id": int(row.entry_id),
+            "content": str(row.content or "").strip(),
+            "keywords": str(row.keywords or "").strip(),
+            "source": str(row.source or "").strip() or "memory",
+            "group_id": int(row.group_id or 0),
+            "embedding_json": row.embedding_json,
+            "embedding_model": row.embedding_model,
+        }
+        for row in rows
+    ]
+    scored = rank_memory_candidates(
+        query_text,
+        candidates,
+        embedding_model=embedding_model_name(c),
+    )
+    dirty = [item for item in scored if item.get("embedding_dirty") and item.get("id") and item.get("embedding")]
+    if dirty:
+        try:
+            for item in dirty:
+                row = await LlmMemoryEntry.find_one({"entry_id": int(item["id"])})
+                if row is None:
+                    continue
+                row.embedding_json = dump_embedding_json(list(item["embedding"]))
+                row.embedding_model = str(item.get("embedding_model") or embedding_model_name(c))
+                await row.save()
+        except Exception as exc:
+            logger.warning("memory embedding cache persist failed err={}", exc)
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for item in scored:
+        content = str(item.get("content") or "").strip()
+        if not content or content in seen:
+            continue
+        seen.add(content)
+        out.append(item)
+        if len(out) >= min(top_k, 3):
+            break
+    return out
+
+
+async def list_memory_entries_mongo(
+    bot_id: int,
+    group_id: int | None,
+    *,
+    query: str = "",
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    max_limit = max(1, min(int(limit), 200))
+    filt: dict[str, Any] = {"bot_id": int(bot_id)}
+    if group_id is not None:
+        filt["group_id"] = normalize_group_scope(group_id)
+    rows = (
+        await LlmMemoryEntry
+        .find(filt)
+        .sort([("updated_at", SortDirection.DESCENDING), ("entry_id", SortDirection.DESCENDING)])
+        .limit(max_limit * 4)
+        .to_list()
+    )
+    needle = str(query or "").strip().casefold()
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        content = str(row.content or "").strip()
+        keywords = str(row.keywords or "").strip()
+        if needle and needle not in content.casefold() and needle not in keywords.casefold():
+            continue
+        items.append({
+            "id": int(row.entry_id),
+            "bot_id": int(row.bot_id),
+            "group_id": int(row.group_id),
+            "keywords": keywords,
+            "content": content,
+            "source": str(row.source or "").strip() or "teach",
+            "created_at": int(row.created_at or 0),
+            "updated_at": int(row.updated_at or 0),
+        })
+        if len(items) >= max_limit:
+            break
+    return items
+
+
+async def delete_memory_entry_mongo(entry_id: int, *, bot_id: int | None = None) -> bool:
+    row = await LlmMemoryEntry.find_one({"entry_id": int(entry_id)})
+    if row is None:
+        return False
+    if bot_id is not None and int(row.bot_id or 0) != int(bot_id):
+        return False
+    await row.delete()
+    return True

--- a/pallas/product/llm/mongo_id.py
+++ b/pallas/product/llm/mongo_id.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pymongo import ReturnDocument
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+async def allocate_mongo_int_id(
+    counter_name: str,
+    *,
+    peek_max: Callable[[], Awaitable[int]],
+) -> int:
+    """原子分配单调递增 int ID（计数器集合 + 与现有 max 对齐）。
+
+    用 ``llm_id_counter`` 文档 ``$inc``，插入前 ``$max`` 对齐业务表当前最大值，
+    避免空库从 1 起步撞上已有数据，也避免并发 max+1 竞态。
+    """
+    from pallas.core.foundation.db.modules import LlmChatMessage
+
+    db = LlmChatMessage.get_pymongo_collection().database
+    coll = db["llm_id_counter"]
+    current_max = max(0, int(await peek_max()))
+    await coll.update_one({"_id": counter_name}, {"$max": {"seq": current_max}}, upsert=True)
+    doc = await coll.find_one_and_update(
+        {"_id": counter_name},
+        {"$inc": {"seq": 1}},
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    if not doc or doc.get("seq") is None:
+        raise RuntimeError(f"mongo id counter unavailable: {counter_name}")
+    return int(doc["seq"])

--- a/pallas/product/llm/session_backend.py
+++ b/pallas/product/llm/session_backend.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from pallas.product.llm.session_models import LlmChatRole, LlmChatTurn, LlmHistorySessionSummary
+
+
+class LlmSessionMessageBackend(Protocol):
+    async def append_message(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        role: LlmChatRole,
+        content: str,
+        *,
+        ttl_sec: int,
+        window: int,
+    ) -> bool: ...
+
+    async def list_user_messages(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]: ...
+
+    async def list_group_ambient(
+        self,
+        bot_id: int,
+        group_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]: ...
+
+    async def list_history_sessions(
+        self,
+        *,
+        bot_id: int | None,
+        group_id: int | None,
+        user_id: int | None,
+        limit: int,
+    ) -> list[LlmHistorySessionSummary]: ...
+
+    async def clear_group(self, bot_id: int, group_id: int) -> int: ...
+
+    async def clear_user(self, bot_id: int, group_id: int, user_id: int) -> int: ...
+
+    async def compact_user_with_summary(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        summary_content: str,
+        *,
+        keep_messages: int,
+    ) -> bool: ...
+
+
+def resolve_session_backend() -> LlmSessionMessageBackend:
+    from pallas.core.foundation.db.runtime import is_mongodb_backend, is_postgresql_backend
+
+    if is_postgresql_backend():
+        from pallas.product.llm.session_store_pg import PgLlmSessionMessageBackend
+
+        return PgLlmSessionMessageBackend()
+    if is_mongodb_backend():
+        from pallas.product.llm.session_store_mongo import MongoLlmSessionMessageBackend
+
+        return MongoLlmSessionMessageBackend()
+    raise RuntimeError("no llm session backend for current db_backend")
+
+
+def session_store_backend_ready() -> bool:
+    from pallas.core.foundation.db import runtime_storage_ready
+    from pallas.core.foundation.db.repository_pg import is_pg_initialized
+    from pallas.core.foundation.db.runtime import is_mongodb_backend, is_postgresql_backend
+
+    if is_postgresql_backend():
+        return is_pg_initialized()
+    if is_mongodb_backend():
+        return runtime_storage_ready("mongodb")
+    return False

--- a/pallas/product/llm/session_backend.py
+++ b/pallas/product/llm/session_backend.py
@@ -77,6 +77,7 @@ def resolve_session_backend() -> LlmSessionMessageBackend:
 
 
 def session_store_backend_ready() -> bool:
+    """当前 db_backend 的持久化存储是否已就绪（PG 或 Mongo）。"""
     from pallas.core.foundation.db import runtime_storage_ready
     from pallas.core.foundation.db.repository_pg import is_pg_initialized
     from pallas.core.foundation.db.runtime import is_mongodb_backend, is_postgresql_backend
@@ -86,3 +87,7 @@ def session_store_backend_ready() -> bool:
     if is_mongodb_backend():
         return runtime_storage_ready("mongodb")
     return False
+
+
+# 记忆 / 关系便签等产品侧存储共用同一就绪判断。
+llm_product_storage_ready = session_store_backend_ready

--- a/pallas/product/llm/session_backend.py
+++ b/pallas/product/llm/session_backend.py
@@ -62,18 +62,34 @@ class LlmSessionMessageBackend(Protocol):
     ) -> bool: ...
 
 
-def resolve_session_backend() -> LlmSessionMessageBackend:
-    from pallas.core.foundation.db.runtime import is_mongodb_backend, is_postgresql_backend
+_session_backend_cache: dict[str, LlmSessionMessageBackend] = {}
 
-    if is_postgresql_backend():
+
+def clear_session_backend_cache() -> None:
+    """测试或热切换 db_backend 时清空进程内缓存。"""
+    _session_backend_cache.clear()
+
+
+def resolve_session_backend() -> LlmSessionMessageBackend:
+    from pallas.core.foundation.db.runtime import get_db_backend, is_mongodb_backend, is_postgresql_backend
+
+    backend_name = get_db_backend()
+    cached = _session_backend_cache.get(backend_name)
+    if cached is not None:
+        return cached
+
+    if is_postgresql_backend(backend_name):
         from pallas.product.llm.session_store_pg import PgLlmSessionMessageBackend
 
-        return PgLlmSessionMessageBackend()
-    if is_mongodb_backend():
+        instance: LlmSessionMessageBackend = PgLlmSessionMessageBackend()
+    elif is_mongodb_backend(backend_name):
         from pallas.product.llm.session_store_mongo import MongoLlmSessionMessageBackend
 
-        return MongoLlmSessionMessageBackend()
-    raise RuntimeError("no llm session backend for current db_backend")
+        instance = MongoLlmSessionMessageBackend()
+    else:
+        raise RuntimeError("no llm session backend for current db_backend")
+    _session_backend_cache[backend_name] = instance
+    return instance
 
 
 def session_store_backend_ready() -> bool:

--- a/pallas/product/llm/session_models.py
+++ b/pallas/product/llm/session_models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+LlmChatRole = Literal["user", "assistant"]
+ALLOWED_ROLES = frozenset({"user", "assistant"})
+
+
+class LlmChatTurn(BaseModel):
+    role: LlmChatRole
+    content: str
+    user_id: int
+    created_at: int
+
+
+class LlmSessionScope(BaseModel):
+    bot_id: int
+    group_id: int = 0
+    user_id: int | None = None
+
+
+class LlmHistorySessionSummary(BaseModel):
+    session_key: str
+    bot_id: int
+    group_id: int
+    user_id: int
+    turn_count: int
+    first_created_at: int
+    last_created_at: int
+    last_role: LlmChatRole
+    last_content: str
+
+
+class LlmHistorySessionDetail(BaseModel):
+    session: LlmHistorySessionSummary
+    turns: list[LlmChatTurn]
+    behavior_runs: list[dict[str, Any]] = Field(default_factory=list)
+    feedback_entries: list[dict[str, Any]] = Field(default_factory=list)
+
+
+def normalize_group_scope(group_id: int | None) -> int:
+    return int(group_id) if group_id is not None else 0
+
+
+def is_private_scope(group_id: int | None) -> bool:
+    return normalize_group_scope(group_id) == 0

--- a/pallas/product/llm/session_store.py
+++ b/pallas/product/llm/session_store.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Literal
+from typing import Any
 
-from pydantic import BaseModel, Field
-from sqlalchemy import delete, func, select
-
-from pallas.core.foundation.db.repository_pg import LlmChatMessageRow, get_session, is_pg_initialized
-from pallas.core.foundation.db.runtime import is_postgresql_backend
 from pallas.product.llm.behavior import infer_behavior_feedback
 from pallas.product.llm.behavior_store import (
     behavior_run_public_dict,
@@ -19,55 +14,26 @@ from pallas.product.llm.config import LlmConfig, get_llm_config
 from pallas.product.llm.kernel.memory_governance import can_read_runtime_state
 from pallas.product.llm.message_guard import format_user_turn
 from pallas.product.llm.models import ChatCompletionMessage
+from pallas.product.llm.session_backend import resolve_session_backend, session_store_backend_ready
+from pallas.product.llm.session_models import (
+    ALLOWED_ROLES,
+    LlmChatRole,
+    LlmChatTurn,
+    LlmHistorySessionDetail,
+    LlmHistorySessionSummary,
+    LlmSessionScope,
+    is_private_scope,
+    normalize_group_scope,
+)
 from pallas.product.persona.prompt_guard import normalize_enum, sanitize_prompt_block, sanitize_prompt_literal
 
-LlmChatRole = Literal["user", "assistant"]
-_ALLOWED_ROLES = frozenset({"user", "assistant"})
-
-
-class LlmChatTurn(BaseModel):
-    role: LlmChatRole
-    content: str
-    user_id: int
-    created_at: int
-
-
-class LlmSessionScope(BaseModel):
-    bot_id: int
-    group_id: int = 0
-    user_id: int | None = None
-
-
-class LlmHistorySessionSummary(BaseModel):
-    session_key: str
-    bot_id: int
-    group_id: int
-    user_id: int
-    turn_count: int
-    first_created_at: int
-    last_created_at: int
-    last_role: LlmChatRole
-    last_content: str
-
-
-class LlmHistorySessionDetail(BaseModel):
-    session: LlmHistorySessionSummary
-    turns: list[LlmChatTurn]
-    behavior_runs: list[dict[str, Any]] = Field(default_factory=list)
-    feedback_entries: list[dict[str, Any]] = Field(default_factory=list)
-
-
-def normalize_group_scope(group_id: int | None) -> int:
-    return int(group_id) if group_id is not None else 0
-
-
-def is_private_scope(group_id: int | None) -> bool:
-    return normalize_group_scope(group_id) == 0
+# Backward-compatible alias used by older imports/tests.
+_ALLOWED_ROLES = ALLOWED_ROLES
 
 
 def is_llm_session_store_available() -> bool:
     cfg = get_llm_config()
-    return cfg.llm_session_enabled and is_postgresql_backend() and is_pg_initialized()
+    return cfg.llm_session_enabled and session_store_backend_ready()
 
 
 def user_ttl_seconds(group_id: int | None, cfg: LlmConfig | None = None) -> int:
@@ -86,7 +52,7 @@ def session_scope(bot_id: int, group_id: int | None, user_id: int | None = None)
 
 
 def sanitize_stored_content(role: str, content: str, *, max_len: int) -> str:
-    role_key = normalize_enum(role, _ALLOWED_ROLES, "user")
+    role_key = normalize_enum(role, ALLOWED_ROLES, "user")
     raw = content
     if role_key == "user":
         cfg = get_llm_config()
@@ -99,92 +65,6 @@ def sanitize_stored_content(role: str, content: str, *, max_len: int) -> str:
     return sanitize_prompt_block(raw, max_len=max_len)
 
 
-async def purge_user_ttl(
-    session,
-    *,
-    bot_id: int,
-    group_id: int,
-    user_id: int,
-    ttl_sec: int,
-    now: int,
-) -> None:
-    if ttl_sec <= 0:
-        return
-    cutoff = now - ttl_sec
-    await session.execute(
-        delete(LlmChatMessageRow).where(
-            LlmChatMessageRow.bot_id == bot_id,
-            LlmChatMessageRow.group_id == group_id,
-            LlmChatMessageRow.user_id == user_id,
-            LlmChatMessageRow.created_at < cutoff,
-        )
-    )
-
-
-async def purge_group_ttl(
-    session,
-    *,
-    bot_id: int,
-    group_id: int,
-    ttl_sec: int,
-    now: int,
-) -> None:
-    if ttl_sec <= 0 or group_id == 0:
-        return
-    cutoff = now - ttl_sec
-    await session.execute(
-        delete(LlmChatMessageRow).where(
-            LlmChatMessageRow.bot_id == bot_id,
-            LlmChatMessageRow.group_id == group_id,
-            LlmChatMessageRow.created_at < cutoff,
-        )
-    )
-
-
-async def trim_user_window(
-    session,
-    *,
-    bot_id: int,
-    group_id: int,
-    user_id: int,
-    window: int,
-) -> None:
-    if window <= 0:
-        return
-    count = (
-        await session.execute(
-            select(func.count())
-            .select_from(LlmChatMessageRow)
-            .where(
-                LlmChatMessageRow.bot_id == bot_id,
-                LlmChatMessageRow.group_id == group_id,
-                LlmChatMessageRow.user_id == user_id,
-            )
-        )
-    ).scalar_one()
-    overflow = int(count) - window
-    if overflow <= 0:
-        return
-    stale_ids = (
-        (
-            await session.execute(
-                select(LlmChatMessageRow.id)
-                .where(
-                    LlmChatMessageRow.bot_id == bot_id,
-                    LlmChatMessageRow.group_id == group_id,
-                    LlmChatMessageRow.user_id == user_id,
-                )
-                .order_by(LlmChatMessageRow.created_at.asc(), LlmChatMessageRow.id.asc())
-                .limit(overflow)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    if stale_ids:
-        await session.execute(delete(LlmChatMessageRow).where(LlmChatMessageRow.id.in_(stale_ids)))
-
-
 async def append_llm_message(
     bot_id: int,
     group_id: int | None,
@@ -195,51 +75,22 @@ async def append_llm_message(
     if not is_llm_session_store_available():
         return False
     cfg = get_llm_config()
-    role_key = normalize_enum(role, _ALLOWED_ROLES, "user")
+    role_key = normalize_enum(role, ALLOWED_ROLES, "user")
     safe_content = sanitize_stored_content(role_key, content, max_len=cfg.llm_session_max_content_len)
     if not safe_content:
         return False
 
     scope_gid = normalize_group_scope(group_id)
-    now = int(time.time())
     ttl = user_ttl_seconds(scope_gid, cfg)
-    async with get_session() as session:
-        session.add(
-            LlmChatMessageRow(
-                bot_id=int(bot_id),
-                group_id=scope_gid,
-                user_id=int(user_id),
-                role=role_key,
-                content=safe_content,
-                created_at=now,
-            )
-        )
-        await session.flush()
-        await purge_user_ttl(
-            session,
-            bot_id=int(bot_id),
-            group_id=scope_gid,
-            user_id=int(user_id),
-            ttl_sec=ttl,
-            now=now,
-        )
-        await trim_user_window(
-            session,
-            bot_id=int(bot_id),
-            group_id=scope_gid,
-            user_id=int(user_id),
-            window=cfg.llm_session_user_window,
-        )
-        if scope_gid != 0:
-            await purge_group_ttl(
-                session,
-                bot_id=int(bot_id),
-                group_id=scope_gid,
-                ttl_sec=user_ttl_seconds(scope_gid, cfg),
-                now=now,
-            )
-        await session.commit()
-    return True
+    return await resolve_session_backend().append_message(
+        int(bot_id),
+        scope_gid,
+        int(user_id),
+        role_key,  # type: ignore[arg-type]
+        safe_content,
+        ttl_sec=ttl,
+        window=cfg.llm_session_user_window,
+    )
 
 
 async def list_user_llm_messages(
@@ -257,33 +108,13 @@ async def list_user_llm_messages(
     max_items = limit if limit is not None else c.llm_session_user_window
     max_items = max(1, min(max_items, c.llm_session_user_window))
     ttl = user_ttl_seconds(scope_gid, c)
-
-    stmt = (
-        select(LlmChatMessageRow)
-        .where(
-            LlmChatMessageRow.bot_id == int(bot_id),
-            LlmChatMessageRow.group_id == scope_gid,
-            LlmChatMessageRow.user_id == int(user_id),
-        )
-        .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
-        .limit(max_items)
+    return await resolve_session_backend().list_user_messages(
+        int(bot_id),
+        scope_gid,
+        int(user_id),
+        limit=max_items,
+        ttl_sec=ttl,
     )
-    if ttl > 0:
-        cutoff = int(time.time()) - ttl
-        stmt = stmt.where(LlmChatMessageRow.created_at >= cutoff)
-
-    async with get_session(read_only=True) as session:
-        rows = (await session.execute(stmt)).scalars().all()
-
-    return [
-        LlmChatTurn(
-            role=row.role if row.role in _ALLOWED_ROLES else "user",
-            content=row.content,
-            user_id=int(row.user_id),
-            created_at=int(row.created_at),
-        )
-        for row in reversed(rows)
-    ]
 
 
 async def list_group_ambient_messages(
@@ -304,32 +135,12 @@ async def list_group_ambient_messages(
     max_items = limit if limit is not None else c.llm_session_group_window
     max_items = max(1, min(max_items, c.llm_session_group_window))
     ttl = user_ttl_seconds(scope_gid, c)
-
-    stmt = (
-        select(LlmChatMessageRow)
-        .where(
-            LlmChatMessageRow.bot_id == int(bot_id),
-            LlmChatMessageRow.group_id == scope_gid,
-        )
-        .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
-        .limit(max_items)
+    return await resolve_session_backend().list_group_ambient(
+        int(bot_id),
+        scope_gid,
+        limit=max_items,
+        ttl_sec=ttl,
     )
-    if ttl > 0:
-        cutoff = int(time.time()) - ttl
-        stmt = stmt.where(LlmChatMessageRow.created_at >= cutoff)
-
-    async with get_session(read_only=True) as session:
-        rows = (await session.execute(stmt)).scalars().all()
-
-    return [
-        LlmChatTurn(
-            role=row.role if row.role in _ALLOWED_ROLES else "user",
-            content=row.content,
-            user_id=int(row.user_id),
-            created_at=int(row.created_at),
-        )
-        for row in reversed(rows)
-    ]
 
 
 async def list_llm_messages(
@@ -355,64 +166,12 @@ async def list_llm_history_sessions(
         return []
 
     max_items = max(1, min(int(limit), 200))
-    stmt = (
-        select(
-            LlmChatMessageRow.bot_id,
-            LlmChatMessageRow.group_id,
-            LlmChatMessageRow.user_id,
-            func.count().label("turn_count"),
-            func.min(LlmChatMessageRow.created_at).label("first_created_at"),
-            func.max(LlmChatMessageRow.created_at).label("last_created_at"),
-        )
-        .group_by(
-            LlmChatMessageRow.bot_id,
-            LlmChatMessageRow.group_id,
-            LlmChatMessageRow.user_id,
-        )
-        .order_by(func.max(LlmChatMessageRow.created_at).desc())
-        .limit(max_items)
+    return await resolve_session_backend().list_history_sessions(
+        bot_id=int(bot_id) if bot_id is not None else None,
+        group_id=normalize_group_scope(group_id) if group_id is not None else None,
+        user_id=int(user_id) if user_id is not None else None,
+        limit=max_items,
     )
-
-    if bot_id is not None:
-        stmt = stmt.where(LlmChatMessageRow.bot_id == int(bot_id))
-    if group_id is not None:
-        stmt = stmt.where(LlmChatMessageRow.group_id == normalize_group_scope(group_id))
-    if user_id is not None:
-        stmt = stmt.where(LlmChatMessageRow.user_id == int(user_id))
-
-    async with get_session(read_only=True) as session:
-        rows = (await session.execute(stmt)).all()
-
-        out: list[LlmHistorySessionSummary] = []
-        for row in rows:
-            latest_stmt = (
-                select(LlmChatMessageRow)
-                .where(
-                    LlmChatMessageRow.bot_id == int(row.bot_id),
-                    LlmChatMessageRow.group_id == int(row.group_id),
-                    LlmChatMessageRow.user_id == int(row.user_id),
-                )
-                .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
-                .limit(1)
-            )
-            latest = (await session.execute(latest_stmt)).scalars().first()
-            if latest is None:
-                continue
-            role = latest.role if latest.role in _ALLOWED_ROLES else "user"
-            out.append(
-                LlmHistorySessionSummary(
-                    session_key=f"{int(row.bot_id)}:{int(row.group_id)}:{int(row.user_id)}",
-                    bot_id=int(row.bot_id),
-                    group_id=int(row.group_id),
-                    user_id=int(row.user_id),
-                    turn_count=int(row.turn_count or 0),
-                    first_created_at=int(row.first_created_at or 0),
-                    last_created_at=int(row.last_created_at or 0),
-                    last_role=role,
-                    last_content=str(latest.content or ""),
-                )
-            )
-    return out
 
 
 async def get_llm_history_session_detail(
@@ -581,52 +340,14 @@ async def clear_llm_messages(bot_id: int, group_id: int | None) -> int:
     if not is_llm_session_store_available():
         return 0
     scope_gid = normalize_group_scope(group_id)
-    async with get_session() as session:
-        count = (
-            await session.execute(
-                select(func.count())
-                .select_from(LlmChatMessageRow)
-                .where(
-                    LlmChatMessageRow.bot_id == int(bot_id),
-                    LlmChatMessageRow.group_id == scope_gid,
-                )
-            )
-        ).scalar_one()
-        await session.execute(
-            delete(LlmChatMessageRow).where(
-                LlmChatMessageRow.bot_id == int(bot_id),
-                LlmChatMessageRow.group_id == scope_gid,
-            )
-        )
-        await session.commit()
-    return int(count)
+    return await resolve_session_backend().clear_group(int(bot_id), scope_gid)
 
 
 async def clear_user_llm_messages(bot_id: int, group_id: int | None, user_id: int) -> int:
     if not is_llm_session_store_available():
         return 0
     scope_gid = normalize_group_scope(group_id)
-    async with get_session() as session:
-        count = (
-            await session.execute(
-                select(func.count())
-                .select_from(LlmChatMessageRow)
-                .where(
-                    LlmChatMessageRow.bot_id == int(bot_id),
-                    LlmChatMessageRow.group_id == scope_gid,
-                    LlmChatMessageRow.user_id == int(user_id),
-                )
-            )
-        ).scalar_one()
-        await session.execute(
-            delete(LlmChatMessageRow).where(
-                LlmChatMessageRow.bot_id == int(bot_id),
-                LlmChatMessageRow.group_id == scope_gid,
-                LlmChatMessageRow.user_id == int(user_id),
-            )
-        )
-        await session.commit()
-    return int(count)
+    return await resolve_session_backend().clear_user(int(bot_id), scope_gid, int(user_id))
 
 
 async def compact_user_llm_history_with_summary(
@@ -644,46 +365,18 @@ async def compact_user_llm_history_with_summary(
     safe_summary = sanitize_prompt_block(summary, max_len=c.llm_session_max_content_len)
     if not safe_summary:
         return False
-    keep = max(2, int(keep_messages))
     scope_gid = normalize_group_scope(group_id)
-    now = int(time.time())
-    async with get_session() as session:
-        rows = (
-            (
-                await session.execute(
-                    select(LlmChatMessageRow)
-                    .where(
-                        LlmChatMessageRow.bot_id == int(bot_id),
-                        LlmChatMessageRow.group_id == scope_gid,
-                        LlmChatMessageRow.user_id == int(user_id),
-                    )
-                    .order_by(LlmChatMessageRow.created_at.asc(), LlmChatMessageRow.id.asc())
-                )
-            )
-            .scalars()
-            .all()
-        )
-        if len(rows) <= keep:
-            return False
-        keep_rows = rows[-keep:]
-        keep_ids = {row.id for row in keep_rows}
-        stale_ids = [row.id for row in rows if row.id not in keep_ids]
-        if stale_ids:
-            await session.execute(delete(LlmChatMessageRow).where(LlmChatMessageRow.id.in_(stale_ids)))
-        anchor_time = int(keep_rows[0].created_at) - 1 if keep_rows else now - 1
-        session.add(
-            LlmChatMessageRow(
-                bot_id=int(bot_id),
-                group_id=scope_gid,
-                user_id=int(user_id),
-                role="user",
-                content=sanitize_stored_content(
-                    "user",
-                    f"【此前对话摘要】\n{safe_summary}",
-                    max_len=c.llm_session_max_content_len,
-                ),
-                created_at=anchor_time,
-            )
-        )
-        await session.commit()
-    return True
+    summary_content = sanitize_stored_content(
+        "user",
+        f"【此前对话摘要】\n{safe_summary}",
+        max_len=c.llm_session_max_content_len,
+    )
+    if not summary_content:
+        return False
+    return await resolve_session_backend().compact_user_with_summary(
+        int(bot_id),
+        scope_gid,
+        int(user_id),
+        summary_content,
+        keep_messages=keep_messages,
+    )

--- a/pallas/product/llm/session_store_mongo.py
+++ b/pallas/product/llm/session_store_mongo.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import time
+
+from beanie import SortDirection
+
+from pallas.core.foundation.db.modules import LlmChatMessage
+from pallas.product.llm.session_models import ALLOWED_ROLES, LlmChatRole, LlmChatTurn, LlmHistorySessionSummary
+
+
+class MongoLlmSessionMessageBackend:
+    async def append_message(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        role: LlmChatRole,
+        content: str,
+        *,
+        ttl_sec: int,
+        window: int,
+    ) -> bool:
+        now = int(time.time())
+        doc = LlmChatMessage(
+            bot_id=int(bot_id),
+            group_id=int(group_id),
+            user_id=int(user_id),
+            role=role,
+            content=content,
+            created_at=now,
+        )
+        await doc.insert()
+        await self._purge_user_ttl(
+            bot_id=int(bot_id),
+            group_id=int(group_id),
+            user_id=int(user_id),
+            ttl_sec=ttl_sec,
+            now=now,
+        )
+        await self._trim_user_window(
+            bot_id=int(bot_id),
+            group_id=int(group_id),
+            user_id=int(user_id),
+            window=window,
+        )
+        if group_id != 0:
+            await self._purge_group_ttl(
+                bot_id=int(bot_id),
+                group_id=int(group_id),
+                ttl_sec=ttl_sec,
+                now=now,
+            )
+        return True
+
+    async def list_user_messages(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]:
+        query = {
+            "bot_id": int(bot_id),
+            "group_id": int(group_id),
+            "user_id": int(user_id),
+        }
+        if ttl_sec > 0:
+            query["created_at"] = {"$gte": int(time.time()) - ttl_sec}
+        rows = (
+            await LlmChatMessage
+            .find(query)
+            .sort(
+                [("created_at", SortDirection.DESCENDING), ("_id", SortDirection.DESCENDING)],
+            )
+            .limit(limit)
+            .to_list()
+        )
+        return [
+            LlmChatTurn(
+                role=row.role if row.role in ALLOWED_ROLES else "user",
+                content=row.content,
+                user_id=int(row.user_id),
+                created_at=int(row.created_at),
+            )
+            for row in reversed(rows)
+        ]
+
+    async def list_group_ambient(
+        self,
+        bot_id: int,
+        group_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]:
+        query: dict = {
+            "bot_id": int(bot_id),
+            "group_id": int(group_id),
+        }
+        if ttl_sec > 0:
+            query["created_at"] = {"$gte": int(time.time()) - ttl_sec}
+        rows = (
+            await LlmChatMessage
+            .find(query)
+            .sort(
+                [("created_at", SortDirection.DESCENDING), ("_id", SortDirection.DESCENDING)],
+            )
+            .limit(limit)
+            .to_list()
+        )
+        return [
+            LlmChatTurn(
+                role=row.role if row.role in ALLOWED_ROLES else "user",
+                content=row.content,
+                user_id=int(row.user_id),
+                created_at=int(row.created_at),
+            )
+            for row in reversed(rows)
+        ]
+
+    async def list_history_sessions(
+        self,
+        *,
+        bot_id: int | None,
+        group_id: int | None,
+        user_id: int | None,
+        limit: int,
+    ) -> list[LlmHistorySessionSummary]:
+        match: dict = {}
+        if bot_id is not None:
+            match["bot_id"] = int(bot_id)
+        if group_id is not None:
+            match["group_id"] = int(group_id)
+        if user_id is not None:
+            match["user_id"] = int(user_id)
+
+        pipeline: list[dict] = []
+        if match:
+            pipeline.append({"$match": match})
+        pipeline.extend([
+            {
+                "$group": {
+                    "_id": {
+                        "bot_id": "$bot_id",
+                        "group_id": "$group_id",
+                        "user_id": "$user_id",
+                    },
+                    "turn_count": {"$sum": 1},
+                    "first_created_at": {"$min": "$created_at"},
+                    "last_created_at": {"$max": "$created_at"},
+                }
+            },
+            {"$sort": {"last_created_at": -1}},
+            {"$limit": int(limit)},
+        ])
+        coll = LlmChatMessage.get_pymongo_collection()
+        rows = await coll.aggregate(pipeline).to_list(length=limit)
+
+        out: list[LlmHistorySessionSummary] = []
+        for row in rows:
+            key = row.get("_id") or {}
+            bid = int(key.get("bot_id") or 0)
+            gid = int(key.get("group_id") or 0)
+            uid = int(key.get("user_id") or 0)
+            latest = (
+                await LlmChatMessage
+                .find({
+                    "bot_id": bid,
+                    "group_id": gid,
+                    "user_id": uid,
+                })
+                .sort(
+                    [("created_at", SortDirection.DESCENDING), ("_id", SortDirection.DESCENDING)],
+                )
+                .limit(1)
+                .to_list()
+            )
+            if not latest:
+                continue
+            item = latest[0]
+            role = item.role if item.role in ALLOWED_ROLES else "user"
+            out.append(
+                LlmHistorySessionSummary(
+                    session_key=f"{bid}:{gid}:{uid}",
+                    bot_id=bid,
+                    group_id=gid,
+                    user_id=uid,
+                    turn_count=int(row.get("turn_count") or 0),
+                    first_created_at=int(row.get("first_created_at") or 0),
+                    last_created_at=int(row.get("last_created_at") or 0),
+                    last_role=role,
+                    last_content=str(item.content or ""),
+                )
+            )
+        return out
+
+    async def clear_group(self, bot_id: int, group_id: int) -> int:
+        query = {"bot_id": int(bot_id), "group_id": int(group_id)}
+        count = await LlmChatMessage.find(query).count()
+        await LlmChatMessage.find(query).delete()
+        return int(count)
+
+    async def clear_user(self, bot_id: int, group_id: int, user_id: int) -> int:
+        query = {
+            "bot_id": int(bot_id),
+            "group_id": int(group_id),
+            "user_id": int(user_id),
+        }
+        count = await LlmChatMessage.find(query).count()
+        await LlmChatMessage.find(query).delete()
+        return int(count)
+
+    async def compact_user_with_summary(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        summary_content: str,
+        *,
+        keep_messages: int,
+    ) -> bool:
+        keep = max(2, int(keep_messages))
+        now = int(time.time())
+        query = {
+            "bot_id": int(bot_id),
+            "group_id": int(group_id),
+            "user_id": int(user_id),
+        }
+        rows = (
+            await LlmChatMessage
+            .find(query)
+            .sort(
+                [("created_at", SortDirection.ASCENDING), ("_id", SortDirection.ASCENDING)],
+            )
+            .to_list()
+        )
+        if len(rows) <= keep:
+            return False
+        keep_rows = rows[-keep:]
+        keep_ids = {row.id for row in keep_rows}
+        stale = [row for row in rows if row.id not in keep_ids]
+        for row in stale:
+            await row.delete()
+        anchor_time = int(keep_rows[0].created_at) - 1 if keep_rows else now - 1
+        await LlmChatMessage(
+            bot_id=int(bot_id),
+            group_id=int(group_id),
+            user_id=int(user_id),
+            role="user",
+            content=summary_content,
+            created_at=anchor_time,
+        ).insert()
+        return True
+
+    async def _purge_user_ttl(
+        self,
+        *,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        ttl_sec: int,
+        now: int,
+    ) -> None:
+        if ttl_sec <= 0:
+            return
+        await LlmChatMessage.find({
+            "bot_id": bot_id,
+            "group_id": group_id,
+            "user_id": user_id,
+            "created_at": {"$lt": now - ttl_sec},
+        }).delete()
+
+    async def _purge_group_ttl(
+        self,
+        *,
+        bot_id: int,
+        group_id: int,
+        ttl_sec: int,
+        now: int,
+    ) -> None:
+        if ttl_sec <= 0 or group_id == 0:
+            return
+        await LlmChatMessage.find({
+            "bot_id": bot_id,
+            "group_id": group_id,
+            "created_at": {"$lt": now - ttl_sec},
+        }).delete()
+
+    async def _trim_user_window(
+        self,
+        *,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        window: int,
+    ) -> None:
+        if window <= 0:
+            return
+        query = {
+            "bot_id": bot_id,
+            "group_id": group_id,
+            "user_id": user_id,
+        }
+        count = await LlmChatMessage.find(query).count()
+        overflow = int(count) - window
+        if overflow <= 0:
+            return
+        stale = (
+            await LlmChatMessage
+            .find(query)
+            .sort(
+                [("created_at", SortDirection.ASCENDING), ("_id", SortDirection.ASCENDING)],
+            )
+            .limit(overflow)
+            .to_list()
+        )
+        for row in stale:
+            await row.delete()

--- a/pallas/product/llm/session_store_pg.py
+++ b/pallas/product/llm/session_store_pg.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import delete, func, select
+
+from pallas.core.foundation.db.repository_pg import LlmChatMessageRow, get_session
+from pallas.product.llm.session_models import ALLOWED_ROLES, LlmChatRole, LlmChatTurn, LlmHistorySessionSummary
+
+
+class PgLlmSessionMessageBackend:
+    async def append_message(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        role: LlmChatRole,
+        content: str,
+        *,
+        ttl_sec: int,
+        window: int,
+    ) -> bool:
+        now = int(time.time())
+        async with get_session() as session:
+            session.add(
+                LlmChatMessageRow(
+                    bot_id=int(bot_id),
+                    group_id=int(group_id),
+                    user_id=int(user_id),
+                    role=role,
+                    content=content,
+                    created_at=now,
+                )
+            )
+            await session.flush()
+            await self._purge_user_ttl(
+                session,
+                bot_id=int(bot_id),
+                group_id=int(group_id),
+                user_id=int(user_id),
+                ttl_sec=ttl_sec,
+                now=now,
+            )
+            await self._trim_user_window(
+                session,
+                bot_id=int(bot_id),
+                group_id=int(group_id),
+                user_id=int(user_id),
+                window=window,
+            )
+            if group_id != 0:
+                await self._purge_group_ttl(
+                    session,
+                    bot_id=int(bot_id),
+                    group_id=int(group_id),
+                    ttl_sec=ttl_sec,
+                    now=now,
+                )
+            await session.commit()
+        return True
+
+    async def list_user_messages(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]:
+        stmt = (
+            select(LlmChatMessageRow)
+            .where(
+                LlmChatMessageRow.bot_id == int(bot_id),
+                LlmChatMessageRow.group_id == int(group_id),
+                LlmChatMessageRow.user_id == int(user_id),
+            )
+            .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
+            .limit(limit)
+        )
+        if ttl_sec > 0:
+            cutoff = int(time.time()) - ttl_sec
+            stmt = stmt.where(LlmChatMessageRow.created_at >= cutoff)
+
+        async with get_session(read_only=True) as session:
+            rows = (await session.execute(stmt)).scalars().all()
+
+        return [
+            LlmChatTurn(
+                role=row.role if row.role in ALLOWED_ROLES else "user",
+                content=row.content,
+                user_id=int(row.user_id),
+                created_at=int(row.created_at),
+            )
+            for row in reversed(rows)
+        ]
+
+    async def list_group_ambient(
+        self,
+        bot_id: int,
+        group_id: int,
+        *,
+        limit: int,
+        ttl_sec: int,
+    ) -> list[LlmChatTurn]:
+        stmt = (
+            select(LlmChatMessageRow)
+            .where(
+                LlmChatMessageRow.bot_id == int(bot_id),
+                LlmChatMessageRow.group_id == int(group_id),
+            )
+            .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
+            .limit(limit)
+        )
+        if ttl_sec > 0:
+            cutoff = int(time.time()) - ttl_sec
+            stmt = stmt.where(LlmChatMessageRow.created_at >= cutoff)
+
+        async with get_session(read_only=True) as session:
+            rows = (await session.execute(stmt)).scalars().all()
+
+        return [
+            LlmChatTurn(
+                role=row.role if row.role in ALLOWED_ROLES else "user",
+                content=row.content,
+                user_id=int(row.user_id),
+                created_at=int(row.created_at),
+            )
+            for row in reversed(rows)
+        ]
+
+    async def list_history_sessions(
+        self,
+        *,
+        bot_id: int | None,
+        group_id: int | None,
+        user_id: int | None,
+        limit: int,
+    ) -> list[LlmHistorySessionSummary]:
+        stmt = (
+            select(
+                LlmChatMessageRow.bot_id,
+                LlmChatMessageRow.group_id,
+                LlmChatMessageRow.user_id,
+                func.count().label("turn_count"),
+                func.min(LlmChatMessageRow.created_at).label("first_created_at"),
+                func.max(LlmChatMessageRow.created_at).label("last_created_at"),
+            )
+            .group_by(
+                LlmChatMessageRow.bot_id,
+                LlmChatMessageRow.group_id,
+                LlmChatMessageRow.user_id,
+            )
+            .order_by(func.max(LlmChatMessageRow.created_at).desc())
+            .limit(limit)
+        )
+
+        if bot_id is not None:
+            stmt = stmt.where(LlmChatMessageRow.bot_id == int(bot_id))
+        if group_id is not None:
+            stmt = stmt.where(LlmChatMessageRow.group_id == int(group_id))
+        if user_id is not None:
+            stmt = stmt.where(LlmChatMessageRow.user_id == int(user_id))
+
+        async with get_session(read_only=True) as session:
+            rows = (await session.execute(stmt)).all()
+
+            out: list[LlmHistorySessionSummary] = []
+            for row in rows:
+                latest_stmt = (
+                    select(LlmChatMessageRow)
+                    .where(
+                        LlmChatMessageRow.bot_id == int(row.bot_id),
+                        LlmChatMessageRow.group_id == int(row.group_id),
+                        LlmChatMessageRow.user_id == int(row.user_id),
+                    )
+                    .order_by(LlmChatMessageRow.created_at.desc(), LlmChatMessageRow.id.desc())
+                    .limit(1)
+                )
+                latest = (await session.execute(latest_stmt)).scalars().first()
+                if latest is None:
+                    continue
+                role = latest.role if latest.role in ALLOWED_ROLES else "user"
+                out.append(
+                    LlmHistorySessionSummary(
+                        session_key=f"{int(row.bot_id)}:{int(row.group_id)}:{int(row.user_id)}",
+                        bot_id=int(row.bot_id),
+                        group_id=int(row.group_id),
+                        user_id=int(row.user_id),
+                        turn_count=int(row.turn_count or 0),
+                        first_created_at=int(row.first_created_at or 0),
+                        last_created_at=int(row.last_created_at or 0),
+                        last_role=role,
+                        last_content=str(latest.content or ""),
+                    )
+                )
+        return out
+
+    async def clear_group(self, bot_id: int, group_id: int) -> int:
+        async with get_session() as session:
+            count = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(LlmChatMessageRow)
+                    .where(
+                        LlmChatMessageRow.bot_id == int(bot_id),
+                        LlmChatMessageRow.group_id == int(group_id),
+                    )
+                )
+            ).scalar_one()
+            await session.execute(
+                delete(LlmChatMessageRow).where(
+                    LlmChatMessageRow.bot_id == int(bot_id),
+                    LlmChatMessageRow.group_id == int(group_id),
+                )
+            )
+            await session.commit()
+        return int(count)
+
+    async def clear_user(self, bot_id: int, group_id: int, user_id: int) -> int:
+        async with get_session() as session:
+            count = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(LlmChatMessageRow)
+                    .where(
+                        LlmChatMessageRow.bot_id == int(bot_id),
+                        LlmChatMessageRow.group_id == int(group_id),
+                        LlmChatMessageRow.user_id == int(user_id),
+                    )
+                )
+            ).scalar_one()
+            await session.execute(
+                delete(LlmChatMessageRow).where(
+                    LlmChatMessageRow.bot_id == int(bot_id),
+                    LlmChatMessageRow.group_id == int(group_id),
+                    LlmChatMessageRow.user_id == int(user_id),
+                )
+            )
+            await session.commit()
+        return int(count)
+
+    async def compact_user_with_summary(
+        self,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        summary_content: str,
+        *,
+        keep_messages: int,
+    ) -> bool:
+        keep = max(2, int(keep_messages))
+        now = int(time.time())
+        async with get_session() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(LlmChatMessageRow)
+                        .where(
+                            LlmChatMessageRow.bot_id == int(bot_id),
+                            LlmChatMessageRow.group_id == int(group_id),
+                            LlmChatMessageRow.user_id == int(user_id),
+                        )
+                        .order_by(LlmChatMessageRow.created_at.asc(), LlmChatMessageRow.id.asc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            if len(rows) <= keep:
+                return False
+            keep_rows = rows[-keep:]
+            keep_ids = {row.id for row in keep_rows}
+            stale_ids = [row.id for row in rows if row.id not in keep_ids]
+            if stale_ids:
+                await session.execute(delete(LlmChatMessageRow).where(LlmChatMessageRow.id.in_(stale_ids)))
+            anchor_time = int(keep_rows[0].created_at) - 1 if keep_rows else now - 1
+            session.add(
+                LlmChatMessageRow(
+                    bot_id=int(bot_id),
+                    group_id=int(group_id),
+                    user_id=int(user_id),
+                    role="user",
+                    content=summary_content,
+                    created_at=anchor_time,
+                )
+            )
+            await session.commit()
+        return True
+
+    async def _purge_user_ttl(
+        self,
+        session,
+        *,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        ttl_sec: int,
+        now: int,
+    ) -> None:
+        if ttl_sec <= 0:
+            return
+        cutoff = now - ttl_sec
+        await session.execute(
+            delete(LlmChatMessageRow).where(
+                LlmChatMessageRow.bot_id == bot_id,
+                LlmChatMessageRow.group_id == group_id,
+                LlmChatMessageRow.user_id == user_id,
+                LlmChatMessageRow.created_at < cutoff,
+            )
+        )
+
+    async def _purge_group_ttl(
+        self,
+        session,
+        *,
+        bot_id: int,
+        group_id: int,
+        ttl_sec: int,
+        now: int,
+    ) -> None:
+        if ttl_sec <= 0 or group_id == 0:
+            return
+        cutoff = now - ttl_sec
+        await session.execute(
+            delete(LlmChatMessageRow).where(
+                LlmChatMessageRow.bot_id == bot_id,
+                LlmChatMessageRow.group_id == group_id,
+                LlmChatMessageRow.created_at < cutoff,
+            )
+        )
+
+    async def _trim_user_window(
+        self,
+        session,
+        *,
+        bot_id: int,
+        group_id: int,
+        user_id: int,
+        window: int,
+    ) -> None:
+        if window <= 0:
+            return
+        count = (
+            await session.execute(
+                select(func.count())
+                .select_from(LlmChatMessageRow)
+                .where(
+                    LlmChatMessageRow.bot_id == bot_id,
+                    LlmChatMessageRow.group_id == group_id,
+                    LlmChatMessageRow.user_id == user_id,
+                )
+            )
+        ).scalar_one()
+        overflow = int(count) - window
+        if overflow <= 0:
+            return
+        stale_ids = (
+            (
+                await session.execute(
+                    select(LlmChatMessageRow.id)
+                    .where(
+                        LlmChatMessageRow.bot_id == bot_id,
+                        LlmChatMessageRow.group_id == group_id,
+                        LlmChatMessageRow.user_id == user_id,
+                    )
+                    .order_by(LlmChatMessageRow.created_at.asc(), LlmChatMessageRow.id.asc())
+                    .limit(overflow)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if stale_ids:
+            await session.execute(delete(LlmChatMessageRow).where(LlmChatMessageRow.id.in_(stale_ids)))

--- a/tests/common/test_llm_memory_mongo.py
+++ b/tests/common/test_llm_memory_mongo.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from pallas.product.llm.config import LlmConfig, clear_llm_config_cache
+from pallas.product.llm.memory.relationship_store import (
+    delete_relationship_note,
+    is_relationship_store_available,
+    list_relationship_notes,
+    retrieve_relationship_note,
+    save_relationship_note,
+)
+from pallas.product.llm.memory.store import (
+    delete_memory_entry,
+    is_llm_memory_store_available,
+    list_memory_entries,
+    retrieve_memory_hits,
+    save_memory_entry,
+)
+
+
+def _patch_mongo_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime.is_postgresql_backend",
+        lambda _backend=None: False,
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime.is_mongodb_backend",
+        lambda _backend=None: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime_storage_ready",
+        lambda _backend=None: True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mongo_memory_save_list_retrieve_delete(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_memory_rag_enabled=True,
+        llm_vector_retrieve="keyword",
+        llm_memory_max_per_group=20,
+        llm_memory_rag_top_k=3,
+    )
+    monkeypatch.setattr("pallas.product.llm.memory.store.get_llm_config", lambda: cfg)
+    assert is_llm_memory_store_available() is True
+
+    assert await save_memory_entry(1, 100, "本群周五固定开黑", source="teach", cfg=cfg) is True
+    assert await save_memory_entry(1, 100, "银灰是谢拉格军阀", source="teach", cfg=cfg) is True
+
+    rows = await list_memory_entries(1, 100, query="开黑")
+    assert len(rows) == 1
+    assert "开黑" in rows[0]["content"]
+    entry_id = int(rows[0]["id"])
+
+    hits = await retrieve_memory_hits(1, 100, "周五开黑", cfg=cfg)
+    assert any("开黑" in str(item.get("content") or "") for item in hits)
+
+    assert await delete_memory_entry(entry_id, bot_id=1) is True
+    assert await list_memory_entries(1, 100, query="开黑") == []
+
+
+@pytest.mark.asyncio
+async def test_mongo_relationship_save_retrieve_delete(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_relationship_notes_enabled=True,
+        llm_relationship_half_life_days=0,
+        llm_relationship_min_weight=0.01,
+    )
+    monkeypatch.setattr("pallas.product.llm.memory.relationship_store.get_llm_config", lambda: cfg)
+    assert is_relationship_store_available() is True
+
+    assert await save_relationship_note(1, 100, 200, "是老熟人", source="teach", cfg=cfg) is True
+    note = await retrieve_relationship_note(1, 100, 200, cfg=cfg)
+    assert note == "是老熟人"
+
+    rows = await list_relationship_notes(1, 100)
+    assert len(rows) == 1
+    note_id = int(rows[0]["id"])
+    assert await delete_relationship_note(note_id, bot_id=1) is True
+    assert await retrieve_relationship_note(1, 100, 200, cfg=cfg) is None

--- a/tests/common/test_llm_memory_mongo.py
+++ b/tests/common/test_llm_memory_mongo.py
@@ -35,6 +35,34 @@ def _patch_mongo_backend(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_mongo_allocate_int_id_monotonic_and_bootstraps(beanie_fixture) -> None:
+    from beanie import SortDirection
+
+    from pallas.core.foundation.db.modules import LlmMemoryEntry
+    from pallas.product.llm.mongo_id import allocate_mongo_int_id
+
+    await LlmMemoryEntry(
+        entry_id=7,
+        bot_id=1,
+        group_id=1,
+        keywords="k",
+        content="seed",
+        source="teach",
+        created_at=1,
+        updated_at=1,
+    ).insert()
+
+    async def peek_max() -> int:
+        rows = await LlmMemoryEntry.find_all().sort([("entry_id", SortDirection.DESCENDING)]).limit(1).to_list()
+        return int(rows[0].entry_id) if rows else 0
+
+    first = await allocate_mongo_int_id("llm_memory_entry_test", peek_max=peek_max)
+    second = await allocate_mongo_int_id("llm_memory_entry_test", peek_max=peek_max)
+    assert first == 8
+    assert second == 9
+
+
+@pytest.mark.asyncio
 async def test_mongo_memory_save_list_retrieve_delete(beanie_fixture, monkeypatch) -> None:
     clear_llm_config_cache()
     _patch_mongo_backend(monkeypatch)

--- a/tests/common/test_llm_session_store_mongo.py
+++ b/tests/common/test_llm_session_store_mongo.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from pallas.product.llm.config import LlmConfig, clear_llm_config_cache
+from pallas.product.llm.session_store import (
+    append_llm_message,
+    build_llm_chat_messages,
+    clear_llm_messages,
+    clear_user_llm_messages,
+    compact_user_llm_history_with_summary,
+    get_llm_history_session_detail,
+    is_llm_session_store_available,
+    list_group_ambient_messages,
+    list_llm_history_sessions,
+    list_user_llm_messages,
+)
+
+
+def _patch_mongo_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime.is_postgresql_backend",
+        lambda _backend=None: False,
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime.is_mongodb_backend",
+        lambda _backend=None: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.runtime_storage_ready",
+        lambda _backend=None: True,
+    )
+    clock = {"t": 1_700_000_000}
+
+    def fake_time() -> int:
+        clock["t"] += 1
+        return clock["t"]
+
+    monkeypatch.setattr("pallas.product.llm.session_store_mongo.time.time", fake_time)
+
+
+@pytest.mark.asyncio
+async def test_mongo_llm_session_user_window_and_ambient(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_session_enabled=True,
+        llm_session_user_window=2,
+        llm_session_group_window=2,
+        llm_session_user_ttl_sec=0,
+    )
+    monkeypatch.setattr("pallas.product.llm.session_store.get_llm_config", lambda: cfg)
+    assert is_llm_session_store_available() is True
+
+    for index in range(3):
+        assert await append_llm_message(10001, 20002, 30003, "user", f"a-{index}") is True
+    for index in range(3):
+        assert await append_llm_message(10001, 20002, 40004, "user", f"b-{index}") is True
+
+    user_a = await list_user_llm_messages(10001, 20002, 30003)
+    user_b = await list_user_llm_messages(10001, 20002, 40004)
+    assert [turn.content for turn in user_a] == ["a-1", "a-2"]
+    assert [turn.content for turn in user_b] == ["b-1", "b-2"]
+
+    ambient = await list_group_ambient_messages(10001, 20002)
+    # group_window=2 → 群内按时间最近 2 条（trim 后剩 a-1/a-2/b-1/b-2）
+    assert len(ambient) == 2
+    assert {turn.content for turn in ambient} == {"b-1", "b-2"}
+
+
+@pytest.mark.asyncio
+async def test_mongo_build_llm_chat_messages_user_thread_and_ambient(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_chat_enabled=True,
+        llm_session_enabled=True,
+        llm_session_user_window=8,
+        llm_session_group_window=4,
+        llm_session_user_ttl_sec=0,
+    )
+    monkeypatch.setattr("pallas.product.llm.session_store.get_llm_config", lambda: cfg)
+
+    from pallas.product.llm.kernel.memory_governance import can_read_runtime_state
+
+    assert can_read_runtime_state(cfg) is True
+
+    await append_llm_message(1, 100, 200, "user", "other-user-msg")
+    await append_llm_message(1, 100, 200, "assistant", "reply-to-other")
+    await append_llm_message(1, 100, 300, "user", "my-old")
+    await append_llm_message(1, 100, 300, "assistant", "my-reply")
+
+    messages = await build_llm_chat_messages(1, 100, 300, "my-new", cfg=cfg)
+    assert messages[-1].role == "user"
+    assert "my-new" in messages[-1].content
+    joined = "\n".join(item.content for item in messages)
+    assert "群环境摘录" in joined, joined
+    assert "my-old" in joined
+
+
+@pytest.mark.asyncio
+async def test_mongo_clear_and_history(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_session_enabled=True,
+        llm_session_user_window=20,
+        llm_session_group_window=20,
+        llm_session_user_ttl_sec=0,
+    )
+    monkeypatch.setattr("pallas.product.llm.session_store.get_llm_config", lambda: cfg)
+
+    await append_llm_message(10, 100, 200, "user", "u200-1")
+    await append_llm_message(10, 100, 200, "assistant", "a200-1")
+    await append_llm_message(10, 100, 300, "user", "u300-1")
+    await append_llm_message(10, 100, 300, "assistant", "a300-1")
+
+    sessions = await list_llm_history_sessions(bot_id=10, group_id=100, limit=10)
+    assert [row.user_id for row in sessions] == [300, 200]
+    assert sessions[0].last_content == "a300-1"
+    assert sessions[0].turn_count == 2
+
+    detail = await get_llm_history_session_detail(bot_id=10, group_id=100, user_id=200, limit=10)
+    assert detail is not None
+    assert [turn.content for turn in detail.turns] == ["u200-1", "a200-1"]
+
+    assert await clear_user_llm_messages(10, 100, 200) == 2
+    assert await list_user_llm_messages(10, 100, 200) == []
+    assert await clear_llm_messages(10, 100) == 2
+
+
+@pytest.mark.asyncio
+async def test_mongo_compact_user_history(beanie_fixture, monkeypatch) -> None:
+    clear_llm_config_cache()
+    _patch_mongo_backend(monkeypatch)
+    cfg = LlmConfig(
+        llm_session_enabled=True,
+        llm_session_user_window=20,
+        llm_session_user_ttl_sec=0,
+    )
+    monkeypatch.setattr("pallas.product.llm.session_store.get_llm_config", lambda: cfg)
+
+    for index in range(5):
+        await append_llm_message(1, 10, 20, "user", f"msg-{index}")
+    assert await compact_user_llm_history_with_summary(
+        1,
+        10,
+        20,
+        "summary-text",
+        keep_messages=2,
+        cfg=cfg,
+    )
+    turns = await list_user_llm_messages(1, 10, 20, limit=20)
+    assert any("此前对话摘要" in turn.content and "summary-text" in turn.content for turn in turns)
+    assert len(turns) == 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ async def beanie_fixture():
         Context,
         GroupConfigModule,
         ImageCache,
+        LlmChatMessage,
         Message,
         UserConfigModule,
     )
@@ -49,6 +50,7 @@ async def beanie_fixture():
             Context,
             BlackList,
             ImageCache,
+            LlmChatMessage,
         ],
         allow_index_dropping=True,
     )
@@ -62,6 +64,7 @@ async def beanie_fixture():
     await motor_db.drop_collection("context")
     await motor_db.drop_collection("blacklist")
     await motor_db.drop_collection("image_cache")
+    await motor_db.drop_collection("llm_chat_message")
     motor_client.close()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ async def beanie_fixture():
         GroupConfigModule,
         ImageCache,
         LlmChatMessage,
+        LlmMemoryEntry,
+        LlmRelationshipNote,
         Message,
         UserConfigModule,
     )
@@ -51,6 +53,8 @@ async def beanie_fixture():
             BlackList,
             ImageCache,
             LlmChatMessage,
+            LlmMemoryEntry,
+            LlmRelationshipNote,
         ],
         allow_index_dropping=True,
     )
@@ -65,6 +69,8 @@ async def beanie_fixture():
     await motor_db.drop_collection("blacklist")
     await motor_db.drop_collection("image_cache")
     await motor_db.drop_collection("llm_chat_message")
+    await motor_db.drop_collection("llm_memory_entry")
+    await motor_db.drop_collection("llm_relationship_note")
     motor_client.close()
 
 


### PR DESCRIPTION
Mongo 老用户对齐 PG 侧 LLM 产品能力。

- P1：`session_store` 双后端（多轮会话 / TTL / 窗口 / WebUI 历史）
- P2：`llm_memory_entry` / `llm_relationship_note` Mongo 读写；向量不可用时关键词回落


## Summary by Sourcery

添加可插拔的 LLM 会话后端，支持 PostgreSQL 和 MongoDB，并扩展 LLM 记忆与关系备注存储，使其在向量检索不可用时能够在 MongoDB 上使用关键词回退机制。

New Features:
- 支持在 MongoDB（与 PostgreSQL 并行）上存储 LLM 聊天会话，包括用户窗口、群组环境历史以及会话压缩。
- 允许 LLM 群组记忆（`llm_memory_entry`）和关系备注在 MongoDB 中进行存储和查询，除了 PostgreSQL 之外也可使用。
- 引入与后端无关的就绪检查，使 LLM 会话、记忆和关系备注在对应数据库初始化完成后，能够在 PG 或 Mongo 上运行。

Enhancements:
- 重构 LLM 会话模型与持久化逻辑为共享抽象与后端特定实现，简化未来的存储变更。
- 更新维护者文档，说明会话、群组记忆和关系备注的 PG/Mongo 双存储方案，并澄清在向量不可用时回退到关键词搜索的行为。

Documentation:
- 记录 LLM 会话、群组记忆和关系备注在 PG/Mongo 上的存储支持，包括运行指导和故障排查，涵盖在向量检索被禁用或不可用时关于存储就绪和关键词回退的说明。

Tests:
- 添加基于 Mongo 的测试，用于验证 LLM 会话行为、记忆 RAG 操作和关系备注，以确保与 PostgreSQL 实现保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a pluggable LLM session backend that supports both PostgreSQL and MongoDB, and extend LLM memory and relationship note storage to work on MongoDB with keyword fallback when vector retrieval is unavailable.

New Features:
- Support LLM chat session storage on MongoDB alongside PostgreSQL, including user windows, group ambient history, and session compaction.
- Enable LLM group memory (`llm_memory_entry`) and relationship notes to be stored and queried on MongoDB in addition to PostgreSQL.
- Introduce backend-agnostic readiness checks so LLM sessions, memory, and relationship notes can run on either PG or Mongo once the respective database is initialized.

Enhancements:
- Refactor LLM session models and persistence into shared abstractions and backend-specific implementations to simplify future storage changes.
- Update maintainer documentation to describe dual PG/Mongo storage for sessions, group memory, and relationship notes, and clarify fallback to keyword search when vectors are unavailable.

Documentation:
- Document PG/Mongo support for LLM session, group memory, and relationship note storage, including operational guidance and troubleshooting for storage readiness and keyword fallback when vector retrieval is disabled or unavailable.

Tests:
- Add Mongo-backed tests for LLM session behavior, memory RAG operations, and relationship notes to ensure parity with the PostgreSQL implementation.

</details>