### PR TITLE
feat(community): 投稿墙 API 与备案域清理

### DIFF
--- a/docs/common/corpus.md
+++ b/docs/common/corpus.md
@@ -19,9 +19,8 @@
 | 用途 | 地址 |
 | --- | --- |
 | 在线统计与语料 API | `https://stats.pallasbot.top` |
-| 备案过渡期备用 | `https://pallas.togetsudo.com` |
 
-Bot 在 auto enroll 下会从心跳地址推导语料 URL；读路径按主/备顺序 failover，与在线统计一致。
+Bot 在 auto enroll 下会从心跳地址推导语料 URL。
 
 ## 配置
 

--- a/docs/common/corpus/README.md
+++ b/docs/common/corpus/README.md
@@ -19,9 +19,8 @@
 | 用途 | 地址 |
 | --- | --- |
 | 在线统计与语料 API | `https://stats.pallasbot.top` |
-| 备案过渡期备用 | `https://pallas.togetsudo.com` |
 
-Bot 在 auto enroll 下会从心跳地址推导语料 URL；读路径按主/备顺序 failover，与在线统计一致。
+Bot 在 auto enroll 下会从心跳地址推导语料 URL。
 
 ## 配置
 

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.1.1-5-g8c0cf92e",
+    "version": "v4.1.1-16-g33ba378c",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -5541,6 +5541,233 @@
               "minimum": 5,
               "default": 40,
               "title": "Limit"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/community-gallery": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Community Gallery List",
