### PR TITLE
fix(ingress): 预筛允许命令后紧贴参数

### DIFF
--- a/pallas/core/platform/ingress/matcher_rule_prefilter.py
+++ b/pallas/core/platform/ingress/matcher_rule_prefilter.py
@@ -69,15 +69,12 @@ def normalize_command(text: str) -> str:
 
 
 def command_matches_message(text: str, command: str) -> bool:
+    """预筛：消息是否像该命令（与 NoneBot 一致，命令后可无空白紧贴参数）。"""
     cmd = normalize_command(command)
     if not cmd:
         return False
     normalized = normalize_command(text)
-    if normalized == cmd:
-        return True
-    if normalized.startswith(cmd) and len(normalized) > len(cmd):
-        return normalized[len(cmd)].isspace()
-    return False
+    return normalized == cmd or normalized.startswith(cmd)
 
 
 @lru_cache(maxsize=512)

--- a/tests/platform/ingress/test_matcher_rule_prefilter.py
+++ b/tests/platform/ingress/test_matcher_rule_prefilter.py
@@ -40,6 +40,21 @@ def test_command_rule_match():
     )
 
 
+def test_command_rule_match_without_whitespace_after_command():
+    """与 NoneBot 一致：命令后可紧贴参数（如「牛牛表情搜索急急国王」）。"""
+    descriptors = prefilter.extract_matcher_rule_descriptors(_FooCommandMatcher)
+    assert (
+        prefilter.matcher_rule_decision(
+            descriptors,
+            plain_text="foobar",
+            raw_text="foobar",
+        )
+        == "match"
+    )
+    assert prefilter.command_matches_message("牛牛表情搜索急急国王", "牛牛表情搜索")
+    assert prefilter.command_matches_message("牛牛表情搜索 急急国王", "牛牛表情搜索")
+
+
 def test_startswith_miss():
     descriptors = prefilter.extract_matcher_rule_descriptors(_BarStartMatcher)
     assert (


### PR DESCRIPTION
命令预筛与 NoneBot 一致：命令后可无空白紧贴参数。