### PR TITLE
feat(webui): 语料源只读详情与 chunk 预览 API

### DIFF
--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.1.1-39-gcb6d4853-dirty",
+    "version": "v4.1.1-41-g0e2ed5d0-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -13656,6 +13656,102 @@
         "summary": " Llm Conversation Kernel Knowledge Sources Get",
         "operationId": "_llm_conversation_kernel_knowledge_sources_get_pallas_api_llm_conversation_kernel_knowledge_sources_get",
         "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/llm/conversation-kernel/knowledge-sources/{source_id}": {
+      "get": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Llm Conversation Kernel Knowledge Source Detail Get",
+        "operationId": "_llm_conversation_kernel_knowledge_source_detail_get_pallas_api_llm_conversation_kernel_knowledge_sources__source_id__get",
+        "parameters": [
+          {
+            "name": "source_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Source Id"
+            }
+          },
+          {
+            "name": "preview_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 30,
+              "title": "Preview Limit"
+            }
+          },
+          {
+            "name": "preview_content_len",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 32,
+              "default": 240,
+              "title": "Preview Content Len"
+            }
+          },
           {
             "name": "token",
             "in": "query",

--- a/packages/pb_webui/extended_api.py
+++ b/packages/pb_webui/extended_api.py
@@ -7635,6 +7635,26 @@ def register_extended_api(
             raise HTTPException(status_code=500, detail=str(e)) from e
         return JSONResponse({"ok": True, "data": {"items": items, "count": len(items)}})
 
+    @router.get(f"{x}/llm/conversation-kernel/knowledge-sources/{{source_id}}", include_in_schema=True)
+    async def _llm_conversation_kernel_knowledge_source_detail_get(
+        source_id: str,
+        preview_limit: int = Query(default=30, ge=1, le=100),
+        preview_content_len: int = Query(default=240, ge=32, le=2000),
+    ) -> JSONResponse:
+        try:
+            from pallas.product.llm.knowledge.registry import build_knowledge_source_detail_ui
+
+            data = build_knowledge_source_detail_ui(
+                source_id,
+                preview_limit=preview_limit,
+                preview_content_len=preview_content_len,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        if data is None:
+            raise HTTPException(status_code=404, detail="未找到该语料源")
+        return JSONResponse({"ok": True, "data": data})
+
     @router.post(f"{x}/common-config/llm/history/behavior/annotate", include_in_schema=True)
     async def _llm_history_behavior_annotate(body: dict[str, Any]) -> JSONResponse:
         from pallas.product.llm.session_store import update_llm_behavior_annotation

--- a/pallas/product/llm/knowledge/registry.py
+++ b/pallas/product/llm/knowledge/registry.py
@@ -80,6 +80,64 @@ def list_active_knowledge_sources(*, cfg: LlmConfig | None = None) -> list[Regis
     return rows
 
 
+def get_knowledge_source_by_id(
+    source_id: str,
+    *,
+    cfg: LlmConfig | None = None,
+) -> RegisteredKnowledgeSource | None:
+    sid = (source_id or "").strip()
+    if not sid:
+        return None
+    for row in list_active_knowledge_sources(cfg=cfg):
+        if row.source_id == sid:
+            return row
+    return None
+
+
+def build_knowledge_source_detail_ui(
+    source_id: str,
+    *,
+    preview_limit: int = 30,
+    preview_content_len: int = 240,
+    cfg: LlmConfig | None = None,
+) -> dict[str, Any] | None:
+    """WebUI 只读语料源详情：元数据 + chunk 预览（截断）。"""
+    row = get_knowledge_source_by_id(source_id, cfg=cfg)
+    if row is None:
+        return None
+    decl = row.decl
+    limit = max(1, min(100, int(preview_limit)))
+    content_len = max(32, min(2000, int(preview_content_len)))
+    chunks_preview: list[dict[str, Any]] = []
+    for index, chunk in enumerate(decl.chunks[:limit]):
+        raw = (chunk.content or "").strip()
+        preview = raw if len(raw) <= content_len else raw[: content_len - 1].rstrip() + "…"
+        chunks_preview.append({
+            "index": index,
+            "title": (chunk.title or "").strip(),
+            "keywords": (chunk.keywords or "").strip(),
+            "content_preview": preview,
+            "content_len": len(raw),
+        })
+    return {
+        "source_id": row.source_id,
+        "title": decl.title,
+        "description": decl.description,
+        "scope": decl.scope.value,
+        "retrieval_mode": decl.retrieval_mode.value,
+        "origin": row.origin.value,
+        "plugin_name": row.plugin_name,
+        "plugin_title": row.plugin_title,
+        "default": bool(decl.default),
+        "top_k": int(decl.top_k),
+        "max_chunk_len": int(decl.max_chunk_len),
+        "chunk_count": len(decl.chunks),
+        "chunks_preview": chunks_preview,
+        "chunks_preview_truncated": len(decl.chunks) > limit,
+        "preview_content_len": content_len,
+    }
+
+
 def retrieve_from_knowledge_sources(
     query_text: str,
     *,

--- a/tests/features/test_knowledge_sources.py
+++ b/tests/features/test_knowledge_sources.py
@@ -13,6 +13,7 @@ from pallas.product.llm.knowledge.declare import knowledge_source_row
 from pallas.product.llm.knowledge.inject import enrich_system_with_knowledge_sources
 from pallas.product.llm.knowledge.metadata import parse_knowledge_source_decl
 from pallas.product.llm.knowledge.registry import (
+    build_knowledge_source_detail_ui,
     knowledge_metadata_payload,
     list_active_knowledge_sources,
     retrieve_from_knowledge_sources,
@@ -95,6 +96,29 @@ def test_list_active_knowledge_sources_includes_builtin() -> None:
     cfg = LlmConfig(llm_chat_enabled=True, llm_knowledge_sources_enabled=True)
     rows = list_active_knowledge_sources(cfg=cfg)
     assert any(row.source_id == "pallas.bot_faq" for row in rows)
+
+
+def test_build_knowledge_source_detail_ui_truncates_preview() -> None:
+    cfg = LlmConfig(llm_chat_enabled=True, llm_knowledge_sources_enabled=True)
+    detail = build_knowledge_source_detail_ui(
+        "pallas.bot_faq",
+        preview_limit=2,
+        preview_content_len=40,
+        cfg=cfg,
+    )
+    assert detail is not None
+    assert detail["source_id"] == "pallas.bot_faq"
+    assert detail["chunk_count"] >= 1
+    assert len(detail["chunks_preview"]) <= 2
+    assert detail["chunks_preview_truncated"] is (detail["chunk_count"] > 2)
+    first = detail["chunks_preview"][0]
+    assert "content_preview" in first
+    assert first["content_len"] >= len(first["content_preview"].rstrip("…"))
+
+
+def test_build_knowledge_source_detail_ui_missing() -> None:
+    cfg = LlmConfig(llm_chat_enabled=True, llm_knowledge_sources_enabled=True)
+    assert build_knowledge_source_detail_ui("missing.source", cfg=cfg) is None
 
 
 def test_knowledge_metadata_payload_includes_trace() -> None:


### PR DESCRIPTION
`GET /pallas/api/llm/conversation-kernel/knowledge-sources/{source_id}` 返回元数据与截断后的条目预览。