### PR TITLE
fix(presence): 隔离僵尸 WS 并避免假在线挡重新上号

### DIFF
--- a/pallas/core/platform/multi_bot/connected_roster.py
+++ b/pallas/core/platform/multi_bot/connected_roster.py
@@ -42,6 +42,23 @@ async def on_bot_connect(bot: Bot) -> None:
     if bot.self_id.isnumeric() and bot.type == "OneBot V11":
         logger.info(f"Bot {bot.self_id} connected.")
         qq = int(bot.self_id)
+        from pallas.core.platform.shard.presence import close_local_bot_connection
+        from pallas.core.platform.shard.presence_health import (
+            health_quarantine_qq_ids,
+            probe_bot_get_status_healthy,
+        )
+
+        # 隔离中的重连：先探测会话；仍不健康则关 WS，避免清 quarantine 后假在线。
+        if qq in health_quarantine_qq_ids():
+            if not await probe_bot_get_status_healthy(bot):
+                logger.warning(
+                    "Bot {} reconnected while quarantined but get_status unhealthy; closing WS",
+                    bot.self_id,
+                )
+                await close_local_bot_connection(qq)
+                return
+            clear_health_quarantine(qq)
+
         note_connected_bot(qq)
         note_bot_session_seen(qq)
         await clear_protocol_bot_offline(qq)

--- a/pallas/core/platform/shard/presence.py
+++ b/pallas/core/platform/shard/presence.py
@@ -496,8 +496,15 @@ def bot_has_local_connection(qq: int) -> bool:
 
 
 def bot_has_cluster_connection(qq: int) -> bool:
-    """本 worker 已连接，或分片下 presence 记录里任意 worker 已连接。"""
+    """本 worker 已连接，或分片下 presence 记录里任意 worker 已连接。
+
+    健康隔离中的 QQ 视为未在线（僵尸 WS 可能仍挂在 get_bots）。
+    """
     bid = int(qq)
+    from pallas.core.platform.shard.presence_health import health_quarantine_qq_ids
+
+    if bid in health_quarantine_qq_ids():
+        return False
     if bot_has_local_connection(bid):
         return True
     if not shard_ctx.sharding_active():

--- a/pallas/core/platform/shard/presence_health.py
+++ b/pallas/core/platform/shard/presence_health.py
@@ -83,13 +83,16 @@ async def probe_bot_get_status_healthy(bot: Any) -> bool:
 
 
 async def apply_presence_qq_health_probes(*, force: bool = False) -> list[int]:
-    """对本机已连 OneBot 牛做 get_status；达阈值则清 presence。返回本轮踢出的 QQ。"""
+    """对本机已连 OneBot 牛做 get_status；达阈值则清 presence 并关闭僵尸 WS。返回本轮踢出的 QQ。"""
     global _last_probe_mono
 
     from nonebot import get_bots
 
     from pallas.core.platform.shard import context as shard_ctx
-    from pallas.core.platform.shard.presence import note_worker_bot_disconnected_sync
+    from pallas.core.platform.shard.presence import (
+        close_local_bot_connection,
+        note_worker_bot_disconnected_sync,
+    )
 
     if not shard_ctx.sharding_active():
         return []
@@ -114,11 +117,13 @@ async def apply_presence_qq_health_probes(*, force: bool = False) -> list[int]:
             ok = await probe_bot_get_status_healthy(bot)
         if record_health_probe_result(qq, ok=ok):
             note_worker_bot_disconnected_sync(qq=qq)
+            closed = await close_local_bot_connection(qq)
             kicked.append(qq)
             logger.warning(
-                "presence_health: qq={} quarantined after {} failed get_status",
+                "presence_health: qq={} quarantined after {} failed get_status closed_ws={}",
                 qq,
                 STATUS_FAIL_THRESHOLD,
+                closed,
             )
 
     await asyncio.gather(*starmap(one, bots.items()))

