### PR TITLE
fix(llm): 整理 ai_callback runner 导入

### DIFF
--- a/pallas/core/platform/ai_callback/runner.py
+++ b/pallas/core/platform/ai_callback/runner.py
@@ -21,11 +21,12 @@ from pallas.core.platform.ai_callback.task_types import (
     SING_TASK_TYPES,
 )
 from pallas.core.platform.shard.coord.ai_task_registry import get_ai_task_record, remove_ai_task
-from pallas.product.llm.delivery import deliver_llm_callback_success, track_llm_callback
 from pallas.product.llm.delivery import (
+    deliver_llm_callback_success,
     deliver_llm_chat_result,
     evaluate_repeater_callback_text,
     maybe_append_llm_repeater_feedback,
+    track_llm_callback,
 )
 
 __all__ = [


### PR DESCRIPTION
修复 #274 合入后 CI ruff I001。

## Summary by Sourcery

重新组织 AI 回调运行器中的 llm delivery 导入，以符合 lint 规则并修复 CI 中断问题。

Enhancements:
- 将 AI 回调运行器中的 llm delivery 函数合并为单个多行导入语句，以满足 ruff 的 I001 导入顺序要求。

Chores:
- 通过修正 AI 回调运行器模块中的导入布局，解决由 #274 引入的 CI lint 失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reorganize llm delivery imports in the AI callback runner to comply with linting rules and fix CI breakage.

Enhancements:
- Group llm delivery functions into a single multi-line import in the AI callback runner to satisfy ruff I001 import order requirements.

Chores:
- Address CI lint failure introduced by #274 by correcting the import layout in the AI callback runner module.

</details>