### PR TITLE
chore(release): v4.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [4.1.12] - 2026-07-28
+
+### 更新公告
+
+- 智能对话可在控制台配置外部 MCP，并挂到工具目录
+- MCP 连接改为常驻复用（stdio / HTTP），避免每次冷启动
+- 注册失败原因可在工具策略里看到
+- 捆绑控制台 WebUI **v0.8.7**
+
+### Added
+
+- `LLM_MCP_SERVERS` / `LLM_MCP_HTTP_ALLOWLIST` 经 WebUI llm 段读写；变更后重注册工具
+
+### Changed
+
+- MCP stdio/HTTP 常驻 session；snapshot 含 sessions
+- 发行捆绑控制台取 WebUI **v0.8.7**
+
 ## [4.1.11] - 2026-07-28
 
 ### 更新公告

--- a/pallas/__init__.py
+++ b/pallas/__init__.py
@@ -1,3 +1,3 @@
 """Pallas Bot 内核包（pallas-core）。"""
 
-__version__ = "4.1.11"
+__version__ = "4.1.12"

--- a/pallas/console/webui/env_sections.py
+++ b/pallas/console/webui/env_sections.py
@@ -250,6 +250,8 @@ def _llm_section() -> WebuiEnvSection:
             "llm_tools_max_rounds": "LLM_TOOLS_MAX_ROUNDS",
             "llm_tools_blacklist": "LLM_TOOLS_BLACKLIST",
             "llm_tools_desc_max_len": "LLM_TOOLS_DESC_MAX_LEN",
+            "mcp_servers": "LLM_MCP_SERVERS",
+            "llm_mcp_http_allowlist": "LLM_MCP_HTTP_ALLOWLIST",
             "web_search_api_url": "WEB_SEARCH_API_URL",
             "tavily_api_key": "TAVILY_API_KEY",
             "llm_chat_max_concurrency": "LLM_CHAT_MAX_CONCURRENCY",
@@ -559,6 +561,22 @@ def apply_webui_env_section_patch(section_id: str, patch: dict[str, Any]) -> dic
             clear_llm_config_cache()
         except Exception:
             pass
+        if "mcp_servers" in patch or "llm_mcp_http_allowlist" in patch:
+            old_mcp = {
+                "mcp_servers": current.get("mcp_servers") or [],
+                "llm_mcp_http_allowlist": str(current.get("llm_mcp_http_allowlist") or "").strip(),
+            }
+            new_mcp = {
+                "mcp_servers": validated.get("mcp_servers") or [],
+                "llm_mcp_http_allowlist": str(validated.get("llm_mcp_http_allowlist") or "").strip(),
+            }
+            if old_mcp != new_mcp:
+                try:
+                    from pallas.product.llm.tools.bootstrap import ensure_llm_tools_bootstrapped
+
+                    ensure_llm_tools_bootstrapped(force=True)
+                except Exception:
+                    pass
         if "ai_server_host" in patch or "ai_server_port" in patch:
             try:
                 from pallas.console.webui.ai_install_writeback import (

--- a/pallas/console/webui/field_labels.py
+++ b/pallas/console/webui/field_labels.py
@@ -209,6 +209,8 @@ FIELD_LABELS: dict[str, str] = {
     "llm_tools_max_rounds": "工具调用最多轮数",
     "llm_tools_blacklist": "工具黑名单",
     "llm_tools_desc_max_len": "工具描述最大长度",
+    "mcp_servers": "MCP 服务器",
+    "llm_mcp_http_allowlist": "MCP HTTP 允许前缀",
     "web_search_api_url": "搜索接口完整地址",
     "tavily_api_key": "搜索接口密钥",
     "llm_reply_postprocess_enabled": "回复后处理",

--- a/pallas/product/llm/tools/mcp_bootstrap.py
+++ b/pallas/product/llm/tools/mcp_bootstrap.py
@@ -1,4 +1,4 @@
-"""将 stdio MCP server 的工具注册进 LLM ToolRegistry。"""
+"""将 MCP server 的工具注册进 LLM ToolRegistry（stdio/HTTP 常驻 session）。"""
 
 from __future__ import annotations
 
@@ -6,6 +6,8 @@ import asyncio
 import json
 import subprocess
 import threading
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from nonebot import logger
@@ -16,11 +18,25 @@ from pallas.product.llm.tools.registry import LlmToolSource, LlmToolSpec, regist
 
 _MCP_TOOL_NAMES: set[str] = set()
 _MCP_REGISTER_ERRORS: list[dict[str, str]] = []
+_SESSION_POOL_LOCK = threading.Lock()
+_SESSIONS: dict[str, Any] = {}
 
 
 def clear_mcp_tools() -> None:
     _MCP_TOOL_NAMES.clear()
     _MCP_REGISTER_ERRORS.clear()
+    close_all_mcp_sessions()
+
+
+def close_all_mcp_sessions() -> None:
+    with _SESSION_POOL_LOCK:
+        sessions = list(_SESSIONS.values())
+        _SESSIONS.clear()
+    for session in sessions:
+        try:
+            session.close()
+        except Exception as err:
+            logger.debug("mcp session close failed id={}: {}", session.server_id, err)
 
 
 def mcp_registration_snapshot() -> dict[str, Any]:
@@ -35,11 +51,22 @@ def mcp_registration_snapshot() -> dict[str, Any]:
         }
         for server in cfg.mcp_servers
     ]
