### PR TITLE
feat(webui): 暴露 LLM 工具只读清单 API

### DIFF
--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.1.1-36-g5f5ade88",
+    "version": "v4.1.1-39-gcb6d4853-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -13255,6 +13255,69 @@
         ],
         "summary": " Llm Knowledge Sources List",
         "operationId": "_llm_knowledge_sources_list_pallas_api_llm_knowledge_sources_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/llm/tools": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Llm Tools List",
+        "operationId": "_llm_tools_list_pallas_api_llm_tools_get",
         "parameters": [
           {
             "name": "token",

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -7547,6 +7547,16 @@ def register_extended_api(
             raise HTTPException(status_code=500, detail=str(e)) from e
         return JSONResponse({"ok": True, "data": {"items": items, "count": len(items)}})
 
+    @router.get(f"{x}/llm/tools", include_in_schema=True)
+    async def _llm_tools_list() -> JSONResponse:
+        try:
+            from pallas.product.llm.tools.registry import build_tools_catalog_ui
+
+            data = build_tools_catalog_ui()
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return JSONResponse({"ok": True, "data": data})
+
     @router.post(f"{x}/llm/conversation-kernel/memory/delete", include_in_schema=True)
     async def _llm_conversation_kernel_memory_delete(
         body: dict[str, Any],

--- a/pallas/product/llm/tools/registry.py
+++ b/pallas/product/llm/tools/registry.py
@@ -294,18 +294,53 @@ def tool_metadata_for_chat(*, task: str | None = None, user_text: str = "") -> d
     }
 
 
-def build_tools_ui_rows() -> list[dict[str, Any]]:
+def build_tools_catalog_ui() -> dict[str, Any]:
+    """WebUI 只读工具清单：全量可见 tool + 当前策略门闸。"""
+    cfg = get_llm_config()
+    kb = get_arknights_kb_config()
     ensure_tools_loaded()
-    rows = [
-        {
-            "name": spec.name,
-            "description": spec.description,
-            "domains": sorted(spec.domains),
-            "command_id": spec.command_id,
-            "source": spec.source.value,
-        }
-        for spec in iter_registered_tools()
-        if spec.visible_in_ui
-    ]
-    rows.sort(key=operator.itemgetter("name"))
-    return rows
+    blacklist = {item.strip().lower() for item in cfg.llm_tools_blacklist if item.strip()}
+    eligible_names = {spec.name for spec in iter_eligible_tool_specs()}
+    items: list[dict[str, Any]] = []
+    for spec in iter_registered_tools():
+        if not spec.visible_in_ui:
+            continue
+        entry = catalog_entry_for_spec(spec)
+        disabled_reason: str | None = None
+        if not cfg.llm_tools_enabled:
+            disabled_reason = "tools_disabled"
+        elif spec.name.lower() in blacklist or spec.domains.intersection(blacklist):
+            disabled_reason = "blacklisted"
+        elif "arknights" in spec.domains and not kb.arknights_kb_enabled:
+            disabled_reason = "arknights_kb_disabled"
+        items.append({
+            "name": entry.name,
+            "description": entry.description,
+            "parameters": entry.parameters,
+            "source": entry.source,
+            "domains": list(entry.domains),
+            "capabilities": list(entry.capabilities),
+            "command_id": entry.audit.command_id,
+            "plugin_name": entry.audit.plugin_name,
+            "provider_name": entry.audit.provider_name,
+            "mcp_server_id": entry.audit.mcp_server_id,
+            "eligible": spec.name in eligible_names,
+            "disabled_reason": disabled_reason,
+        })
+    items.sort(key=operator.itemgetter("name"))
+    return {
+        "items": items,
+        "count": len(items),
+        "policy": {
+            "tools_enabled": bool(cfg.llm_tools_enabled),
+            "selective_enabled": bool(cfg.llm_tools_selective),
+            "max_rounds": int(cfg.llm_tools_max_rounds),
+            "blacklist": [str(item) for item in (cfg.llm_tools_blacklist or []) if str(item).strip()],
+            "arknights_kb_enabled": bool(kb.arknights_kb_enabled),
+            "desc_max_len": int(cfg.llm_tools_desc_max_len),
+        },
+    }
+
+
+def build_tools_ui_rows() -> list[dict[str, Any]]:
+    return list(build_tools_catalog_ui().get("items") or [])

--- a/tests/product/llm/test_tool_registry.py
+++ b/tests/product/llm/test_tool_registry.py
@@ -22,6 +22,7 @@ def _patch_tool_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
             llm_tools_blacklist=[],
             llm_tools_desc_max_len=120,
             llm_tools_selective=False,
+            llm_tools_max_rounds=4,
         ),
     )
     monkeypatch.setattr(
@@ -100,17 +101,18 @@ def test_build_tools_ui_rows_exposes_source(monkeypatch: pytest.MonkeyPatch) -> 
         )
     )
 
+    catalog = registry.build_tools_catalog_ui()
     rows = registry.build_tools_ui_rows()
 
-    assert rows == [
-        {
-            "name": "plugin.roll",
-            "description": "plugin.roll description",
-            "domains": ["command", "dice"],
-            "command_id": None,
-            "source": "plugin_command",
-        }
-    ]
+    assert catalog["count"] == 1
+    assert catalog["policy"]["tools_enabled"] is True
+    assert catalog["policy"]["selective_enabled"] is False
+    assert rows[0]["name"] == "plugin.roll"
+    assert rows[0]["source"] == "plugin_command"
+    assert rows[0]["domains"] == ["command", "dice"]
+    assert rows[0]["eligible"] is True
+    assert rows[0]["disabled_reason"] is None
+    assert rows[0]["command_id"] is None
 
 
 def test_execute_tool_async_normalizes_non_ok_dict(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
对话配置可拉取已注册 LLM 工具与策略门闸（`GET /pallas/api/llm/tools`）。