### PR TITLE
chore(plugins): 官方扩展 GitHub 迁至 PallasBot/Plugin-*

### DIFF
--- a/docs/developer/extension-pypi-publish.md
+++ b/docs/developer/extension-pypi-publish.md
@@ -28,8 +28,8 @@ unzip -l build/pallas-core/dist/*.whl | grep 'pallas/__init__'
 
 | 字段 | 值 |
 | --- | --- |
-| Owner | `TogetsuDo`（或实际 org） |
-| Repository | `pallas-plugin-<name>` |
+| Owner | `PallasBot` |
+| Repository | `Plugin-<Name>`（GitHub）；PyPI 包名仍为 `pallas-plugin-<name>` |
 | Workflow | `publish-pypi.yml` |
 | Environment | `pypi`（可选，与 workflow 一致） |
 

--- a/docs/plugins/bot_status/README.md
+++ b/docs/plugins/bot_status/README.md
@@ -71,4 +71,4 @@
 ## 相关链接
 
 - [命令权限说明](../common/cmd_perm/README.md)
-- [牛牛状态插件仓库](https://github.com/TogetsuDo/pallas-plugin-bot-status)
+- [牛牛状态插件仓库](https://github.com/PallasBot/Plugin-Bot-Status)

--- a/docs/plugins/draw/README.md
+++ b/docs/plugins/draw/README.md
@@ -46,7 +46,7 @@
 
 ## 实现
 
-源码位置：扩展仓 [`src/pallas_plugin_draw/`](https://github.com/TogetsuDo/pallas-plugin-draw/tree/main/src/pallas_plugin_draw)
+源码位置：扩展仓 [`src/pallas_plugin_draw/`](https://github.com/PallasBot/Plugin-Draw/tree/main/src/pallas_plugin_draw)
 
 关键文件：
 
@@ -63,4 +63,4 @@
 ## 相关链接
 
 - [命令权限说明](../common/cmd_perm/README.md)
-- [牛牛画画插件仓库](https://github.com/TogetsuDo/pallas-plugin-draw)
+- [牛牛画画插件仓库](https://github.com/PallasBot/Plugin-Draw)

--- a/docs/plugins/dream/README.md
+++ b/docs/plugins/dream/README.md
@@ -68,4 +68,4 @@
 
 - [命令权限说明](../common/cmd_perm/README.md)
 - [喝酒插件说明](../drink/README.md)
-- [牛牛做梦插件仓库](https://github.com/TogetsuDo/pallas-plugin-dream)
+- [牛牛做梦插件仓库](https://github.com/PallasBot/Plugin-Dream)

--- a/docs/plugins/duel/README.md
+++ b/docs/plugins/duel/README.md
@@ -76,4 +76,4 @@ uv run python scripts/fetch_arknights_duel_data.py
 
 - [命令权限说明](../common/cmd_perm/README.md)
 - [安装插件](../guide/install-plugins.md)
-- [牛牛决斗插件仓库](https://github.com/TogetsuDo/pallas-plugin-duel)
+- [牛牛决斗插件仓库](https://github.com/PallasBot/Plugin-Duel)

--- a/docs/plugins/maa/README.md
+++ b/docs/plugins/maa/README.md
@@ -96,5 +96,5 @@
 
 - [插件文档索引](../README.md)
 - [命令权限说明](../common/cmd_perm/README.md)
-- [MAA 插件仓库](https://github.com/TogetsuDo/pallas-plugin-maa)
+- [MAA 插件仓库](https://github.com/PallasBot/Plugin-Maa)
 - [MAA 远程控制协议](https://docs.maa.plus/zh-cn/protocol/remote-control-schema.html)

--- a/docs/plugins/pb_protocol/README.md
+++ b/docs/plugins/pb_protocol/README.md
@@ -71,4 +71,4 @@
 ## 相关链接
 
 - [重新上号说明](../relogin_bot/README.md)
-- [协议端管理插件仓库](https://github.com/TogetsuDo/pallas-plugin-protocol)
+- [协议端管理插件仓库](https://github.com/PallasBot/Plugin-Protocol)

--- a/docs/plugins/relogin_bot/README.md
+++ b/docs/plugins/relogin_bot/README.md
@@ -66,4 +66,4 @@
 
 - [命令权限说明](../common/cmd_perm/README.md)
 - [协议端管理说明](../pb_protocol/README.md)
-- [重新上号插件仓库](https://github.com/TogetsuDo/pallas-plugin-protocol)
+- [重新上号插件仓库](https://github.com/PallasBot/Plugin-Protocol)

--- a/docs/plugins/sing/README.md
+++ b/docs/plugins/sing/README.md
@@ -73,5 +73,5 @@
 
 - [命令权限说明](../common/cmd_perm/README.md)
 - [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)
-- [牛牛唱歌插件仓库](https://github.com/TogetsuDo/pallas-plugin-ai-media)
+- [牛牛唱歌插件仓库](https://github.com/PallasBot/Plugin-Ai-Media)
 - [智能对话 / 酒后](../llm_chat/README.md)

--- a/docs/plugins/who_is_spy/README.md
+++ b/docs/plugins/who_is_spy/README.md
@@ -77,4 +77,4 @@
 ## 相关链接
 
 - [命令权限说明](../common/cmd_perm/README.md)
-- [牛牛卧底插件仓库](https://github.com/TogetsuDo/pallas-plugin-who-is-spy)
+- [牛牛卧底插件仓库](https://github.com/PallasBot/Plugin-Who-Is-Spy)

--- a/pallas/core/platform/bot_runtime/plugin_matrix.py
+++ b/pallas/core/platform/bot_runtime/plugin_matrix.py
@@ -73,14 +73,14 @@ EXTRA_PACKAGE_PRIORITY: dict[str, str] = {
 }
 
 OFFICIAL_EXTENSION_REPOS: dict[str, str] = {
-    "pallas-plugin-protocol": "https://github.com/TogetsuDo/pallas-plugin-protocol",
-    "pallas-plugin-duel": "https://github.com/TogetsuDo/pallas-plugin-duel",
-    "pallas-plugin-maa": "https://github.com/TogetsuDo/pallas-plugin-maa",
-    "pallas-plugin-who-is-spy": "https://github.com/TogetsuDo/pallas-plugin-who-is-spy",
-    "pallas-plugin-dream": "https://github.com/TogetsuDo/pallas-plugin-dream",
-    "pallas-plugin-draw": "https://github.com/TogetsuDo/pallas-plugin-draw",
-    "pallas-plugin-ai-media": "https://github.com/TogetsuDo/pallas-plugin-ai-media",
-    "pallas-plugin-bot-status": "https://github.com/TogetsuDo/pallas-plugin-bot-status",
+    "pallas-plugin-protocol": "https://github.com/PallasBot/Plugin-Protocol",
+    "pallas-plugin-duel": "https://github.com/PallasBot/Plugin-Duel",
+    "pallas-plugin-maa": "https://github.com/PallasBot/Plugin-Maa",
+    "pallas-plugin-who-is-spy": "https://github.com/PallasBot/Plugin-Who-Is-Spy",
+    "pallas-plugin-dream": "https://github.com/PallasBot/Plugin-Dream",
+    "pallas-plugin-draw": "https://github.com/PallasBot/Plugin-Draw",
+    "pallas-plugin-ai-media": "https://github.com/PallasBot/Plugin-Ai-Media",
+    "pallas-plugin-bot-status": "https://github.com/PallasBot/Plugin-Bot-Status",
 }
 
 OFFICIAL_EXTENSION_ACTIVATION_POLICY: dict[str, ActivationPolicy] = {
@@ -197,7 +197,7 @@ def official_extension_repo_url(package: str) -> str | None:
     return OFFICIAL_EXTENSION_REPOS.get((package or "").strip())
 
 
-_OFFICIAL_EXTENSION_REPO_OWNER = "TogetsuDo"
+_OFFICIAL_EXTENSION_REPO_OWNER = "PallasBot"
 _OFFICIAL_EXTENSION_DEFAULT_REF = "main"
 _OFFICIAL_EXTENSION_BRAND_AVATAR_PATH = "assets/brand-avatar.png"
 _README_CENTERED_PARAGRAPH_RE = re.compile(r"<p\s+align=[\"']center[\"']>(.*?)</p>", flags=re.IGNORECASE | re.DOTALL)

--- a/tests/common/test_plugin_catalog.py
+++ b/tests/common/test_plugin_catalog.py
@@ -342,8 +342,8 @@ def test_catalog_row_reuses_official_extension_visuals(monkeypatch) -> None:
         lambda plugin_id: (
             {
                 "avatar": None,
-                "icon": "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-draw/main/assets/brand-avatar.png",
-                "cover": "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-draw/main/assets/brand-avatar.png",
+                "icon": "https://raw.githubusercontent.com/PallasBot/Plugin-Draw/main/assets/brand-avatar.png",
+                "cover": "https://raw.githubusercontent.com/PallasBot/Plugin-Draw/main/assets/brand-avatar.png",
             }
             if plugin_id == "draw"
             else {"avatar": None, "icon": None, "cover": None}
@@ -354,8 +354,8 @@ def test_catalog_row_reuses_official_extension_visuals(monkeypatch) -> None:
     row = next(r for r in rows if r["name"] == "draw")
 
     assert row["avatar"] in (None, "")
-    assert row["icon"] == "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-draw/main/assets/brand-avatar.png"
-    assert row["cover"] == "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-draw/main/assets/brand-avatar.png"
+    assert row["icon"] == "https://raw.githubusercontent.com/PallasBot/Plugin-Draw/main/assets/brand-avatar.png"
+    assert row["cover"] == "https://raw.githubusercontent.com/PallasBot/Plugin-Draw/main/assets/brand-avatar.png"
 
 
 def test_catalog_row_reuses_community_plugin_visuals(monkeypatch) -> None:

--- a/tests/common/test_plugin_docs_readme.py
+++ b/tests/common/test_plugin_docs_readme.py
@@ -31,14 +31,14 @@ def test_normalize_bundled_readme_rewrites_plugin_relative_assets() -> None:
 def test_normalize_bundled_readme_uses_official_extension_cover_for_maa() -> None:
     md = '<p align="center"><img src="../assets/brand-avatar.png" width="220" alt="MAA"></p>'
     out = normalize_bundled_plugin_readme_markdown("maa", md)
-    assert "raw.githubusercontent.com/TogetsuDo/pallas-plugin-maa/main/assets/brand-avatar.png" in out
+    assert "raw.githubusercontent.com/PallasBot/Plugin-Maa/main/assets/brand-avatar.png" in out
     assert "/pallas/assets/brand-avatar.png" not in out
 
 
-def test_normalize_bundled_readme_uses_official_extension_cover_for_chat() -> None:
-    md = '<p align="center"><img src="../assets/brand-avatar.png" width="220" alt="chat"></p>'
-    out = normalize_bundled_plugin_readme_markdown("chat", md)
-    assert "raw.githubusercontent.com/TogetsuDo/pallas-plugin-ai-media/main/assets/brand-avatar.png" in out
+def test_normalize_bundled_readme_uses_official_extension_cover_for_sing() -> None:
+    md = '<p align="center"><img src="../assets/brand-avatar.png" width="220" alt="sing"></p>'
+    out = normalize_bundled_plugin_readme_markdown("sing", md)
+    assert "raw.githubusercontent.com/PallasBot/Plugin-Ai-Media/main/assets/brand-avatar.png" in out
     assert "/pallas/assets/brand-avatar.png" not in out
 
 

--- a/tests/common/test_plugin_matrix.py
+++ b/tests/common/test_plugin_matrix.py
@@ -193,5 +193,5 @@ def test_official_extension_visuals_use_official_repo_assets() -> None:
     assert visuals["icon"] == visuals["cover"]
     assert (
         visuals["cover"]
-        == "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-draw/main/assets/brand-avatar.png"
+        == "https://raw.githubusercontent.com/PallasBot/Plugin-Draw/main/assets/brand-avatar.png"
     )

--- a/tests/common/test_plugin_registry.py
+++ b/tests/common/test_plugin_registry.py
@@ -35,9 +35,9 @@ def test_build_official_extension_rows_include_visuals():
     rows = build_official_extension_rows()
     duel = next(r for r in rows if r["package"] == "pallas-plugin-duel")
     assert duel["icon"]
-    assert "pallas-plugin-duel" in duel["icon"]
+    assert "Plugin-Duel" in duel["icon"]
     assert duel["cover"]
-    assert "pallas-plugin-duel" in duel["cover"] or "brand-avatar" in duel["cover"]
+    assert "Plugin-Duel" in duel["cover"] or "brand-avatar" in duel["cover"]
     assert duel["description"] == "泰拉风味多幕决斗，带剧情事件、抢答和八角笼玩法。"
     assert duel["display_name"] == "牛牛决斗"
     assert duel["avatar"] is None

--- a/tests/common/test_plugin_registry.py
+++ b/tests/common/test_plugin_registry.py
@@ -35,9 +35,9 @@ def test_build_official_extension_rows_include_visuals():
     rows = build_official_extension_rows()
     duel = next(r for r in rows if r["package"] == "pallas-plugin-duel")
     assert duel["icon"]
-    assert "Plugin-Duel" in duel["icon"]
+    assert "duel" in duel["icon"].lower() or "brand-avatar" in duel["icon"]
     assert duel["cover"]
-    assert "Plugin-Duel" in duel["cover"] or "brand-avatar" in duel["cover"]
+    assert "duel" in duel["cover"].lower() or "brand-avatar" in duel["cover"]
     assert duel["description"] == "泰拉风味多幕决斗，带剧情事件、抢答和八角笼玩法。"
     assert duel["display_name"] == "牛牛决斗"
     assert duel["avatar"] is None

--- a/tests/common/test_plugin_registry.py
+++ b/tests/common/test_plugin_registry.py
@@ -26,7 +26,7 @@ def test_build_official_extension_rows_marks_bundled_duel():
     assert isinstance(duel["bundled_plugin_ids"], list)
     assert duel["status"] in ("bundled", "bundled_active", "installed", "pip_installed", "external")
     assert isinstance(duel["installed"], bool)
-    assert duel["repository_url"] == "https://github.com/TogetsuDo/pallas-plugin-duel"
+    assert duel["repository_url"] == "https://github.com/PallasBot/Plugin-Duel"
     assert duel["install_cli"] == "uv run pallas ext install pallas-plugin-duel"
     assert duel["activation_policy"] == "workers-restart"
 
@@ -48,7 +48,7 @@ def test_build_official_extension_rows_ai_media_cover():
     ai = next(r for r in rows if r["package"] == "pallas-plugin-ai-media")
     assert ai["cover"]
     assert ai["cover"] in (
-        "https://raw.githubusercontent.com/TogetsuDo/pallas-plugin-ai-media/main/assets/brand-avatar.png",
+        "https://raw.githubusercontent.com/PallasBot/Plugin-Ai-Media/main/assets/brand-avatar.png",
         "/pallas/store-assets/cover/official-pallas-plugin-ai-media.png",
     )
 
@@ -73,11 +73,11 @@ def test_build_official_extension_rows_prefers_cached_asset_urls(monkeypatch):
 def test_build_official_extension_rows_p0_repo_urls():
     rows = build_official_extension_rows()
     by_pkg = {r["package"]: r["repository_url"] for r in rows}
-    assert by_pkg["pallas-plugin-protocol"] == "https://github.com/TogetsuDo/pallas-plugin-protocol"
-    assert by_pkg["pallas-plugin-maa"] == "https://github.com/TogetsuDo/pallas-plugin-maa"
-    assert by_pkg["pallas-plugin-who-is-spy"] == "https://github.com/TogetsuDo/pallas-plugin-who-is-spy"
-    assert by_pkg.get("pallas-plugin-draw") == "https://github.com/TogetsuDo/pallas-plugin-draw"
-    assert by_pkg.get("pallas-plugin-dream") == "https://github.com/TogetsuDo/pallas-plugin-dream"
+    assert by_pkg["pallas-plugin-protocol"] == "https://github.com/PallasBot/Plugin-Protocol"
+    assert by_pkg["pallas-plugin-maa"] == "https://github.com/PallasBot/Plugin-Maa"
+    assert by_pkg["pallas-plugin-who-is-spy"] == "https://github.com/PallasBot/Plugin-Who-Is-Spy"
+    assert by_pkg.get("pallas-plugin-draw") == "https://github.com/PallasBot/Plugin-Draw"
+    assert by_pkg.get("pallas-plugin-dream") == "https://github.com/PallasBot/Plugin-Dream"
     assert "pallas-plugin-llm-chat" not in by_pkg
 
 


### PR DESCRIPTION
官方插件仓已迁入 `PallasBot` 并改名为 `Plugin-*`。本 PR 更新矩阵仓库地址、文档链接与相关测试；PyPI / 安装包名仍为 `pallas-plugin-*`。

画画仓若尚未改名为 `Plugin-Draw`，对应 raw/仓库链在改名前会短暂不可用。

## Summary by Sourcery

更新官方插件的元数据、文档和测试，以反映扩展仓库迁移到 PallasBot/Plugin-* GitHub 组织及新的命名方案。

增强功能：
- 刷新插件矩阵中的官方扩展仓库 URL 和所有者，使其指向 PallasBot/Plugin-* 仓库。

文档：
- 更新开发者和插件文档，以引用新的 PallasBot/Plugin-* 仓库，并澄清 GitHub 仓库名称与 PyPI 包名称之间的区别。

测试：
- 调整插件注册表、目录、矩阵以及 README 规范化测试，以针对新的官方仓库和原始资源 URL 进行断言，包括 sing 插件封面映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update official plugin metadata, docs, and tests to reflect migration of extension repositories to the PallasBot/Plugin-* GitHub org and naming scheme.

Enhancements:
- Refresh official extension repository URLs and owner in the plugin matrix to point to PallasBot/Plugin-* repos.

Documentation:
- Update developer and plugin documentation to reference the new PallasBot/Plugin-* repositories and clarify the difference between GitHub repo names and PyPI package names.

Tests:
- Adjust plugin registry, catalog, matrix, and README normalization tests to assert against the new official repository and raw asset URLs, including the sing plugin cover mapping.

</details>