+    with _SESSION_POOL_LOCK:
+        live = [
+            {
+                "id": session.server_id,
+                "transport": session.transport,
+                "alive": session.alive(),
+                "calls": session.call_count,
+            }
+            for session in _SESSIONS.values()
+        ]
     return {
         "servers": servers,
         "registered_tool_names": sorted(_MCP_TOOL_NAMES),
         "registered_count": len(_MCP_TOOL_NAMES),
         "errors": list(_MCP_REGISTER_ERRORS),
+        "sessions": live,
     }
 
 
@@ -74,80 +101,11 @@ def _tool_name(server_id: str, tool_row: dict[str, Any]) -> str:
     return f"mcp.{server_id}.{base_name}"
 
 
-def _spawn_stdio_server(server: LlmMcpServerConfig) -> subprocess.Popen[str]:
-    transport = (server.transport or "stdio").strip().lower()
-    if transport not in ("stdio", ""):
-        raise RuntimeError(f"use http transport helper for: {server.transport}")
-    if not server.command:
-        raise RuntimeError(f"mcp server {server.id} missing command")
-    proc = subprocess.Popen(
-        list(server.command),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        bufsize=1,
-    )
-    if proc.stdin is None or proc.stdout is None:
-        raise RuntimeError(f"mcp server {server.id} missing stdio pipe")
-
-    def drain_stderr() -> None:
-        if proc.stderr is None:
-            return
-        for _line in proc.stderr:
-            continue
-
-    threading.Thread(target=drain_stderr, daemon=True).start()
-    return proc
-
-
-def _read_json_line(proc: subprocess.Popen[str]) -> dict[str, Any]:
-    assert proc.stdout is not None
-    while True:
-        line = proc.stdout.readline()
-        if not line:
-            raise RuntimeError("mcp stdout closed")
-        line = line.strip()
-        if not line:
-            continue
-        return json.loads(line)
-
-
-def _send_json_line(proc: subprocess.Popen[str], payload: dict[str, Any]) -> None:
-    assert proc.stdin is not None
-    proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    proc.stdin.flush()
-
-
-def _call_jsonrpc(
-    proc: subprocess.Popen[str],
-    *,
-    req_id: int,
-    method: str,
-    params: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    payload = {"jsonrpc": "2.0", "id": req_id, "method": method}
-    if params is not None:
-        payload["params"] = params
-    _send_json_line(proc, payload)
-    while True:
-        response = _read_json_line(proc)
-        if response.get("id") == req_id:
-            return response
-
-
-def _initialize_server(proc: subprocess.Popen[str]) -> None:
-    _call_jsonrpc(
-        proc,
-        req_id=1,
-        method="initialize",
-        params={
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "pallas-llm-mcp", "version": "1.0"},
-        },
-    )
-    _send_json_line(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+def _server_fingerprint(server: LlmMcpServerConfig) -> str:
+    transport = (server.transport or "stdio").strip().lower() or "stdio"
+    if transport in ("http", "sse"):
+        return f"http|{str(server.url or '').strip()}"
+    return "stdio|" + json.dumps(list(server.command or []), ensure_ascii=False)
 
 
 def _mcp_http_allowed(url: str) -> bool:
@@ -161,24 +119,266 @@ def _mcp_http_allowed(url: str) -> bool:
     return any(normalized.startswith(prefix) for prefix in allowed)
 
 
-def _call_mcp_http(server: LlmMcpServerConfig, *, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-    url = str(server.url or "").strip()
-    if not url:
-        raise RuntimeError(f"mcp server {server.id} missing url")
-    if not _mcp_http_allowed(url):
-        raise RuntimeError(f"mcp http url not in LLM_MCP_HTTP_ALLOWLIST: {url}")
-    import httpx
+@dataclass
+class _McpSessionBase:
+    server_id: str
+    transport: str
+    fingerprint: str
+    call_count: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    _next_id: int = 1
 
-    payload = {"jsonrpc": "2.0", "id": 2, "method": method}
-    if params is not None:
-        payload["params"] = params
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(url, json=payload)
-        response.raise_for_status()
-        body = response.json()
-    if not isinstance(body, dict):
-        raise RuntimeError("invalid mcp http response")
-    return body
+    def next_req_id(self) -> int:
+        req_id = self._next_id
+        self._next_id += 1
+        return req_id
+
+    def alive(self) -> bool:
+        raise NotImplementedError
+
+    def matches(self, server: LlmMcpServerConfig) -> bool:
+        return self.fingerprint == _server_fingerprint(server)
+
+    def call(self, *, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+@dataclass
+class _StdioMcpSession(_McpSessionBase):
+    proc: subprocess.Popen[str] | None = None
+
+    def alive(self) -> bool:
+        return self.proc is not None and self.proc.poll() is None
+
+    def ensure_started(self, server: LlmMcpServerConfig) -> None:
+        if self.alive():
+            return
+        if not server.command:
+            raise RuntimeError(f"mcp server {server.id} missing command")
+        proc = subprocess.Popen(
+            list(server.command),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        if proc.stdin is None or proc.stdout is None:
+            proc.terminate()
+            raise RuntimeError(f"mcp server {server.id} missing stdio pipe")
+
+        def drain_stderr() -> None:
+            if proc.stderr is None:
+                return
+            for _line in proc.stderr:
+                continue
+
+        threading.Thread(target=drain_stderr, daemon=True).start()
+        self.proc = proc
+        self._next_id = 1
+        self._initialize()
+        logger.info("mcp stdio session started id={}", self.server_id)
+
+    def _read_json_line(self) -> dict[str, Any]:
+        proc = self.proc
+        if proc is None or proc.stdout is None:
+            raise RuntimeError("mcp stdio not started")
+        deadline = time.monotonic() + 60.0
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                raise RuntimeError("mcp stdout closed")
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                # npm / uvx 启动横幅等非 JSON 行
+                continue
+        raise RuntimeError("mcp stdout timeout waiting for json")
+
+    def _send_json_line(self, payload: dict[str, Any]) -> None:
+        proc = self.proc
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("mcp stdio not started")
+        proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        proc.stdin.flush()
+
+    def _call_jsonrpc(
+        self,
+        *,
+        req_id: int,
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._send_json_line(payload)
+        while True:
+            response = self._read_json_line()
+            if response.get("id") == req_id:
+                return response
+
+    def _initialize(self) -> None:
+        self._call_jsonrpc(
+            req_id=self.next_req_id(),
+            method="initialize",
+            params={
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "pallas-llm-mcp", "version": "1.0"},
+            },
+        )
+        self._send_json_line({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def call(self, *, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        with self.lock:
+            if not self.alive():
+                raise RuntimeError(f"mcp stdio session dead: {self.server_id}")
+            response = self._call_jsonrpc(req_id=self.next_req_id(), method=method, params=params)
+            self.call_count += 1
+            if "error" in response:
+                error = response["error"]
+                if isinstance(error, dict):
+                    raise RuntimeError(str(error.get("message") or "mcp call failed"))
+                raise RuntimeError(str(error))
+            result = response.get("result")
+            return result if isinstance(result, dict) else {}
+
+    def close(self) -> None:
+        proc = self.proc
+        self.proc = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=3)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+
+@dataclass
+class _HttpMcpSession(_McpSessionBase):
+    url: str = ""
+    client: Any = None
+
+    def alive(self) -> bool:
+        return self.client is not None and bool(self.url)
+
+    def ensure_started(self, server: LlmMcpServerConfig) -> None:
+        import httpx
+
+        url = str(server.url or "").strip()
+        if not url:
+            raise RuntimeError(f"mcp server {server.id} missing url")
+        if not _mcp_http_allowed(url):
+            raise RuntimeError(f"mcp http url not in LLM_MCP_HTTP_ALLOWLIST: {url}")
+        if self.alive() and self.url == url:
+            return
+        self.close()
+        self.url = url
+        self.client = httpx.Client(timeout=30.0)
+        self._next_id = 1
+        logger.info("mcp http session ready id={} url={}", self.server_id, url)
+
+    def call(self, *, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        with self.lock:
+            if not self.alive():
+                raise RuntimeError(f"mcp http session dead: {self.server_id}")
+            payload: dict[str, Any] = {"jsonrpc": "2.0", "id": self.next_req_id(), "method": method}
+            if params is not None:
+                payload["params"] = params
+            response = self.client.post(self.url, json=payload)
+            response.raise_for_status()
+            body = response.json()
+            self.call_count += 1
+            if not isinstance(body, dict):
+                raise RuntimeError("invalid mcp http response")
+            error = body.get("error")
+            if isinstance(error, dict):
+                raise RuntimeError(str(error.get("message") or "mcp call failed"))
+            result = body.get("result")
+            return result if isinstance(result, dict) else {}
+
+    def close(self) -> None:
+        client = self.client
+        self.client = None
+        self.url = ""
+        if client is None:
+            return
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+def _new_session(server: LlmMcpServerConfig) -> _McpSessionBase:
+    transport = (server.transport or "stdio").strip().lower() or "stdio"
+    fingerprint = _server_fingerprint(server)
+    if transport in ("http", "sse"):
+        http_session = _HttpMcpSession(
+            server_id=server.id,
+            transport="http",
+            fingerprint=fingerprint,
+        )
+        http_session.ensure_started(server)
+        return http_session
+    stdio_session = _StdioMcpSession(
+        server_id=server.id,
+        transport="stdio",
+        fingerprint=fingerprint,
+    )
+    stdio_session.ensure_started(server)
+    return stdio_session
+
+
+def get_or_create_mcp_session(server: LlmMcpServerConfig) -> _McpSessionBase:
+    server_id = str(server.id or "").strip()
+    if not server_id:
+        raise RuntimeError("mcp server missing id")
+    with _SESSION_POOL_LOCK:
+        existing = _SESSIONS.get(server_id)
+        if existing is not None and existing.matches(server) and existing.alive():
+            return existing
+        if existing is not None:
+            _SESSIONS.pop(server_id, None)
+        else:
+            existing = None
+    if existing is not None:
+        try:
+            existing.close()
+        except Exception:
+            pass
+    session = _new_session(server)
+    with _SESSION_POOL_LOCK:
+        old = _SESSIONS.get(server_id)
+        if old is not None and old.matches(server) and old.alive():
+            try:
+                session.close()
+            except Exception:
+                pass
+            return old
+        if old is not None:
+            try:
+                old.close()
+            except Exception:
+                pass
+        _SESSIONS[server_id] = session
+        return session
+
+
+def _call_mcp_http(server: LlmMcpServerConfig, *, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """兼容旧测试与一次性探测：走常驻 HTTP session。"""
+    session = get_or_create_mcp_session(server)
+    return session.call(method=method, params=params)
 
 
 def _call_mcp_method(
@@ -187,26 +387,19 @@ def _call_mcp_method(
     method: str,
     params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    transport = (server.transport or "stdio").strip().lower()
-    if transport in ("http", "sse"):
-        response = _call_mcp_http(server, method=method, params=params)
-        error = response.get("error")
-        if isinstance(error, dict):
-            raise RuntimeError(str(error.get("message") or "mcp call failed"))
-        return response.get("result") if isinstance(response.get("result"), dict) else {}
-    proc = _spawn_stdio_server(server)
     try:
-        _initialize_server(proc)
-        response = _call_jsonrpc(proc, req_id=2, method=method, params=params)
-    finally:
-        proc.terminate()
-    if "error" in response:
-        error = response["error"]
-        if isinstance(error, dict):
-            raise RuntimeError(str(error.get("message") or "mcp call failed"))
-        raise RuntimeError(str(error))
-    result = response.get("result")
-    return result if isinstance(result, dict) else {}
+        session = get_or_create_mcp_session(server)
+        return session.call(method=method, params=params)
+    except Exception:
+        with _SESSION_POOL_LOCK:
+            stale = _SESSIONS.pop(str(server.id or "").strip(), None)
+        if stale is not None:
+            try:
+                stale.close()
+            except Exception:
+                pass
+        session = get_or_create_mcp_session(server)
+        return session.call(method=method, params=params)
 
 
 def list_mcp_tools(server: LlmMcpServerConfig) -> list[dict[str, Any]]:
@@ -276,6 +469,7 @@ def build_mcp_tool_spec(server: LlmMcpServerConfig, tool_row: dict[str, Any]) ->
 def register_mcp_tools() -> int:
     count = 0
     _MCP_REGISTER_ERRORS.clear()
+    close_all_mcp_sessions()
     for server in get_llm_config().mcp_servers:
         server_id = str(server.id or "").strip()
         if not server_id:

--- a/pallas/product/llm/tools/mcp_bootstrap.py
+++ b/pallas/product/llm/tools/mcp_bootstrap.py
@@ -8,15 +8,39 @@ import subprocess
 import threading
 from typing import Any
 
+from nonebot import logger
+
 from pallas.product.llm.config import LlmMcpServerConfig, get_llm_config
 from pallas.product.llm.tools.contracts import ToolCapability
 from pallas.product.llm.tools.registry import LlmToolSource, LlmToolSpec, register_tool
 
 _MCP_TOOL_NAMES: set[str] = set()
+_MCP_REGISTER_ERRORS: list[dict[str, str]] = []
 
 
 def clear_mcp_tools() -> None:
     _MCP_TOOL_NAMES.clear()
+    _MCP_REGISTER_ERRORS.clear()
+
+
+def mcp_registration_snapshot() -> dict[str, Any]:
+    cfg = get_llm_config()
+    servers = [
+        {
+            "id": server.id,
+            "transport": (server.transport or "stdio").strip().lower() or "stdio",
+            "command": list(server.command or []),
+            "url": str(server.url or "").strip(),
+            "enabled_tools": list(server.enabled_tools or []),
+        }
+        for server in cfg.mcp_servers
+    ]
+    return {
+        "servers": servers,
+        "registered_tool_names": sorted(_MCP_TOOL_NAMES),
+        "registered_count": len(_MCP_TOOL_NAMES),
+        "errors": list(_MCP_REGISTER_ERRORS),
+    }
 
 
 def _tool_capabilities(tool_row: dict[str, Any]) -> frozenset[str]:
@@ -251,10 +275,18 @@ def build_mcp_tool_spec(server: LlmMcpServerConfig, tool_row: dict[str, Any]) ->
 
 def register_mcp_tools() -> int:
     count = 0
+    _MCP_REGISTER_ERRORS.clear()
     for server in get_llm_config().mcp_servers:
+        server_id = str(server.id or "").strip()
+        if not server_id:
+            _MCP_REGISTER_ERRORS.append({"server_id": "", "error": "missing_server_id"})
+            continue
         try:
             tools = list_mcp_tools(server)
-        except Exception:
+        except Exception as err:
+            msg = str(err).strip() or err.__class__.__name__
+            logger.warning("mcp register failed server_id={}: {}", server_id, msg)
+            _MCP_REGISTER_ERRORS.append({"server_id": server_id, "error": msg})
             continue
         for tool_row in tools:
             name = _tool_name(server.id, tool_row)

--- a/pallas/product/llm/tools/registry.py
+++ b/pallas/product/llm/tools/registry.py
@@ -553,6 +553,8 @@ def build_tools_catalog_ui() -> dict[str, Any]:
         })
         seen_names.add(decl.name)
     items.sort(key=operator.itemgetter("name"))
+    from pallas.product.llm.tools.mcp_bootstrap import mcp_registration_snapshot
+
     return {
         "items": items,
         "count": len(items),
@@ -563,6 +565,7 @@ def build_tools_catalog_ui() -> dict[str, Any]:
             "blacklist": [str(item) for item in (cfg.llm_tools_blacklist or []) if str(item).strip()],
             "arknights_kb_enabled": bool(kb.arknights_kb_enabled),
             "desc_max_len": int(cfg.llm_tools_desc_max_len),
+            "mcp": mcp_registration_snapshot(),
         },
         "overrides": overrides,
     }

--- a/pallas/product/llm/webui_config.py
+++ b/pallas/product/llm/webui_config.py
@@ -7,7 +7,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from pallas.console.webui.field_help import field_help
-from pallas.product.llm.config import get_llm_config
+from pallas.product.llm.config import LlmMcpServerConfig, get_llm_config
 
 VectorRetrieveMode = Literal["keyword", "embedding", "hybrid", "vector"]
 RepeaterMode = Literal["off", "select", "select_polish_lite", "select_fallback", "fallback"]
@@ -394,6 +394,22 @@ class LlmWebuiConfig(BaseModel):
             "发给模型的工具说明最长多少字（多了截断）",
             "默认 120。说明太短模型可能用错工具可略增；想省 token 保持默认或略减",
             "只影响写入模型的说明长度，不改工具本身功能",
+        ),
+    )
+    mcp_servers: list[LlmMcpServerConfig] = Field(
+        default_factory=list,
+        description=field_help(
+            "接入哪些外部 MCP 工具服务器",
+            "在「对话配置 → 工具」里增删。stdio 填启动命令；HTTP 还须配置下方允许的 URL 前缀",
+            "保存后会重新注册工具目录。command / enabled_tools 为空时按传输类型忽略对应项",
+        ),
+    )
+    llm_mcp_http_allowlist: str = Field(
+        default="",
+        description=field_help(
+            "允许访问的 MCP HTTP 地址前缀（逗号分隔）",
+            "仅 transport=http 时需要。例如 http://127.0.0.1:8765 。留空则拒绝所有 HTTP MCP",
+            "须与服务器 url 前缀匹配；未列入名单的地址不会连接",
         ),
     )
     web_search_api_url: str = Field(
@@ -854,6 +870,8 @@ def get_llm_webui_config() -> LlmWebuiConfig:
         llm_tools_max_rounds=cfg.llm_tools_max_rounds,
         llm_tools_blacklist=list(cfg.llm_tools_blacklist or []),
         llm_tools_desc_max_len=cfg.llm_tools_desc_max_len,
+        mcp_servers=list(cfg.mcp_servers or []),
+        llm_mcp_http_allowlist=str(repo_env_raw_value("LLM_MCP_HTTP_ALLOWLIST") or "").strip(),
         web_search_api_url=str(repo_env_raw_value("WEB_SEARCH_API_URL") or "").strip(),
         tavily_api_key=str(repo_env_raw_value("TAVILY_API_KEY") or "").strip(),
         llm_chat_max_concurrency=cfg.llm_chat_max_concurrency,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pallas-bot"
-version = "4.1.11"
+version = "4.1.12"
 description = "《明日方舟》帕拉斯 Bot"
 authors = [{ name = "MistEO" }]
 maintainers = [

--- a/tests/product/llm/test_mcp_session.py
+++ b/tests/product/llm/test_mcp_session.py
@@ -1,0 +1,115 @@
+"""MCP 常驻 session 复用。"""
+
+from __future__ import annotations
+
+from pallas.product.llm.config import LlmMcpServerConfig
+from pallas.product.llm.tools import mcp_bootstrap
+
+
+class _FakeStdioSession(mcp_bootstrap._StdioMcpSession):
+    def __init__(self, server_id: str, fingerprint: str) -> None:
+        super().__init__(server_id=server_id, transport="stdio", fingerprint=fingerprint)
+        self.starts = 0
+        self.methods: list[str] = []
+
+    def alive(self) -> bool:
+        return True
+
+    def ensure_started(self, server: LlmMcpServerConfig) -> None:
+        self.starts += 1
+        self.fingerprint = mcp_bootstrap._server_fingerprint(server)
+
+    def call(self, *, method: str, params: dict | None = None) -> dict:
+        self.methods.append(method)
+        self.call_count += 1
+        if method == "tools/list":
+            return {"tools": [{"name": "ping", "description": "p", "inputSchema": {"type": "object"}}]}
+        if method == "tools/call":
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+        return {}
+
+    def close(self) -> None:
+        return
+
+
+def test_stdio_session_reused_across_calls(monkeypatch) -> None:
+    mcp_bootstrap.close_all_mcp_sessions()
+    created: list[_FakeStdioSession] = []
+
+    def fake_new(server: LlmMcpServerConfig):
+        session = _FakeStdioSession(server.id, mcp_bootstrap._server_fingerprint(server))
+        session.ensure_started(server)
+        created.append(session)
+        return session
+
+    monkeypatch.setattr(mcp_bootstrap, "_new_session", fake_new)
+    server = LlmMcpServerConfig(id="demo", transport="stdio", command=["fake-mcp"])
+
+    tools1 = mcp_bootstrap.list_mcp_tools(server)
+    tools2 = mcp_bootstrap.list_mcp_tools(server)
+    call = mcp_bootstrap.call_mcp_tool(server, tool_name="ping", arguments={})
+
+    assert tools1[0]["name"] == "ping"
+    assert tools2[0]["name"] == "ping"
+    assert call["is_error"] is False
+    assert len(created) == 1
+    assert created[0].call_count == 3
+    assert created[0].methods == ["tools/list", "tools/list", "tools/call"]
+    snap = mcp_bootstrap.mcp_registration_snapshot()
+    assert snap["sessions"][0]["id"] == "demo"
+    assert snap["sessions"][0]["alive"] is True
+    mcp_bootstrap.close_all_mcp_sessions()
+
+
+def test_session_recreated_when_fingerprint_changes(monkeypatch) -> None:
+    mcp_bootstrap.close_all_mcp_sessions()
+    created: list[_FakeStdioSession] = []
+
+    def fake_new(server: LlmMcpServerConfig):
+        session = _FakeStdioSession(server.id, mcp_bootstrap._server_fingerprint(server))
+        session.ensure_started(server)
+        created.append(session)
+        return session
+
+    monkeypatch.setattr(mcp_bootstrap, "_new_session", fake_new)
+    a = LlmMcpServerConfig(id="demo", transport="stdio", command=["mcp-a"])
+    b = LlmMcpServerConfig(id="demo", transport="stdio", command=["mcp-b"])
+
+    mcp_bootstrap.list_mcp_tools(a)
+    mcp_bootstrap.list_mcp_tools(b)
+    assert len(created) == 2
+    mcp_bootstrap.close_all_mcp_sessions()
+
+
+def test_register_closes_previous_sessions(monkeypatch) -> None:
+    mcp_bootstrap.close_all_mcp_sessions()
+    closed: list[str] = []
+
+    class Tracking(_FakeStdioSession):
+        def close(self) -> None:
+            closed.append(self.server_id)
+
+    def fake_new(server: LlmMcpServerConfig):
+        session = Tracking(server.id, mcp_bootstrap._server_fingerprint(server))
+        session.ensure_started(server)
+        return session
+
+    monkeypatch.setattr(mcp_bootstrap, "_new_session", fake_new)
+    monkeypatch.setattr(
+        mcp_bootstrap,
+        "get_llm_config",
+        lambda: type(
+            "C",
+            (),
+            {"mcp_servers": [LlmMcpServerConfig(id="demo", transport="stdio", command=["x"])]},
+        )(),
+    )
+    # 先建一个 session
+    mcp_bootstrap.list_mcp_tools(LlmMcpServerConfig(id="demo", transport="stdio", command=["x"]))
+    assert mcp_bootstrap.mcp_registration_snapshot()["sessions"]
+    count = mcp_bootstrap.register_mcp_tools()
+    assert count == 1
+    assert "demo" in closed
+    # register 后会重新 list，应仍有活 session
+    assert mcp_bootstrap.mcp_registration_snapshot()["sessions"]
+    mcp_bootstrap.close_all_mcp_sessions()

--- a/tests/product/llm/test_mcp_webui_config.py
+++ b/tests/product/llm/test_mcp_webui_config.py
@@ -1,0 +1,126 @@
+"""MCP 配置经 WebUI llm section 落盘与重注册。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_llm_webui_config_exposes_mcp_fields(monkeypatch) -> None:
+    from pallas.product.llm import webui_config as webui_mod
+    from pallas.product.llm.config import LlmConfig, LlmMcpServerConfig
+
+    monkeypatch.setattr(
+        webui_mod,
+        "get_llm_config",
+        lambda: LlmConfig(
+            mcp_servers=[
+                LlmMcpServerConfig(id="prts", transport="stdio", command=["uvx", "prts-mcp"]),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.config.repo_settings.repo_env_raw_value",
+        lambda key: "http://127.0.0.1:8765" if key == "LLM_MCP_HTTP_ALLOWLIST" else None,
+    )
+    cfg = webui_mod.get_llm_webui_config()
+    assert len(cfg.mcp_servers) == 1
+    assert cfg.mcp_servers[0].id == "prts"
+    assert cfg.llm_mcp_http_allowlist == "http://127.0.0.1:8765"
+
+
+def test_llm_section_maps_mcp_env_keys() -> None:
+    from pallas.console.webui.env_sections import clear_webui_env_sections_cache, get_webui_env_section
+
+    clear_webui_env_sections_cache()
+    section = get_webui_env_section("llm")
+    assert section.field_to_env["mcp_servers"] == "LLM_MCP_SERVERS"
+    assert section.field_to_env["llm_mcp_http_allowlist"] == "LLM_MCP_HTTP_ALLOWLIST"
+
+
+def test_apply_llm_mcp_patch_rewrites_env_and_reboots_tools(monkeypatch) -> None:
+    from pallas.console.webui import apply_webui_env_section_patch
+    from pallas.console.webui.env_sections import clear_webui_env_sections_cache
+    from pallas.product.llm import webui_config as webui_mod
+    from pallas.product.llm.config import LlmConfig
+
+    clear_webui_env_sections_cache()
+    monkeypatch.setattr(webui_mod, "get_llm_config", lambda: LlmConfig())
+    monkeypatch.setattr(
+        "pallas.core.foundation.config.repo_settings.repo_env_raw_value",
+        lambda _key: None,
+    )
+
+    written: dict[str, str] = {}
+    reboot: list[bool] = []
+
+    monkeypatch.setattr(
+        "pallas.console.webui.env_sections.upsert_repo_settings_items",
+        lambda items: written.update(items),
+    )
+    monkeypatch.setattr(
+        "pallas.product.llm.config.clear_llm_config_cache",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "pallas.product.llm.tools.bootstrap.ensure_llm_tools_bootstrapped",
+        lambda *, force=False: reboot.append(force),
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.config.repo_settings.purge_misplaced_ai_env_keys_from_webui",
+        lambda: None,
+    )
+
+    apply_webui_env_section_patch(
+        "llm",
+        {
+            "mcp_servers": [
+                {
+                    "id": "demo",
+                    "transport": "stdio",
+                    "command": ["echo", "hi"],
+                    "enabled_tools": ["a"],
+                    "url": "",
+                }
+            ],
+            "llm_mcp_http_allowlist": "http://127.0.0.1:9",
+        },
+    )
+
+    assert "LLM_MCP_SERVERS" in written
+    assert '"id": "demo"' in written["LLM_MCP_SERVERS"] or '"id":"demo"' in written["LLM_MCP_SERVERS"]
+    assert written["LLM_MCP_HTTP_ALLOWLIST"] == "http://127.0.0.1:9"
+    assert reboot == [True]
+
+
+def test_mcp_registration_snapshot_records_errors(monkeypatch) -> None:
+    from pallas.product.llm.tools import mcp_bootstrap
+    from pallas.product.llm.tools.bootstrap import reset_llm_tools_bootstrap_for_tests
+    from pallas.product.llm.tools.registry import clear_tool_registry
+
+    reset_llm_tools_bootstrap_for_tests()
+    clear_tool_registry()
+    mcp_bootstrap.clear_mcp_tools()
+
+    server = SimpleNamespace(
+        id="broken",
+        transport="stdio",
+        command=["false"],
+        enabled_tools=[],
+        url="",
+    )
+    monkeypatch.setattr(
+        mcp_bootstrap,
+        "get_llm_config",
+        lambda: SimpleNamespace(mcp_servers=[server]),
+    )
+    monkeypatch.setattr(
+        mcp_bootstrap,
+        "list_mcp_tools",
+        lambda _server: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    count = mcp_bootstrap.register_mcp_tools()
+    snap = mcp_bootstrap.mcp_registration_snapshot()
+    assert count == 0
+    assert snap["errors"] == [{"server_id": "broken", "error": "boom"}]
+    assert snap["registered_count"] == 0


### PR DESCRIPTION
## 更新公告

- 智能对话可在控制台配置外部 MCP，并挂到工具目录
- MCP 连接改为常驻复用（stdio / HTTP），避免每次冷启动
- 注册失败原因可在工具策略里看到
- 捆绑控制台 WebUI **v0.8.7**

## Added

- `LLM_MCP_SERVERS` / `LLM_MCP_HTTP_ALLOWLIST` 经 WebUI llm 段读写；变更后重注册工具

## Changed

- MCP stdio/HTTP 常驻 session；snapshot 含 sessions

## Summary by Sourcery

发布 4.1.12 版本，引入持久化 MCP 会话以及由 WebUI 管理的 LLM 工具 MCP 配置。

New Features:
- 在 LLM WebUI 部分中暴露 MCP 服务器配置和 HTTP allowlist，并由环境变量 `LLM_MCP_SERVERS` 和 `LLM_MCP_HTTP_ALLOWLIST` 提供支持。
- 在工具目录 UI 中包含 MCP 注册信息和会话快照详情，使 MCP 状态和错误可以在控制台中可见。

Enhancements:
- 重构 MCP 集成，以在多次调用中复用长连接的 stdio/HTTP 会话，引入会话池管理，并在故障时自动恢复。
- 按服务器记录 MCP 工具注册错误，并在重新注册时清理会话和错误，以保持状态一致。
- 当与 MCP 相关的 WebUI 设置发生变化时，触发 LLM 工具重新引导，以便工具目录反映更新后的 MCP 服务器。
- 在变更日志和项目元数据中将内置控制台 WebUI 版本引用更新为 v0.8.7。

Build:
- 将项目/包版本从 4.1.11 提升到 4.1.12。

Tests:
- 新增测试，用于覆盖通过 LLM WebUI 配置暴露 MCP 设置及其到环境变量区段的映射，包括环境持久化和工具重启行为。
- 新增测试，用于验证 MCP 会话复用、在配置指纹变化时的会话重建，以及在注册时的清理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Release version 4.1.12 with persistent MCP sessions and WebUI-managed MCP configuration for LLM tools.

New Features:
- Expose MCP server configuration and HTTP allowlist in the LLM WebUI section, backed by LLM_MCP_SERVERS and LLM_MCP_HTTP_ALLOWLIST env keys.
- Include MCP registration and session snapshot details in the tools catalog UI so MCP status and errors are visible from the console.

Enhancements:
- Refactor MCP integration to reuse long-lived stdio/HTTP sessions across calls, with pooled session management and automatic recovery on failure.
- Record MCP tool registration errors per server and clear sessions and errors on re-registration to keep state consistent.
- Trigger LLM tool re-bootstrap when MCP-related WebUI settings change so the tool directory reflects updated MCP servers.
- Update bundled console WebUI version reference to v0.8.7 in the changelog and project metadata.

Build:
- Bump project/package version from 4.1.11 to 4.1.12.

Tests:
- Add tests covering MCP settings exposure via LLM WebUI config and env section mapping, including env persistence and tool reboot behavior.
- Add tests verifying MCP session reuse, recreation when configuration fingerprints change, and cleanup on registration.

</details>