--- a/tests/common/test_presence_health.py
+++ b/tests/common/test_presence_health.py
@@ -38,6 +38,7 @@ async def test_apply_probes_kicks_and_disconnects(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(h, "STATUS_FAIL_THRESHOLD", 2)
     monkeypatch.setattr(h, "STATUS_PROBE_MIN_INTERVAL_SEC", 0)
     disconnected: list[int] = []
+    closed: list[int] = []
 
     class _Bot:
         self_id = "222"
@@ -45,6 +46,10 @@ async def test_apply_probes_kicks_and_disconnects(monkeypatch: pytest.MonkeyPatc
         async def call_api(self, api: str):
             assert api == "get_status"
             raise TimeoutError("zombie")
+
+    async def fake_close(qq: int) -> bool:
+        closed.append(int(qq))
+        return True
 
     monkeypatch.setattr(
         "pallas.core.platform.shard.context.sharding_active",
@@ -55,12 +60,65 @@ async def test_apply_probes_kicks_and_disconnects(monkeypatch: pytest.MonkeyPatc
         "pallas.core.platform.shard.presence.note_worker_bot_disconnected_sync",
         lambda *, qq: disconnected.append(int(qq)),
     )
+    monkeypatch.setattr(
+        "pallas.core.platform.shard.presence.close_local_bot_connection",
+        fake_close,
+    )
 
     assert await h.apply_presence_qq_health_probes(force=True) == []
     kicked = await h.apply_presence_qq_health_probes(force=True)
     assert kicked == [222]
     assert disconnected == [222]
+    assert closed == [222]
     assert 222 in h.health_quarantine_qq_ids()
+
+
+def test_bot_has_cluster_connection_false_when_quarantined(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pallas.core.platform.shard import presence as presence_mod
+
+    h.record_health_probe_result(100, ok=False)
+    h.record_health_probe_result(100, ok=False)
+    h.record_health_probe_result(100, ok=False)
+    assert 100 in h.health_quarantine_qq_ids()
+
+    monkeypatch.setattr(presence_mod, "bot_has_local_connection", lambda qq: qq == 100)
+    monkeypatch.setattr(presence_mod.shard_ctx, "sharding_active", lambda: True)
+    monkeypatch.setattr(presence_mod, "get_cluster_online_bot_ids", lambda: frozenset({100}))
+    assert presence_mod.bot_has_cluster_connection(100) is False
+
+
+@pytest.mark.asyncio
+async def test_on_bot_connect_closes_unhealthy_quarantined_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pallas.core.platform.multi_bot import connected_roster as roster
+
+    closed: list[int] = []
+    h.record_health_probe_result(444, ok=False)
+    h.record_health_probe_result(444, ok=False)
+    h.record_health_probe_result(444, ok=False)
+    assert 444 in h.health_quarantine_qq_ids()
+
+    class _Bot:
+        self_id = "444"
+        type = "OneBot V11"
+
+        async def call_api(self, api: str):
+            assert api == "get_status"
+            return {"online": False}
+
+    async def fake_close(qq: int) -> bool:
+        closed.append(int(qq))
+        return True
+
+    monkeypatch.setattr(
+        "pallas.core.platform.shard.presence.close_local_bot_connection",
+        fake_close,
+    )
+    await roster.on_bot_connect(_Bot())  # type: ignore[arg-type]
+    assert closed == [444]
+    assert 444 in h.health_quarantine_qq_ids()
+    assert 444 not in roster.connected_bot_ids()
 
 
 @pytest.mark.asyncio

--- a/tests/common/test_shard_presence_fanout.py
+++ b/tests/common/test_shard_presence_fanout.py
@@ -18,6 +18,10 @@ def test_bot_has_cluster_connection_local(monkeypatch):
     monkeypatch.setattr(presence_mod, "bot_has_local_connection", lambda qq: qq == 100)
     monkeypatch.setattr(presence_mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(presence_mod, "get_cluster_online_bot_ids", lambda: frozenset({200}))
+    monkeypatch.setattr(
+        "pallas.core.platform.shard.presence_health.health_quarantine_qq_ids",
+        lambda: frozenset(),
+    )
     assert presence_mod.bot_has_cluster_connection(100) is True
     assert presence_mod.bot_has_cluster_connection(200) is True
     assert presence_mod.bot_has_cluster_connection(300) is False


### PR DESCRIPTION
quarantine 达阈值时主动关闭僵尸 OneBot WS；`bot_has_cluster_connection` 对隔离账号返回离线，避免「牛牛已在线」挡住重新上号。隔离态重连会先探测 `get_status`，不健康则再次断开。