### PR TITLE
fix(docs): FILE_MAP 登记 llm-output-path 同步项

### DIFF
--- a/tools/scripts/sync_docs_to_web.py
+++ b/tools/scripts/sync_docs_to_web.py
@@ -53,6 +53,7 @@ FILE_MAP: dict[str, str] = {
     "developer/architecture/config-storage.md": "developer/architecture/config-storage.md",
     "developer/architecture/plugin-governance.md": "developer/architecture/plugin-governance.md",
     "developer/architecture/shard-runtime.md": "developer/architecture/shard-runtime.md",
+    "developer/architecture/llm-output-path.md": "developer/architecture/llm-output-path.md",
     "developer/plugin-development/getting-started.md": (
         "developer/plugin-development/getting-started.md"
     ),


### PR DESCRIPTION
主仓已有 `docs/developer/architecture/llm-output-path.md`，但 docs 同步脚本未登记，导致 Docs 站死链、CI 失败。本次补上 `FILE_MAP` 条目，避免再次漏同步。