### PR TITLE
fix(llm): 修复 AI 统计 flush 重复累加导致区间总量漂移

### DIFF
--- a/packages/llm_chat/drunk_chat.py
+++ b/packages/llm_chat/drunk_chat.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from nonebot import logger, on_message
-from nonebot.adapters import Bot
 from nonebot.adapters.onebot.v11 import GroupMessageEvent, permission
 from nonebot.rule import Rule
 from ulid import ULID
@@ -23,6 +23,9 @@ from pallas.product.llm import (
 from pallas.product.llm.drunk_tts import is_chat_tts_enabled
 from pallas.product.llm.legacy_rwkv import delete_rwkv_chat_session, submit_rwkv_drunk_chat
 from pallas.product.llm.session_store import clear_llm_messages
+
+if TYPE_CHECKING:
+    from nonebot.adapters import Bot
 
 CHAT_COOLDOWN_KEY = "chat"
 # 与历史扩展仓 chat 一致：优先于清醒 @（llm_chat 默认 ~51）

--- a/pallas/product/llm/provider_request_metrics.py
+++ b/pallas/product/llm/provider_request_metrics.py
@@ -13,6 +13,7 @@ _STORE_VER = 1
 
 _lock = threading.Lock()
 _day_key = ""
+_hydrated = False
 _by_provider: dict[str, dict[str, Any]] = {}
 _by_model: dict[str, dict[str, Any]] = {}
 _failure_counts: dict[str, int] = {}
@@ -71,7 +72,7 @@ def _row_with_avg(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def rollover_if_needed() -> None:
-    global _day_key  # noqa: PLW0603
+    global _day_key, _hydrated  # noqa: PLW0603
     today = today_key()
     if _day_key == today:
         return
@@ -93,10 +94,54 @@ def rollover_if_needed() -> None:
             )
         except Exception:
             pass
+        _by_provider.clear()
+        _by_model.clear()
+        _failure_counts.clear()
+        _day_key = today
+        _hydrated = True
+        return
     _day_key = today
-    _by_provider.clear()
-    _by_model.clear()
-    _failure_counts.clear()
+    _hydrated = False
+
+
+def _copy_dimension_from_persisted(dst: dict[str, dict[str, Any]], src: Any) -> None:
+    if not isinstance(src, dict):
+        return
+    for key, row in src.items():
+        if not isinstance(row, dict):
+            continue
+        name = str(key or "").strip()
+        if not name:
+            continue
+        dst[name] = {
+            "requests": int(row.get("requests") or 0),
+            "succeeded": int(row.get("succeeded") or row.get("ok") or 0),
+            "failed": int(row.get("failed") or row.get("fail") or 0),
+            "total_latency_ms": int(row.get("total_latency_ms") or 0),
+            "recent_failure_class": str(row.get("recent_failure_class") or "").strip(),
+        }
+
+
+def _hydrate_from_disk_locked() -> None:
+    global _hydrated  # noqa: PLW0603
+    if _hydrated:
+        return
+    _hydrated = True
+    raw = load_stats_file()
+    if not isinstance(raw, dict) or not raw.get("day_key"):
+        return
+    if str(raw.get("day_key") or "") != str(_day_key or today_key()):
+        return
+    if _by_provider or _by_model or _failure_counts:
+        return
+    _copy_dimension_from_persisted(_by_provider, raw.get("provider_stats"))
+    _copy_dimension_from_persisted(_by_model, raw.get("model_stats"))
+    fails = raw.get("failure_counts")
+    if isinstance(fails, dict):
+        for key, count in fails.items():
+            name = str(key or "").strip()
+            if name:
+                _failure_counts[name] = int(count or 0)
 
 
 def _snapshot_locked(*, day_override: str | None = None) -> dict[str, Any]:
@@ -124,6 +169,7 @@ def record_provider_request(
     fail_cls = str(failure_class or "").strip()
     with _lock:
         rollover_if_needed()
+        _hydrate_from_disk_locked()
         prow = _by_provider.setdefault(provider_key, _empty_row())
         _bump_row(prow, ok=ok, latency_ms=latency, failure_class=fail_cls)
         if model_key:
@@ -196,30 +242,9 @@ def merge_provider_request_snapshots(rows: list[dict[str, Any]]) -> dict[str, An
 def llm_provider_request_metrics_snapshot(*, include_persisted: bool = True) -> dict[str, Any]:
     with _lock:
         rollover_if_needed()
-        local = _snapshot_locked()
-    if not include_persisted:
-        return local
-    persisted_raw = load_stats_file()
-    if not isinstance(persisted_raw, dict) or not persisted_raw.get("day_key"):
-        return local
-    if str(persisted_raw.get("day_key") or "") != str(local.get("day_key") or ""):
-        return local
-    persisted = {
-        "source": str(persisted_raw.get("source") or "bot"),
-        "day_key": str(persisted_raw.get("day_key") or ""),
-        "updated_at": float(persisted_raw.get("updated_at") or 0),
-        "provider_stats": persisted_raw.get("provider_stats")
-        if isinstance(persisted_raw.get("provider_stats"), dict)
-        else {},
-        "model_stats": persisted_raw.get("model_stats") if isinstance(persisted_raw.get("model_stats"), dict) else {},
-        "failure_counts": persisted_raw.get("failure_counts")
-        if isinstance(persisted_raw.get("failure_counts"), dict)
-        else {},
-    }
-    local_has = bool(local.get("provider_stats")) or bool(local.get("model_stats"))
-    if not local_has:
-        return merge_provider_request_snapshots([persisted]) if persisted.get("day_key") else local
-    return merge_provider_request_snapshots([persisted, local])
+        if include_persisted:
+            _hydrate_from_disk_locked()
+        return _snapshot_locked()
 
 
 def cluster_llm_provider_request_metrics_snapshot(*, max_stale_sec: float = 300.0) -> dict[str, Any]:
@@ -257,11 +282,7 @@ def flush_provider_request_stats_sync() -> None:
 
         if shard_ctx.sharding_active() and shard_ctx.is_worker():
             return
-        snapshot = (
-            cluster_llm_provider_request_metrics_snapshot()
-            if shard_ctx.sharding_active() and shard_ctx.is_hub()
-            else llm_provider_request_metrics_snapshot(include_persisted=True)
-        )
+        snapshot = llm_provider_request_metrics_snapshot(include_persisted=True)
     except Exception:
         snapshot = llm_provider_request_metrics_snapshot(include_persisted=True)
     if not snapshot.get("provider_stats") and not snapshot.get("model_stats"):
@@ -293,9 +314,10 @@ def flush_provider_request_stats_sync() -> None:
 
 
 def clear_llm_provider_request_metrics_for_tests() -> None:
-    global _day_key  # noqa: PLW0603
+    global _day_key, _hydrated  # noqa: PLW0603
     with _lock:
-        _day_key = ""
+        _day_key = today_key()
+        _hydrated = True
         _by_provider.clear()
         _by_model.clear()
         _failure_counts.clear()

--- a/pallas/product/llm/rag_metrics.py
+++ b/pallas/product/llm/rag_metrics.py
@@ -13,6 +13,7 @@ _STORE_VER = 1
 
 _lock = threading.Lock()
 _day_key = ""
+_hydrated = False
 _hit_count = 0
 _miss_count = 0
 _by_document: dict[str, int] = {}
@@ -34,8 +35,48 @@ def _hit_rate(hit: int, miss: int) -> float:
     return round(100.0 * hit / total, 1)
 
 
+def load_stats_file() -> dict[str, Any]:
+    path = stats_file_path()
+    if not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _hydrate_from_disk_locked() -> None:
+    """进程内只 hydrate 一次，避免落盘快照与内存再次相加导致命中数漂移。"""
+    global _hydrated, _hit_count, _miss_count  # noqa: PLW0603
+    if _hydrated:
+        return
+    _hydrated = True
+    raw = load_stats_file()
+    if not isinstance(raw, dict) or not raw.get("day_key"):
+        return
+    if str(raw.get("day_key") or "") != str(_day_key or today_key()):
+        return
+    if _hit_count or _miss_count or _by_document or _by_source:
+        return
+    _hit_count = int(raw.get("hit_count") or 0)
+    _miss_count = int(raw.get("miss_count") or 0)
+    docs = raw.get("by_document")
+    if isinstance(docs, dict):
+        for key, value in docs.items():
+            name = str(key or "").strip()
+            if name:
+                _by_document[name] = int(value or 0)
+    sources = raw.get("by_source")
+    if isinstance(sources, dict):
+        for key, value in sources.items():
+            sid = str(key or "").strip()
+            if sid:
+                _by_source[sid] = int(value or 0)
+
+
 def rollover_if_needed() -> None:
-    global _day_key, _hit_count, _miss_count  # noqa: PLW0603
+    global _day_key, _hydrated, _hit_count, _miss_count  # noqa: PLW0603
     today = today_key()
     if _day_key == today:
         return
@@ -47,11 +88,15 @@ def rollover_if_needed() -> None:
             write_day_side(_day_key, "ai", {"rag": old, "day_key": _day_key, "source": "bot"})
         except Exception:
             pass
+        _hit_count = 0
+        _miss_count = 0
+        _by_document.clear()
+        _by_source.clear()
+        _day_key = today
+        _hydrated = True
+        return
     _day_key = today
-    _hit_count = 0
-    _miss_count = 0
-    _by_document.clear()
-    _by_source.clear()
+    _hydrated = False
 
 
 def record_rag_query_result(
@@ -63,6 +108,7 @@ def record_rag_query_result(
     try:
         with _lock:
             rollover_if_needed()
+            _hydrate_from_disk_locked()
             global _hit_count, _miss_count  # noqa: PLW0603
             if hit:
                 _hit_count += 1
@@ -92,17 +138,6 @@ def _snapshot_locked(*, day_override: str | None = None) -> dict[str, Any]:
         "by_document": dict(_by_document),
         "by_source": dict(_by_source),
     }
-
-
-def load_stats_file() -> dict[str, Any]:
-    path = stats_file_path()
-    if not path.is_file():
-        return {}
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    return raw if isinstance(raw, dict) else {}
 
 
 def merge_llm_rag_snapshots(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -153,28 +188,9 @@ def merge_llm_rag_snapshots(rows: list[dict[str, Any]]) -> dict[str, Any]:
 def llm_rag_metrics_snapshot(*, include_persisted: bool = True) -> dict[str, Any]:
     with _lock:
         rollover_if_needed()
-        local = _snapshot_locked()
-    if not include_persisted:
-        return local
-    persisted_raw = load_stats_file()
-    if not isinstance(persisted_raw, dict) or not persisted_raw.get("day_key"):
-        return local
-    if str(persisted_raw.get("day_key") or "") != str(local.get("day_key") or ""):
-        return local
-    persisted = {
-        "source": str(persisted_raw.get("source") or "bot"),
-        "day_key": str(persisted_raw.get("day_key") or ""),
-        "updated_at": float(persisted_raw.get("updated_at") or 0),
-        "hit_count": int(persisted_raw.get("hit_count") or 0),
-        "miss_count": int(persisted_raw.get("miss_count") or 0),
-        "hit_rate": float(persisted_raw.get("hit_rate") or 0),
-        "by_document": (persisted_raw.get("by_document") if isinstance(persisted_raw.get("by_document"), dict) else {}),
-        "by_source": persisted_raw.get("by_source") if isinstance(persisted_raw.get("by_source"), dict) else {},
-    }
-    local_has = int(local.get("hit_count") or 0) > 0 or int(local.get("miss_count") or 0) > 0
-    if not local_has:
-        return merge_llm_rag_snapshots([persisted]) if persisted.get("day_key") else local
-    return merge_llm_rag_snapshots([persisted, local])
+        if include_persisted:
+            _hydrate_from_disk_locked()
+        return _snapshot_locked()
 
 
 def cluster_llm_rag_metrics_snapshot(*, max_stale_sec: float = 300.0) -> dict[str, Any]:
@@ -211,11 +227,7 @@ def flush_rag_stats_sync() -> None:
 
         if shard_ctx.sharding_active() and shard_ctx.is_worker():
             return
-        snapshot = (
-            cluster_llm_rag_metrics_snapshot()
-            if shard_ctx.sharding_active() and shard_ctx.is_hub()
-            else llm_rag_metrics_snapshot(include_persisted=True)
-        )
+        snapshot = llm_rag_metrics_snapshot(include_persisted=True)
     except Exception:
         snapshot = llm_rag_metrics_snapshot(include_persisted=True)
     if int(snapshot.get("hit_count") or 0) <= 0 and int(snapshot.get("miss_count") or 0) <= 0:
@@ -241,9 +253,10 @@ def flush_rag_stats_sync() -> None:
 
 
 def clear_llm_rag_metrics_for_tests() -> None:
-    global _day_key, _hit_count, _miss_count  # noqa: PLW0603
+    global _day_key, _hydrated, _hit_count, _miss_count  # noqa: PLW0603
     with _lock:
-        _day_key = ""
+        _day_key = today_key()
+        _hydrated = True
         _hit_count = 0
         _miss_count = 0
         _by_document.clear()

--- a/pallas/product/llm/token_metrics.py
+++ b/pallas/product/llm/token_metrics.py
@@ -13,6 +13,7 @@ _STORE_VER = 1
 
 _lock = threading.Lock()
 _day_key = ""
+_hydrated = False
 _prompt_tokens = 0
 _completion_tokens = 0
 _cache_read_tokens = 0
@@ -37,8 +38,55 @@ def stats_file_path():
     return plugin_data_dir("pb_webui", create=True) / "llm_token_stats.json"
 
 
+def _copy_breakdown_from_persisted(dst: dict[str, dict[str, int]], src: Any) -> None:
+    if not isinstance(src, dict):
+        return
+    for key, metrics in src.items():
+        if not isinstance(metrics, dict):
+            continue
+        k = str(key).strip()
+        if not k:
+            continue
+        dst[k] = {
+            "prompt_tokens": int(metrics.get("prompt_tokens") or 0),
+            "completion_tokens": int(metrics.get("completion_tokens") or 0),
+            "cache_read_tokens": int(metrics.get("cache_read_tokens") or 0),
+            "cache_write_tokens": int(metrics.get("cache_write_tokens") or 0),
+        }
+
+
+def _hydrate_from_disk_locked() -> None:
+    """进程内只 hydrate 一次：把当日落盘计数载入内存，避免与内存再次相加。"""
+    global _hydrated, _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
+    if _hydrated:
+        return
+    _hydrated = True
+    raw = load_stats_file()
+    if not isinstance(raw, dict) or not raw.get("day_key"):
+        return
+    if str(raw.get("day_key") or "") != str(_day_key or today_key()):
+        return
+    if (
+        _prompt_tokens
+        or _completion_tokens
+        or _cache_read_tokens
+        or _cache_write_tokens
+        or _by_task
+        or _by_provider
+        or _by_model
+    ):
+        return
+    _prompt_tokens = int(raw.get("prompt_tokens") or 0)
+    _completion_tokens = int(raw.get("completion_tokens") or 0)
+    _cache_read_tokens = int(raw.get("cache_read_tokens") or 0)
+    _cache_write_tokens = int(raw.get("cache_write_tokens") or 0)
+    _copy_breakdown_from_persisted(_by_task, raw.get("by_task"))
+    _copy_breakdown_from_persisted(_by_provider, raw.get("by_provider"))
+    _copy_breakdown_from_persisted(_by_model, raw.get("by_model"))
+
+
 def rollover_if_needed() -> None:
-    global _day_key, _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
+    global _day_key, _hydrated, _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
     today = today_key()
     if _day_key == today:
         return
@@ -51,14 +99,19 @@ def rollover_if_needed() -> None:
             write_day_side(_day_key, "ai", {"tokens": old, "day_key": _day_key, "source": "bot"})
         except Exception:
             pass
+        _prompt_tokens = 0
+        _completion_tokens = 0
+        _cache_read_tokens = 0
+        _cache_write_tokens = 0
+        _by_task.clear()
+        _by_provider.clear()
+        _by_model.clear()
+        _day_key = today
+        _hydrated = True
+        return
+    # 进程首次进入当日：先定 day_key，由 hydrate 按需载入落盘
     _day_key = today
-    _prompt_tokens = 0
-    _completion_tokens = 0
-    _cache_read_tokens = 0
-    _cache_write_tokens = 0
-    _by_task.clear()
-    _by_provider.clear()
-    _by_model.clear()
+    _hydrated = False
 
 
 def _bump_row(row: dict[str, int], *, prompt: int, completion: int, cache_read: int, cache_write: int) -> None:
@@ -88,6 +141,7 @@ def record_llm_token_usage(
     try:
         with _lock:
             rollover_if_needed()
+            _hydrate_from_disk_locked()
             global _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
             _prompt_tokens += prompt
             _completion_tokens += completion
@@ -210,31 +264,9 @@ def merge_llm_token_snapshots(rows: list[dict[str, Any]]) -> dict[str, Any]:
 def llm_token_metrics_snapshot(*, include_persisted: bool = True) -> dict[str, Any]:
     with _lock:
         rollover_if_needed()
-        local = _snapshot_locked()
-    if not include_persisted:
-        return local
-    persisted_raw = load_stats_file()
-    if not isinstance(persisted_raw, dict) or not persisted_raw.get("day_key"):
-        return local
-    if str(persisted_raw.get("day_key") or "") != str(local.get("day_key") or ""):
-        return local
-    persisted = {
-        "source": str(persisted_raw.get("source") or "bot"),
-        "day_key": str(persisted_raw.get("day_key") or ""),
-        "updated_at": float(persisted_raw.get("updated_at") or 0),
-        "prompt_tokens": int(persisted_raw.get("prompt_tokens") or 0),
-        "completion_tokens": int(persisted_raw.get("completion_tokens") or 0),
-        "cache_read_tokens": int(persisted_raw.get("cache_read_tokens") or 0),
-        "cache_write_tokens": int(persisted_raw.get("cache_write_tokens") or 0),
-        "total_tokens": int(persisted_raw.get("total_tokens") or 0),
-        "by_task": persisted_raw.get("by_task") if isinstance(persisted_raw.get("by_task"), dict) else {},
-        "by_provider": persisted_raw.get("by_provider") if isinstance(persisted_raw.get("by_provider"), dict) else {},
-        "by_model": persisted_raw.get("by_model") if isinstance(persisted_raw.get("by_model"), dict) else {},
-    }
-    local_has = int(local.get("total_tokens") or 0) > 0 or bool(local.get("by_task"))
-    if not local_has:
-        return merge_llm_token_snapshots([persisted]) if persisted.get("day_key") else local
-    return merge_llm_token_snapshots([persisted, local])
+        if include_persisted:
+            _hydrate_from_disk_locked()
+        return _snapshot_locked()
 
 
 def cluster_llm_token_metrics_snapshot(*, max_stale_sec: float = 300.0) -> dict[str, Any]:
@@ -272,11 +304,8 @@ def flush_stats_sync() -> None:
 
         if shard_ctx.sharding_active() and shard_ctx.is_worker():
             return
-        snapshot = (
-            cluster_llm_token_metrics_snapshot()
-            if shard_ctx.sharding_active() and shard_ctx.is_hub()
-            else llm_token_metrics_snapshot(include_persisted=True)
-        )
+        # 只落盘本进程内存（经 hydrate），禁止再与磁盘快照相加，否则刷新统计会翻倍漂移
+        snapshot = llm_token_metrics_snapshot(include_persisted=True)
     except Exception:
         snapshot = llm_token_metrics_snapshot(include_persisted=True)
     if not snapshot.get("by_task") and int(snapshot.get("total_tokens") or 0) == 0:
@@ -303,9 +332,10 @@ def flush_stats_sync() -> None:
 
 
 def clear_llm_token_metrics_for_tests() -> None:
-    global _day_key, _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
+    global _day_key, _hydrated, _prompt_tokens, _completion_tokens, _cache_read_tokens, _cache_write_tokens  # noqa: PLW0603
     with _lock:
-        _day_key = ""
+        _day_key = today_key()
+        _hydrated = True
         _prompt_tokens = 0
         _completion_tokens = 0
         _cache_read_tokens = 0

--- a/tests/product/llm/test_rag_metrics.py
+++ b/tests/product/llm/test_rag_metrics.py
@@ -69,3 +69,20 @@ def test_merge_and_cluster_rag_snapshots(monkeypatch: pytest.MonkeyPatch) -> Non
     assert combined["hit_count"] == 1
     assert combined["miss_count"] == 3
     assert combined["hit_rate"] == 25.0
+
+
+def test_rag_flush_does_not_double_count(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.product.llm import rag_metrics as rm
+
+    clear_llm_rag_metrics_for_tests()
+    path = tmp_path / "llm_rag_stats.json"
+    monkeypatch.setattr(rm, "stats_file_path", lambda: path)
+
+    record_rag_query_result(hit=True, documents=[("doc", "src")])
+    record_rag_query_result(hit=False)
+    rm.flush_rag_stats_sync()
+    rm.flush_rag_stats_sync()
+    snap = llm_rag_metrics_snapshot(include_persisted=True)
+    assert snap["hit_count"] == 1
+    assert snap["miss_count"] == 1
+    assert snap["by_document"]["doc"] == 1

--- a/tests/product/llm/test_token_metrics.py
+++ b/tests/product/llm/test_token_metrics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from pallas.product.llm.token_metrics import (
@@ -95,6 +97,58 @@ def test_cluster_llm_token_metrics_merges_worker_rows(monkeypatch: pytest.Monkey
     assert merged["total_tokens"] == 65
     assert merged["by_provider"]["hub"]["total_tokens"] == 15
     assert merged["by_provider"]["ds"]["total_tokens"] == 50
+
+
+def test_flush_does_not_double_count(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.product.llm import token_metrics as tm
+
+    clear_llm_token_metrics_for_tests()
+    path = tmp_path / "llm_token_stats.json"
+    monkeypatch.setattr(tm, "stats_file_path", lambda: path)
+
+    record_llm_token_usage(
+        task="llm_chat",
+        provider="openai",
+        model="m",
+        prompt_tokens=100,
+        completion_tokens=20,
+    )
+    tm.flush_stats_sync()
+    tm.flush_stats_sync()
+    tm.flush_stats_sync()
+    snap = llm_token_metrics_snapshot(include_persisted=True)
+    assert snap["total_tokens"] == 120
+    assert snap["prompt_tokens"] == 100
+    assert int(json.loads(path.read_text(encoding="utf-8"))["total_tokens"]) == 120
+
+
+def test_hydrate_from_disk_after_restart(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.product.llm import token_metrics as tm
+
+    clear_llm_token_metrics_for_tests()
+    path = tmp_path / "llm_token_stats.json"
+    monkeypatch.setattr(tm, "stats_file_path", lambda: path)
+
+    record_llm_token_usage(task="llm_chat", provider="x", model="m", prompt_tokens=40, completion_tokens=10)
+    tm.flush_stats_sync()
+
+    tm._day_key = ""
+    tm._hydrated = False
+    tm._prompt_tokens = 0
+    tm._completion_tokens = 0
+    tm._cache_read_tokens = 0
+    tm._cache_write_tokens = 0
+    tm._by_task.clear()
+    tm._by_provider.clear()
+    tm._by_model.clear()
+
+    snap = llm_token_metrics_snapshot(include_persisted=True)
+    assert snap["total_tokens"] == 50
+    record_llm_token_usage(task="llm_chat", provider="x", model="m", prompt_tokens=5, completion_tokens=0)
+    snap2 = llm_token_metrics_snapshot(include_persisted=True)
+    assert snap2["total_tokens"] == 55
+    tm.flush_stats_sync()
+    assert int(json.loads(path.read_text(encoding="utf-8"))["total_tokens"]) == 55
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
控制台 AI 统计刷新时，token / RAG / 提供方请求会把「磁盘快照 + 内存」再累加写回，导致当前区间总量与命中数翻倍漂移。

改为进程内 hydrate 一次后以内存为准落盘；分片展示仍走 cluster 聚合。补了重复 flush 与重启 hydrate 单测。