+        "operationId": "_community_gallery_list_pallas_api_community_gallery_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 48,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "mine",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Mine"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Community Gallery Create",
+        "operationId": "_community_gallery_create_pallas_api_community_gallery_post",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body__community_gallery_create_pallas_api_community_gallery_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/community-gallery/{post_id}": {
+      "delete": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Community Gallery Delete",
+        "operationId": "_community_gallery_delete_pallas_api_community_gallery__post_id__delete",
+        "parameters": [
+          {
+            "name": "post_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Post Id"
             }
           },
           {
@@ -18664,6 +18891,60 @@
   },
   "components": {
     "schemas": {
+      "Body__community_gallery_create_pallas_api_community_gallery_post": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "default": ""
+          },
+          "nickname": {
+            "type": "string",
+            "title": "Nickname",
+            "default": ""
+          },
+          "avatar_url": {
+            "type": "string",
+            "title": "Avatar Url",
+            "default": ""
+          },
+          "bot_qq": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bot Qq"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "manual"
+          },
+          "keywords": {
+            "type": "string",
+            "title": "Keywords",
+            "default": ""
+          },
+          "image": {
+            "anyOf": [
+              {
+                "type": "string",
+                "contentMediaType": "application/octet-stream"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image"
+          }
+        },
+        "type": "object",
+        "title": "Body__community_gallery_create_pallas_api_community_gallery_post"
+      },
       "GitMirrorApplyPluginBody": {
         "properties": {
           "preferred_id": {

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -5317,7 +5317,7 @@ def register_extended_api(
     @router.post(f"{x}/community-gallery", include_in_schema=True)
     async def _community_gallery_create(
         text: str = Form(default=""),
-        nickname: str = Form(...),
+        nickname: str = Form(default=""),
         avatar_url: str = Form(default=""),
         bot_qq: int | None = Form(default=None),
         source: str = Form(default="manual"),
@@ -5339,7 +5339,7 @@ def register_extended_api(
         try:
             data = await create_gallery_post(
                 text=text,
-                nickname=nickname,
+                nickname=(nickname or "").strip() or "牛牛",
                 avatar_url=avatar_url,
                 bot_qq=bot_qq,
                 source=source,

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -19,7 +19,7 @@ from operator import itemgetter
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, File, Form, Header, HTTPException, Query, Request, UploadFile
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from nonebot import get_bots, get_driver, logger
@@ -5298,6 +5298,75 @@ def register_extended_api(
 
         cache_key = f"community-corpus-hot:{mode_norm}:{period_norm}:{limit}"
         data = await cached_read(key=cache_key, loader=_load, ttl_sec=120.0, stale_sec=300.0)
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.get(f"{x}/community-gallery", include_in_schema=True)
+    async def _community_gallery_list(
+        limit: int = Query(default=48, ge=1, le=100),
+        mine: bool = Query(default=False),
+    ) -> JSONResponse:
+        from pallas.product.community_stats.gallery_client import list_gallery_posts
+
+        try:
+            data = await list_gallery_posts(limit=limit, mine=mine)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Pallas-Bot 控制台: 社区投稿列表失败")
+            raise HTTPException(status_code=502, detail=f"社区投稿列表失败: {e}") from e
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.post(f"{x}/community-gallery", include_in_schema=True)
+    async def _community_gallery_create(
+        text: str = Form(default=""),
+        nickname: str = Form(...),
+        avatar_url: str = Form(default=""),
+        bot_qq: int | None = Form(default=None),
+        source: str = Form(default="manual"),
+        keywords: str = Form(default=""),
+        image: UploadFile | None = File(default=None),  # noqa: B008
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        _check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        from pallas.product.community_stats.gallery_client import create_gallery_post
+
+        image_bytes = None
+        image_filename = None
+        image_content_type = None
+        if image is not None and image.filename:
+            image_bytes = await image.read()
+            image_filename = image.filename
+            image_content_type = image.content_type
+        try:
+            data = await create_gallery_post(
+                text=text,
+                nickname=nickname,
+                avatar_url=avatar_url,
+                bot_qq=bot_qq,
+                source=source,
+                keywords=keywords,
+                image_bytes=image_bytes,
+                image_filename=image_filename,
+                image_content_type=image_content_type,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Pallas-Bot 控制台: 社区投稿失败")
+            raise HTTPException(status_code=502, detail=f"社区投稿失败: {e}") from e
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.delete(f"{x}/community-gallery/{{post_id}}", include_in_schema=True)
+    async def _community_gallery_delete(
+        post_id: str,
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        _check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        from pallas.product.community_stats.gallery_client import delete_gallery_post
+
+        try:
+            data = await delete_gallery_post(post_id)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Pallas-Bot 控制台: 社区投稿撤下失败")
+            raise HTTPException(status_code=502, detail=f"社区投稿撤下失败: {e}") from e
         return JSONResponse({"ok": True, "data": data})
 
     @router.get(f"{x}/local-corpus-hot", include_in_schema=True)

--- a/pallas/product/community_stats/connectivity_probe.py
+++ b/pallas/product/community_stats/connectivity_probe.py
@@ -10,7 +10,6 @@ from nonebot import logger
 
 from pallas.product.community_stats.config import get_community_stats_config
 from pallas.product.community_stats.endpoints import (
-    FALLBACK_HEARTBEAT,
     PRIMARY_HEARTBEAT,
     custom_heartbeat_url,
 )
@@ -22,15 +21,12 @@ _PROBE_TIMEOUT_SEC = 8.0
 
 
 def connectivity_probe_urls() -> list[str]:
-    """自动模式固定主+备；自定义 endpoint 只测一条。"""
+    """自动模式探测正式中心；自定义 endpoint 只测一条。"""
     cfg = get_community_stats_config()
     custom = custom_heartbeat_url(cfg)
     if custom:
         return [stats_url_from_endpoint(custom)]
-    return [
-        stats_url_from_endpoint(PRIMARY_HEARTBEAT),
-        stats_url_from_endpoint(FALLBACK_HEARTBEAT),
-    ]
+    return [stats_url_from_endpoint(PRIMARY_HEARTBEAT)]
 
 
 def _error_text(exc: BaseException) -> str:

--- a/pallas/product/community_stats/endpoints.py
+++ b/pallas/product/community_stats/endpoints.py
@@ -1,24 +1,20 @@
-"""社区统计心跳 / stats 地址：正式域名 + 备案前备用，自动切换。"""
+"""社区统计心跳 / stats 地址。"""
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING
-
-from pallas.product.community_stats.store import load_community_stats_state
 
 if TYPE_CHECKING:
     from pallas.product.community_stats.config import CommunityStatsConfig
 
 PRIMARY_HEARTBEAT = "https://stats.pallasbot.top/v1/heartbeat"
-FALLBACK_HEARTBEAT = "https://pallas.togetsudo.com/v1/heartbeat"
 PRIMARY_CORPUS_API_BASE = "https://stats.pallasbot.top/v1/corpus"
-FALLBACK_CORPUS_API_BASE = "https://pallas.togetsudo.com/v1/corpus"
 
-_BUILTIN_HEARTBEATS: frozenset[str] = frozenset({PRIMARY_HEARTBEAT, FALLBACK_HEARTBEAT})
-
-# 走备用入口时，每隔若干秒再探测一次正式域名是否已可用
-_PRIMARY_REPROBE_SEC = 6 * 3600
+# 历史备案备用域：仅识别为「自动模式」并改走正式中心，不再请求。
+_LEGACY_FALLBACK_HEARTBEATS: frozenset[str] = frozenset({
+    "https://pallas.togetsudo.com/v1/heartbeat",
+    "http://pallas.togetsudo.com/v1/heartbeat",
+})
 
 
 def normalize_heartbeat_url(url: str) -> str:
@@ -26,11 +22,11 @@ def normalize_heartbeat_url(url: str) -> str:
 
 
 def is_auto_endpoint_mode(cfg: CommunityStatsConfig) -> bool:
-    """未配置自定义 endpoint，或仍为内置主/备地址之一。"""
+    """未配置自定义 endpoint，或仍为正式中心 / 历史备用域之一。"""
     ep = normalize_heartbeat_url(cfg.endpoint)
-    if not ep:
+    if not ep or ep == PRIMARY_HEARTBEAT:
         return True
-    return ep in _BUILTIN_HEARTBEATS
+    return ep in _LEGACY_FALLBACK_HEARTBEATS
 
 
 def custom_heartbeat_url(cfg: CommunityStatsConfig) -> str | None:
@@ -42,24 +38,11 @@ def custom_heartbeat_url(cfg: CommunityStatsConfig) -> str | None:
     return ep + "/heartbeat" if ep else None
 
 
-def should_reprobe_primary(*, last_probe_unix: int) -> bool:
-    if last_probe_unix <= 0:
-        return True
-    return int(time.time()) - last_probe_unix >= _PRIMARY_REPROBE_SEC
-
-
 def heartbeat_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:
     custom = custom_heartbeat_url(cfg)
     if custom:
         return [custom]
-    state = load_community_stats_state()
-    active = normalize_heartbeat_url(str(state.get("heartbeat_endpoint") or ""))
-    last_probe = int(state.get("last_primary_probe_unix") or 0)
-    primary = PRIMARY_HEARTBEAT
-    fallback = FALLBACK_HEARTBEAT
-    if active == fallback and not should_reprobe_primary(last_probe_unix=last_probe):
-        return [fallback]
-    return [primary, fallback]
+    return [PRIMARY_HEARTBEAT]
 
 
 def stats_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:
@@ -97,7 +80,7 @@ def corpus_api_base_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:
     custom = custom_heartbeat_url(cfg)
     if custom:
         return [corpus_api_base_from_heartbeat(custom)]
-    return [corpus_api_base_from_heartbeat(u) for u in heartbeat_urls_for_config(cfg)]
+    return [PRIMARY_CORPUS_API_BASE]
 
 
 def gallery_posts_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:

--- a/pallas/product/community_stats/endpoints.py
+++ b/pallas/product/community_stats/endpoints.py
@@ -98,3 +98,9 @@ def corpus_api_base_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:
     if custom:
         return [corpus_api_base_from_heartbeat(custom)]
     return [corpus_api_base_from_heartbeat(u) for u in heartbeat_urls_for_config(cfg)]
+
+
+def gallery_posts_urls_for_config(cfg: CommunityStatsConfig) -> list[str]:
+    from pallas.product.community_stats.stats_url import gallery_posts_url_from_endpoint
+
+    return [gallery_posts_url_from_endpoint(u) for u in heartbeat_urls_for_config(cfg)]

--- a/pallas/product/community_stats/gallery_client.py
+++ b/pallas/product/community_stats/gallery_client.py
@@ -1,0 +1,130 @@
+"""向社区中心投稿墙读写代理。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from nonebot import logger
+
+from pallas.product.community_stats.config import get_community_stats_config
+from pallas.product.community_stats.endpoints import gallery_posts_urls_for_config
+from pallas.product.community_stats.store import load_or_create_deployment_id
+from pallas.product.corpus.config import resolved_community_token
+from pallas.product.message_scrub.quiet_http_loggers import scrub_http_log_noise
+
+_TIMEOUT_SEC = 20.0
+
+
+def _auth_headers() -> dict[str, str]:
+    token = resolved_community_token()
+    if not token:
+        cfg = get_community_stats_config()
+        token = str(cfg.token or "").strip()
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+async def list_gallery_posts(*, limit: int = 48, mine: bool = False) -> dict[str, Any]:
+    cfg = get_community_stats_config()
+    urls = gallery_posts_urls_for_config(cfg)
+    if not urls:
+        raise RuntimeError("gallery endpoint unavailable")
+    params: dict[str, Any] = {"limit": limit}
+    if mine:
+        params["deployment_id"] = load_or_create_deployment_id()
+    scrub_http_log_noise()
+    last_err: Exception | None = None
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SEC) as client:
+        for url in urls:
+            try:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+                if isinstance(data, dict):
+                    return data
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                logger.debug("community gallery list failed url={} err={}", url, e)
+    raise RuntimeError(f"gallery list failed: {last_err}")
+
+
+async def create_gallery_post(
+    *,
+    text: str,
+    nickname: str,
+    avatar_url: str = "",
+    bot_qq: int | None = None,
+    source: str = "manual",
+    keywords: str = "",
+    image_bytes: bytes | None = None,
+    image_filename: str | None = None,
+    image_content_type: str | None = None,
+) -> dict[str, Any]:
+    cfg = get_community_stats_config()
+    urls = gallery_posts_urls_for_config(cfg)
+    if not urls:
+        raise RuntimeError("gallery endpoint unavailable")
+    dep = load_or_create_deployment_id()
+    headers = _auth_headers()
+    data = {
+        "deployment_id": dep,
+        "text": text or "",
+        "nickname": nickname or "",
+        "avatar_url": avatar_url or "",
+        "source": source or "manual",
+        "keywords": keywords or "",
+    }
+    if bot_qq is not None:
+        data["bot_qq"] = str(int(bot_qq))
+    files = None
+    if image_bytes:
+        files = {
+            "image": (
+                image_filename or "upload.bin",
+                image_bytes,
+                image_content_type or "application/octet-stream",
+            )
+        }
+    scrub_http_log_noise()
+    last_err: Exception | None = None
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SEC) as client:
+        for url in urls:
+            try:
+                resp = await client.post(url, data=data, files=files, headers=headers)
+                if resp.status_code >= 400:
+                    detail = resp.text[:240]
+                    raise RuntimeError(f"gallery create HTTP {resp.status_code}: {detail}")
+                payload = resp.json()
+                if isinstance(payload, dict):
+                    return payload
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                logger.debug("community gallery create failed url={} err={}", url, e)
+    raise RuntimeError(f"gallery create failed: {last_err}")
+
+
+async def delete_gallery_post(post_id: str) -> dict[str, Any]:
+    cfg = get_community_stats_config()
+    urls = gallery_posts_urls_for_config(cfg)
+    if not urls:
+        raise RuntimeError("gallery endpoint unavailable")
+    dep = load_or_create_deployment_id()
+    headers = _auth_headers()
+    scrub_http_log_noise()
+    last_err: Exception | None = None
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SEC) as client:
+        for base in urls:
+            url = f"{base.rstrip('/')}/{post_id.strip()}"
+            try:
+                resp = await client.delete(url, params={"deployment_id": dep}, headers=headers)
+                if resp.status_code >= 400:
+                    raise RuntimeError(f"gallery delete HTTP {resp.status_code}: {resp.text[:240]}")
+                payload = resp.json()
+                if isinstance(payload, dict):
+                    return payload
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                logger.debug("community gallery delete failed url={} err={}", url, e)
+    raise RuntimeError(f"gallery delete failed: {last_err}")

--- a/pallas/product/community_stats/reporter.py
+++ b/pallas/product/community_stats/reporter.py
@@ -14,8 +14,6 @@ from pallas.core.platform.shard import context as shard_ctx
 from pallas.core.platform.shard.registry.store import get_shard_registry, is_test_shard_record
 from pallas.product.community_stats.config import CommunityStatsConfig, get_community_stats_config
 from pallas.product.community_stats.endpoints import (
-    FALLBACK_HEARTBEAT,
-    PRIMARY_HEARTBEAT,
     heartbeat_urls_for_config,
     is_auto_endpoint_mode,
 )
@@ -28,7 +26,6 @@ from pallas.product.community_stats.store import (
 from pallas.product.message_scrub.quiet_http_loggers import scrub_http_log_noise
 
 _HTTP_TIMEOUT_SEC = 15.0
-_PROBE_TIMEOUT_SEC = 8.0
 
 
 def should_run_community_stats_reporter() -> bool:
@@ -131,7 +128,7 @@ async def send_community_stats_heartbeat() -> bool:
     if not urls:
         logger.warning("community_stats: no endpoint configured, skip heartbeat")
         return False
-    if is_auto_endpoint_mode(cfg) and urls[0] == PRIMARY_HEARTBEAT:
+    if is_auto_endpoint_mode(cfg):
         touch_primary_probe_unix()
     show_qq_by_account: dict[int, bool] | None = None
     if cfg.roster_public:
@@ -148,12 +145,15 @@ async def send_community_stats_heartbeat() -> bool:
     try:
         async with scrub_http_log_noise():
             async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SEC) as client:
-                for i, endpoint in enumerate(urls):
-                    timeout = _PROBE_TIMEOUT_SEC if i == 0 and len(urls) > 1 else _HTTP_TIMEOUT_SEC
+                for endpoint in urls:
                     try:
-                        if await _post_heartbeat(client, endpoint, payload=payload, cfg=cfg, timeout_sec=timeout):
-                            if is_auto_endpoint_mode(cfg) and endpoint == FALLBACK_HEARTBEAT and i > 0:
-                                logger.info("community_stats: primary endpoint unavailable, using fallback")
+                        if await _post_heartbeat(
+                            client,
+                            endpoint,
+                            payload=payload,
+                            cfg=cfg,
+                            timeout_sec=_HTTP_TIMEOUT_SEC,
+                        ):
                             return True
                     except httpx.HTTPError as e:
                         logger.warning(f"community_stats: heartbeat failed endpoint={endpoint}: {e}")

--- a/pallas/product/community_stats/stats_url.py
+++ b/pallas/product/community_stats/stats_url.py
@@ -48,3 +48,17 @@ def corpus_hot_url_from_endpoint(heartbeat_endpoint: str) -> str:
         root = f"{parsed.scheme}://{parsed.netloc}"
         return urljoin(root + "/", "v1/corpus/hot")
     return "https://stats.pallasbot.top/v1/corpus/hot"
+
+
+def gallery_posts_url_from_endpoint(heartbeat_endpoint: str) -> str:
+    ep = (heartbeat_endpoint or "").strip()
+    if not ep:
+        return "https://stats.pallasbot.top/v1/gallery/posts"
+    norm = ep.rstrip("/")
+    if norm.endswith("/heartbeat"):
+        return norm[: -len("/heartbeat")] + "/gallery/posts"
+    parsed = urlparse(ep)
+    if parsed.scheme and parsed.netloc:
+        root = f"{parsed.scheme}://{parsed.netloc}"
+        return urljoin(root + "/", "v1/gallery/posts")
+    return "https://stats.pallasbot.top/v1/gallery/posts"

--- a/tests/common/corpus/test_community_source.py
+++ b/tests/common/corpus/test_community_source.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from pallas.product.community_stats.endpoints import FALLBACK_CORPUS_API_BASE, PRIMARY_CORPUS_API_BASE
+from pallas.product.community_stats.endpoints import PRIMARY_CORPUS_API_BASE
 from pallas.product.corpus.community_source import RemoteCorpusRepository
 
 
@@ -35,7 +35,8 @@ def open_remote_corpus_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_find_by_keywords_failover_to_fallback():
+async def test_find_by_keywords_failover_to_secondary_base():
+    secondary = "https://stats.example/v1/corpus"
     calls: list[str] = []
 
     async def fake_get(self, url, **kwargs):
@@ -55,7 +56,7 @@ async def test_find_by_keywords_failover_to_fallback():
         return mock
 
     repo = RemoteCorpusRepository(
-        api_bases=[PRIMARY_CORPUS_API_BASE, FALLBACK_CORPUS_API_BASE],
+        api_bases=[PRIMARY_CORPUS_API_BASE, secondary],
         token="pc_test",
     )
     with patch.object(httpx.AsyncClient, "get", fake_get):
@@ -63,7 +64,7 @@ async def test_find_by_keywords_failover_to_fallback():
     assert ctx is not None
     assert ctx.keywords == "test"
     assert calls[0] == f"{PRIMARY_CORPUS_API_BASE}/context"
-    assert calls[1] == f"{FALLBACK_CORPUS_API_BASE}/context"
+    assert calls[1] == f"{secondary}/context"
 
 
 @pytest.mark.asyncio
@@ -80,8 +81,9 @@ async def test_find_by_keywords_404_returns_none():
 
 @pytest.mark.asyncio
 async def test_find_by_keywords_all_bases_fail_raises():
+    secondary = "https://stats.example/v1/corpus"
     repo = RemoteCorpusRepository(
-        api_bases=[PRIMARY_CORPUS_API_BASE, FALLBACK_CORPUS_API_BASE],
+        api_bases=[PRIMARY_CORPUS_API_BASE, secondary],
         token="pc_test",
     )
 

--- a/tests/common/corpus/test_enroll.py
+++ b/tests/common/corpus/test_enroll.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from pallas.product.community_stats.endpoints import FALLBACK_HEARTBEAT, PRIMARY_HEARTBEAT
+from pallas.product.community_stats.endpoints import PRIMARY_HEARTBEAT
 from pallas.product.community_stats.store import community_stats_state_path
 from pallas.product.corpus.enroll import enroll_url_from_heartbeat, ensure_corpus_community_enrolled
 from pallas.product.corpus.store import load_corpus_community_state
@@ -73,14 +73,14 @@ async def test_enroll_prefers_derived_api_base_in_auto_mode(tmp_path, monkeypatc
     monkeypatch.setattr("pallas.product.corpus.enroll.should_run_corpus_auto_enroll", lambda: True)
     monkeypatch.setattr(
         "pallas.product.corpus.enroll.corpus_enroll_urls",
-        lambda: [f"{FALLBACK_HEARTBEAT.replace('/heartbeat', '/corpus/enroll')}"],
+        lambda: [f"{PRIMARY_HEARTBEAT.replace('/heartbeat', '/corpus/enroll')}"],
     )
 
     response = httpx.Response(
         200,
         json={
             "corpus_token": "pc_testtoken",
-            "api_base": "https://stats.pallasbot.top/v1/corpus",
+            "api_base": "https://stats.example/v1/corpus",
             "policy": {"read": True, "contribute": True},
         },
     )
@@ -90,7 +90,7 @@ async def test_enroll_prefers_derived_api_base_in_auto_mode(tmp_path, monkeypatc
 
     assert ok is True
     saved = load_corpus_community_state()
-    assert saved["api_base"] == "https://pallas.togetsudo.com/v1/corpus"
+    assert saved["api_base"] == "https://stats.pallasbot.top/v1/corpus"
 
 
 @pytest.mark.asyncio

--- a/tests/common/test_community_connectivity_probe.py
+++ b/tests/common/test_community_connectivity_probe.py
@@ -42,7 +42,7 @@ def _seed_community_state(path: Path, payload: dict) -> None:
 
 
 @pytest.mark.asyncio
-async def test_probe_community_connectivity_auto_mode_covers_primary_and_fallback(
+async def test_probe_community_connectivity_auto_mode_covers_primary(
     community_state_file: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -74,11 +74,9 @@ async def test_probe_community_connectivity_auto_mode_covers_primary_and_fallbac
 
     assert [p["url"] for p in payload["probes"]] == [
         "https://stats.pallasbot.top/v1/stats",
-        "https://pallas.togetsudo.com/v1/stats",
     ]
     assert payload["probes"][0]["ok"] is True
     assert payload["probes"][0]["http_status"] == 200
-    assert payload["probes"][1]["ok"] is False
     assert payload["reporting"]["enabled"] is True
     assert payload["reporting"]["deployment_id"] == "123e4567-e89b-12d3-a456-426614174000"
     assert payload["reporting"]["last_heartbeat_ok_unix"] == 1_700_000_100

--- a/tests/common/test_community_stats.py
+++ b/tests/common/test_community_stats.py
@@ -7,12 +7,11 @@ import pytest
 from pallas.core.foundation.apscheduler_runtime import ensure_apscheduler_running, register_apscheduler_startup_hook
 from pallas.product.community_stats import config as cfg_mod
 from pallas.product.community_stats.endpoints import (
-    FALLBACK_CORPUS_API_BASE,
-    FALLBACK_HEARTBEAT,
     PRIMARY_CORPUS_API_BASE,
     PRIMARY_HEARTBEAT,
     corpus_api_base_from_heartbeat,
     corpus_api_base_urls_for_config,
+    gallery_posts_urls_for_config,
     heartbeat_urls_for_config,
     is_auto_endpoint_mode,
 )
@@ -39,7 +38,7 @@ def test_auto_endpoint_mode_builtin_default(monkeypatch):
     cfg_mod.clear_community_stats_config_cache()
     cfg = cfg_mod.get_community_stats_config()
     assert is_auto_endpoint_mode(cfg) is True
-    assert heartbeat_urls_for_config(cfg)[:2] == [PRIMARY_HEARTBEAT, FALLBACK_HEARTBEAT]
+    assert heartbeat_urls_for_config(cfg) == [PRIMARY_HEARTBEAT]
 
 
 def test_auto_endpoint_custom_url_not_builtin(monkeypatch):
@@ -64,14 +63,45 @@ def test_stats_url_from_heartbeat_endpoint():
 
 def test_corpus_api_base_from_heartbeat():
     assert corpus_api_base_from_heartbeat(PRIMARY_HEARTBEAT) == PRIMARY_CORPUS_API_BASE
-    assert corpus_api_base_from_heartbeat(FALLBACK_HEARTBEAT) == FALLBACK_CORPUS_API_BASE
+    assert (
+        corpus_api_base_from_heartbeat("https://stats.example/v1/heartbeat") == "https://stats.example/v1/corpus"
+    )
 
 
 def test_corpus_api_base_urls_follow_heartbeat_order(monkeypatch):
     monkeypatch.delenv("PALLAS_COMMUNITY_STATS_ENDPOINT", raising=False)
     cfg_mod.clear_community_stats_config_cache()
     cfg = cfg_mod.get_community_stats_config()
-    assert corpus_api_base_urls_for_config(cfg)[:2] == [PRIMARY_CORPUS_API_BASE, FALLBACK_CORPUS_API_BASE]
+    assert corpus_api_base_urls_for_config(cfg) == [PRIMARY_CORPUS_API_BASE]
+
+
+def test_gallery_posts_urls_prefer_primary_center(monkeypatch):
+    monkeypatch.delenv("PALLAS_COMMUNITY_STATS_ENDPOINT", raising=False)
+    cfg_mod.clear_community_stats_config_cache()
+    cfg = cfg_mod.get_community_stats_config()
+    assert gallery_posts_urls_for_config(cfg) == ["https://stats.pallasbot.top/v1/gallery/posts"]
+
+    monkeypatch.setattr(
+        "pallas.product.community_stats.config.repo_env_raw_value",
+        lambda key: "https://stats.example/v1/heartbeat" if key == "PALLAS_COMMUNITY_STATS_ENDPOINT" else None,
+    )
+    cfg_mod.clear_community_stats_config_cache()
+    cfg = cfg_mod.get_community_stats_config()
+    assert gallery_posts_urls_for_config(cfg) == ["https://stats.example/v1/gallery/posts"]
+
+
+def test_legacy_fallback_endpoint_maps_to_primary(monkeypatch):
+    monkeypatch.setattr(
+        "pallas.product.community_stats.config.repo_env_raw_value",
+        lambda key: "https://pallas.togetsudo.com/v1/heartbeat"
+        if key == "PALLAS_COMMUNITY_STATS_ENDPOINT"
+        else None,
+    )
+    cfg_mod.clear_community_stats_config_cache()
+    cfg = cfg_mod.get_community_stats_config()
+    assert is_auto_endpoint_mode(cfg) is True
+    assert heartbeat_urls_for_config(cfg) == [PRIMARY_HEARTBEAT]
+    assert gallery_posts_urls_for_config(cfg) == ["https://stats.pallasbot.top/v1/gallery/posts"]
 
 
 def test_resolved_community_api_base_urls_auto_mode(monkeypatch):
@@ -82,7 +112,7 @@ def test_resolved_community_api_base_urls_auto_mode(monkeypatch):
     cfg_mod.clear_community_stats_config_cache()
     clear_corpus_config_cache()
     urls = resolved_community_api_base_urls()
-    assert urls[:2] == [PRIMARY_CORPUS_API_BASE, FALLBACK_CORPUS_API_BASE]
+    assert urls == [PRIMARY_CORPUS_API_BASE]
 
 
 def test_parse_stats_body():
@@ -510,7 +540,7 @@ def test_config_roster_split_flags(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_heartbeat_fallback_after_primary_fails(monkeypatch, tmp_path):
+async def test_send_heartbeat_records_primary_endpoint(monkeypatch, tmp_path):
     monkeypatch.delenv("PALLAS_COMMUNITY_STATS_ENDPOINT", raising=False)
     cfg_mod.clear_community_stats_config_cache()
     state_path = tmp_path / "pallas_config" / "community_stats.json"
@@ -524,8 +554,6 @@ async def test_send_heartbeat_fallback_after_primary_fails(monkeypatch, tmp_path
     async def fake_post(self, url, **kwargs):
         calls.append(url)
         mock = MagicMock()
-        if url == PRIMARY_HEARTBEAT:
-            raise httpx.ConnectError("ssl eof", request=MagicMock())
         mock.status_code = 200
         mock.text = '{"ok":true}'
         return mock
@@ -543,10 +571,9 @@ async def test_send_heartbeat_fallback_after_primary_fails(monkeypatch, tmp_path
         patch.object(httpx.AsyncClient, "post", fake_post),
     ):
         assert await send_community_stats_heartbeat() is True
-    assert calls[0] == PRIMARY_HEARTBEAT
-    assert calls[1] == FALLBACK_HEARTBEAT
+    assert calls == [PRIMARY_HEARTBEAT]
     raw = json.loads(state_path.read_text(encoding="utf-8"))
-    assert raw["heartbeat_endpoint"] == FALLBACK_HEARTBEAT
+    assert raw["heartbeat_endpoint"] == PRIMARY_HEARTBEAT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
控制台代理社区投稿墙；投稿可不选 Bot；移除备案备用域，心跳固定走正式中心。