### PR TITLE
feat(persona): 牛格区分度与专属别名

### DIFF
--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -59,6 +59,7 @@ from pallas.product.llm.reply_gate import evaluate_llm_reply_gate_result, reply_
 from pallas.product.llm.reply_variation import (
     build_recent_reply_ending_hint,
     build_recent_reply_variation_hint,
+    extract_recent_motifs,
     repeated_assistant_openers,
     should_wait_for_more,
 )
@@ -153,6 +154,7 @@ async def build_llm_chat_expression_suffix(
     bot_id: int = 0,
     scene: str = "",
     blocked_openers: list[str] | None = None,
+    blocked_motifs: list[str] | None = None,
 ) -> str:
     suffix, _entries = await build_llm_chat_expression_selection(
         group_id,
@@ -160,6 +162,7 @@ async def build_llm_chat_expression_suffix(
         bot_id=bot_id,
         scene=scene,
         blocked_openers=blocked_openers,
+        blocked_motifs=blocked_motifs,
     )
     return suffix
 
@@ -171,6 +174,7 @@ async def build_llm_chat_expression_selection(
     bot_id: int = 0,
     scene: str = "",
     blocked_openers: list[str] | None = None,
+    blocked_motifs: list[str] | None = None,
 ) -> tuple[str, list]:
     if group_id is None:
         return "", []
@@ -191,6 +195,7 @@ async def build_llm_chat_expression_selection(
         scene=scene,
         style_profile=profile,
         blocked_openers=blocked_openers,
+        blocked_motifs=blocked_motifs,
     )
 
 
@@ -268,6 +273,46 @@ async def latest_llm_assistant_reply(bot_id: int, group_id: int | None, user_id:
         if str(getattr(turn, "role", "")).strip() == "assistant":
             return str(getattr(turn, "content", "") or "").strip()
     return ""
+
+
+def build_blocked_motifs(
+    *,
+    recent_turns,
+    recent_group_rows,
+    bot_id: int,
+) -> list[str]:
+    group_texts: list[str] = []
+    target_bot_id = int(bot_id)
+    for row in recent_group_rows or ():
+        if isinstance(row, str):
+            plain = row.strip()
+            if plain and "[CQ:" not in plain:
+                group_texts.append(plain)
+            continue
+        plain = str(
+            row.get("text", "") if isinstance(row, dict) else getattr(row, "text", "")
+        ).strip()
+        if not plain or "[CQ:" in plain:
+            continue
+        role = str(
+            row.get("role", "") if isinstance(row, dict) else getattr(row, "role", "")
+        ).strip()
+        row_user_id = int(
+            row.get("user_id", 0) if isinstance(row, dict) else getattr(row, "user_id", 0) or 0
+        )
+        row_bot_id = int(
+            row.get("bot_id", 0) if isinstance(row, dict) else getattr(row, "bot_id", 0) or 0
+        )
+        if role == "assistant" or row_user_id == target_bot_id or row_bot_id == target_bot_id:
+            group_texts.append(plain)
+    motifs = extract_recent_motifs(group_texts)
+    if motifs:
+        return motifs
+    return extract_recent_motifs([
+        str(getattr(turn, "content", "") or "").strip()
+        for turn in recent_turns
+        if str(getattr(turn, "role", "")).strip() == "assistant"
+    ])
 
 
 @llm_chat_msg.handle()
@@ -532,6 +577,23 @@ async def handle_llm_chat(bot: Bot, event: Event):
     request_id = str(ULID())
     recent_turns = await list_user_llm_messages(int(bot.self_id), group_id, user_id, limit=6)
     blocked_openers = repeated_assistant_openers(recent_turns)
+    recent_reply_texts: list[str] = []
+    if group_id is not None:
+        from pallas.product.llm.repeater_persona_context import load_recent_bot_plain_replies
+
+        try:
+            recent_reply_texts = await load_recent_bot_plain_replies(
+                int(bot.self_id),
+                int(group_id),
+                limit=6,
+            )
+        except Exception:
+            recent_reply_texts = []
+    blocked_motifs = build_blocked_motifs(
+        recent_turns=recent_turns,
+        recent_group_rows=recent_reply_texts,
+        bot_id=int(bot.self_id),
+    )
     focus_text = plain or msg
     recent_plain = [str(getattr(turn, "content", "") or "").strip() for turn in recent_turns[-6:]]
     has_multi_party = (
@@ -552,6 +614,7 @@ async def handle_llm_chat(bot: Bot, event: Event):
         bot_id=int(bot.self_id),
         scene=str(behavior_scene),
         blocked_openers=blocked_openers,
+        blocked_motifs=blocked_motifs,
     )
     selected_expression_ids = [item.entry_id for item in selected_expression_entries]
     from pallas.product.llm.situational_rules import enrich_system_with_situational_rules
@@ -750,18 +813,6 @@ async def handle_llm_chat(bot: Bot, event: Event):
     if current_turn_decision.action is CurrentTurnAction.FOLLOW_UP:
         style_user_hints.append("本轮只追问一个必要信息，问题要短。")
     last_reply_text = await latest_llm_assistant_reply(int(bot.self_id), group_id, user_id)
-    recent_reply_texts: list[str] = []
-    if group_id is not None:
-        from pallas.product.llm.repeater_persona_context import load_recent_bot_plain_replies
-
-        try:
-            recent_reply_texts = await load_recent_bot_plain_replies(
-                int(bot.self_id),
-                int(group_id),
-                limit=6,
-            )
-        except Exception:
-            recent_reply_texts = []
     persona_dict = None
     if persona_bundle is not None:
         try:

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -289,20 +289,12 @@ def build_blocked_motifs(
             if plain and "[CQ:" not in plain:
                 group_texts.append(plain)
             continue
-        plain = str(
-            row.get("text", "") if isinstance(row, dict) else getattr(row, "text", "")
-        ).strip()
+        plain = str(row.get("text", "") if isinstance(row, dict) else getattr(row, "text", "")).strip()
         if not plain or "[CQ:" in plain:
             continue
-        role = str(
-            row.get("role", "") if isinstance(row, dict) else getattr(row, "role", "")
-        ).strip()
-        row_user_id = int(
-            row.get("user_id", 0) if isinstance(row, dict) else getattr(row, "user_id", 0) or 0
-        )
-        row_bot_id = int(
-            row.get("bot_id", 0) if isinstance(row, dict) else getattr(row, "bot_id", 0) or 0
-        )
+        role = str(row.get("role", "") if isinstance(row, dict) else getattr(row, "role", "")).strip()
+        row_user_id = int(row.get("user_id", 0) if isinstance(row, dict) else getattr(row, "user_id", 0) or 0)
+        row_bot_id = int(row.get("bot_id", 0) if isinstance(row, dict) else getattr(row, "bot_id", 0) or 0)
         if role == "assistant" or row_user_id == target_bot_id or row_bot_id == target_bot_id:
             group_texts.append(plain)
     motifs = extract_recent_motifs(group_texts)

--- a/pallas/core/platform/ingress/alias_route.py
+++ b/pallas/core/platform/ingress/alias_route.py
@@ -39,6 +39,18 @@ def speak_aliases_for_bot_sync(bot_id: int) -> list[str]:
     return extract_self_aliases(persona, login_nickname=nick or None)
 
 
+def speak_exclusive_aliases_for_bot_sync(bot_id: int) -> list[str]:
+    from pallas.product.persona.self_identity import (
+        extract_exclusive_self_aliases,
+        resolve_cached_login_nickname,
+    )
+
+    nick = resolve_cached_login_nickname(int(bot_id))
+    learned = cached_learned_self_aliases(int(bot_id))
+    persona = {"self_aliases": learned} if learned else None
+    return extract_exclusive_self_aliases(persona, login_nickname=nick or None)
+
+
 def fleet_bots_matching_plain(plain_text: str, *, min_alias_len: int = 2) -> frozenset[int]:
     from pallas.core.platform.multi_bot.fleet import get_fleet_bot_ids
     from pallas.product.llm.speak_perception import text_mentions_aliases
@@ -49,7 +61,7 @@ def fleet_bots_matching_plain(plain_text: str, *, min_alias_len: int = 2) -> fro
     hits: set[int] = set()
     for raw_id in get_fleet_bot_ids():
         bot_id = int(raw_id)
-        aliases = speak_aliases_for_bot_sync(bot_id)
+        aliases = speak_exclusive_aliases_for_bot_sync(bot_id)
         if text_mentions_aliases(plain, aliases, min_alias_len=min_alias_len):
             hits.add(bot_id)
     return frozenset(hits)

--- a/pallas/product/llm/reply_variation.py
+++ b/pallas/product/llm/reply_variation.py
@@ -35,6 +35,7 @@ _USER_WAIT_TOKENS = ("等等", "等下", "先别", "我补一句", "还有", "�
 _STRUCTURE_MARKERS = ("先", "别", "可以", "不用", "慢慢", "一下", "这事", "你先")
 _GENERIC_PREFIX_MIN_LEN = 3
 _GENERIC_PREFIX_MAX_LEN = 4
+DEFAULT_MOTIF_TOKENS = ("草料", "土木", "漂亮牛牛")
 
 
 def should_wait_for_more(user_text: str) -> bool:
@@ -48,6 +49,13 @@ def should_wait_for_more(user_text: str) -> bool:
 
 def has_kaomoji_suffix(text: str) -> bool:
     return bool(_KAOMOJI_SUFFIX_RE.search(str(text or "").strip()))
+
+
+def extract_recent_motifs(texts: list[str]) -> list[str]:
+    recent_texts = [str(item or "").strip() for item in texts[-6:] if str(item or "").strip()]
+    if not recent_texts:
+        return []
+    return [token for token in DEFAULT_MOTIF_TOKENS if any(token in text for text in recent_texts)]
 
 
 def repeated_assistant_openers(turns: list[LlmChatTurn], *, limit: int = 3) -> list[str]:
@@ -152,6 +160,9 @@ def build_recent_reply_variation_hint(turns: list[LlmChatTurn]) -> str:
         return ""
 
     hints: list[str] = []
+    motifs = extract_recent_motifs(assistant_texts)
+    if motifs:
+        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs))
     openers = repeated_assistant_openers(turns)
     if openers:
         hints.append("最近几轮别再用这些开头：" + "、".join(openers))
@@ -234,6 +245,9 @@ def build_variation_hint_from_recent_texts(recent_texts: list[str]) -> str:
         return ""
 
     hints: list[str] = []
+    motifs = extract_recent_motifs(texts)
+    if motifs:
+        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs))
     openers: list[str] = []
     for text in reversed(texts[-6:]):
         opener = classify_repeated_opener(text)

--- a/pallas/product/llm/speak_perception.py
+++ b/pallas/product/llm/speak_perception.py
@@ -23,6 +23,28 @@ _CQ_AT_RE = re.compile(r"\[CQ:at,qq=\d+[^\]]*\]", re.IGNORECASE)
 _AT_PLAIN_RE = re.compile(r"@[^\s@，,。！!？?：:;；]{1,24}")
 _REPLY_MARK_RE = re.compile(r"\[回复[^\]]*\]")
 _COMMAND_START_RE = re.compile(r"^[/!！#＃.]")
+_GENERIC_ALIAS_PREFIX_CUES = ("叫", "喊", "问", "找", "戳", "cue", "艾特")
+_GENERIC_ALIAS_SUFFIX_CUES = (
+    "出来",
+    "一下",
+    "一声",
+    "在吗",
+    "在嘛",
+    "在不",
+    "你好",
+    "呢",
+    "呀",
+    "啊",
+    "吗",
+    "嘛",
+    "么",
+    "快",
+    "看",
+    "说",
+    "回",
+    "救",
+    "帮",
+)
 _REPLY_CUE_TOKENS = (
     "?",
     "？",
@@ -62,18 +84,82 @@ def strip_mention_noise(text: str) -> str:
     return " ".join(out.split()).strip()
 
 
+def _is_cjk_or_alnum(char: str) -> bool:
+    if not char:
+        return False
+    codepoint = ord(char)
+    if (
+        0x4E00 <= codepoint <= 0x9FFF
+        or 0x3400 <= codepoint <= 0x4DBF
+        or 0x20000 <= codepoint <= 0x2A6DF
+        or 0x2A700 <= codepoint <= 0x2B73F
+        or 0x2B740 <= codepoint <= 0x2B81F
+        or 0x2B820 <= codepoint <= 0x2CEAF
+        or 0xF900 <= codepoint <= 0xFAFF
+    ):
+        return True
+    return char.isalnum()
+
+
+def _generic_alias_before_ok(content: str, start: int) -> bool:
+    if start == 0:
+        return True
+    prev = content[start - 1]
+    if not _is_cjk_or_alnum(prev):
+        return True
+    prefix = content[max(0, start - 2) : start]
+    return any(prefix.endswith(token) for token in _GENERIC_ALIAS_PREFIX_CUES)
+
+
+def _generic_alias_after_ok(content: str, end: int) -> bool:
+    if end == len(content):
+        return True
+    next_char = content[end]
+    if not _is_cjk_or_alnum(next_char):
+        return True
+    tail = content[end:]
+    return any(tail.startswith(token) for token in _GENERIC_ALIAS_SUFFIX_CUES)
+
+
+def _contains_generic_alias(content: str, alias: str) -> bool:
+    alias_text = str(alias or "").strip()
+    if not content or not alias_text:
+        return False
+    alias_folded = alias_text.casefold()
+    alias_len = len(alias_text)
+    max_start = len(content) - alias_len
+    for start in range(max_start + 1):
+        segment = content[start : start + alias_len]
+        if segment != alias_text and segment.casefold() != alias_folded:
+            continue
+        before_ok = _generic_alias_before_ok(content, start)
+        end = start + alias_len
+        after_ok = _generic_alias_after_ok(content, end)
+        if before_ok and after_ok:
+            return True
+    return False
+
+
 def text_mentions_aliases(
     text: str,
     aliases: Sequence[str],
     *,
     min_alias_len: int = 2,
+    generic_aliases: Sequence[str] | None = None,
 ) -> bool:
     content = strip_mention_noise(text)
     if not content:
         return False
     folded = content.casefold()
+    generic_casefolds = {
+        str(alias or "").strip().casefold() for alias in (generic_aliases or ()) if str(alias or "").strip()
+    }
     for alias in sorted((str(a or "").strip() for a in aliases), key=len, reverse=True):
         if len(alias) < int(min_alias_len):
+            continue
+        if alias.casefold() in generic_casefolds:
+            if _contains_generic_alias(content, alias):
+                return True
             continue
         if alias.casefold() in folded or alias in content:
             return True
@@ -165,6 +251,7 @@ def evaluate_speak_perception(
     *,
     plain_text: str,
     aliases: Sequence[str],
+    generic_aliases: Sequence[str] | None = None,
     is_to_me: bool,
     bot_id: int | None = None,
     mention_enabled: bool = True,
@@ -200,7 +287,21 @@ def evaluate_speak_perception(
     if looks_like_spam_or_promo(plain):
         return SpeakDecision(False, "spam", 0)
 
-    if mention_enabled and text_mentions_aliases(plain, aliases, min_alias_len=min_alias_len):
+    speak_generic_aliases = generic_aliases
+    if speak_generic_aliases is None:
+        try:
+            from pallas.product.persona.self_identity import extract_generic_self_aliases
+
+            speak_generic_aliases = extract_generic_self_aliases()
+        except Exception:
+            speak_generic_aliases = ()
+
+    if mention_enabled and text_mentions_aliases(
+        plain,
+        aliases,
+        min_alias_len=min_alias_len,
+        generic_aliases=speak_generic_aliases,
+    ):
         return SpeakDecision(True, "mention", 100)
 
     if followup_active and plain and not is_noise_fragment(plain):

--- a/pallas/product/persona/compile_persona_prompt.py
+++ b/pallas/product/persona/compile_persona_prompt.py
@@ -28,6 +28,7 @@ from .prompt_guard import (
     sanitize_prompt_block,
     wrap_stats_block,
 )
+from .seed import normalize_seed_prefs, resolve_effective_seed_prefs
 from .self_identity import (
     compile_repeater_self_identity_prompt,
     compile_self_identity_prompt,
@@ -77,6 +78,20 @@ _LENGTH_HINTS: dict[str, str] = {
     "short": "优先简短回复（1-2 句）",
     "medium": "适中长度（2-3 句）",
     "long": "可稍详细展开，但仍保持口语",
+}
+
+_ARCHETYPE_FINGERPRINTS: dict[str, str] = {
+    "terse": "- 少展开，能一句接完就一句接完，别起哄加戏。",
+    "chaotic": "- 可短促接梗，少总结陈词，别把梗抻成长段。",
+    "polite": "- 先应一句再吐槽，少抢话下结论，给人留接茬口。",
+}
+
+_SEED_FINGERPRINTS: dict[str, str] = {
+    "short": "- 优先短句收口，能不铺垫就别铺垫。",
+    "long": "- 需要展开时也只多补半句，别写成小作文。",
+    "warm": "- 先把对方的话接住，再顺势回一句。",
+    "chaotic": "- 可顺手接梗反抛半句，但别连着抖包袱。",
+    "restrained": "- 收着点火候，别追着一个梗反复拱。",
 }
 
 _DRUNK_CHAT_OVERLAY = (
@@ -188,7 +203,12 @@ def clear_base_system_prompt_cache() -> None:
         _base_cached_text = ""
 
 
-def build_bot_behavior_prompt(persona: ResolvedPersona, *, profile: str = PROMPT_PROFILE_DEFAULT) -> str:
+def build_bot_behavior_prompt(
+    persona: ResolvedPersona,
+    *,
+    profile: str = PROMPT_PROFILE_DEFAULT,
+    seed_prefs: list[str] | None = None,
+) -> str:
     tone = normalize_enum(str(persona.tone or ""), ALLOWED_TONES, "neutral")
     length_pref = normalize_enum(str(persona.length_pref or ""), ALLOWED_LENGTH_PREFS, "any")
     tone_map = _REPEATER_TONE_HINTS if profile == PROMPT_PROFILE_REPEATER else _TONE_HINTS
@@ -219,6 +239,21 @@ def build_bot_behavior_prompt(persona: ResolvedPersona, *, profile: str = PROMPT
     bluntness_hint = bluntness_behavior_hint(float(persona.bluntness))
     if bluntness_hint:
         lines.append(bluntness_hint)
+    fingerprint_lines: list[str] = []
+    archetype_fingerprint = _ARCHETYPE_FINGERPRINTS.get(str(persona.archetype or "").strip().lower())
+    if archetype_fingerprint:
+        fingerprint_lines.extend(["【接话指纹】", archetype_fingerprint])
+    normalized_seed_prefs = normalize_seed_prefs(seed_prefs or [])
+    if normalized_seed_prefs:
+        if not fingerprint_lines:
+            fingerprint_lines.append("【接话指纹】")
+        for pref in normalized_seed_prefs:
+            seed_line = _SEED_FINGERPRINTS.get(pref)
+            if seed_line and seed_line not in fingerprint_lines:
+                fingerprint_lines.append(seed_line)
+        fingerprint_lines.append("- 少反复同一隐喻起手。")
+    if fingerprint_lines:
+        lines.extend(fingerprint_lines)
     return wrap_stats_block("bot_behavior", "\n".join(lines))
 
 
@@ -266,7 +301,8 @@ def compile_persona_prompt(
         (base_system or "").strip() or load_base_system_prompt(custom_path=base_system_path),
         max_len=12000,
     )
-    bot_behavior = build_bot_behavior_prompt(persona, profile=profile)
+    seed_prefs, _seed_source = resolve_effective_seed_prefs(bot_persona, int(bot_id))
+    bot_behavior = build_bot_behavior_prompt(persona, profile=profile, seed_prefs=seed_prefs)
     group_style = compile_group_style_prompt(style_profile)
     group_expression = compile_group_expression_prompt(style_profile)
     try:

--- a/pallas/product/persona/expression_habits.py
+++ b/pallas/product/persona/expression_habits.py
@@ -61,6 +61,7 @@ async def build_expression_context_suffix(
     scene: str = "",
     style_profile: dict[str, Any] | None = None,
     blocked_openers: list[str] | None = None,
+    blocked_motifs: list[str] | None = None,
 ) -> str:
     reference, _entries = await build_expression_context_with_entries(
         group_id,
@@ -69,6 +70,7 @@ async def build_expression_context_suffix(
         scene=scene,
         style_profile=style_profile,
         blocked_openers=blocked_openers,
+        blocked_motifs=blocked_motifs,
     )
     return reference
 
@@ -81,6 +83,7 @@ async def build_expression_context_with_entries(
     scene: str = "",
     style_profile: dict[str, Any] | None = None,
     blocked_openers: list[str] | None = None,
+    blocked_motifs: list[str] | None = None,
 ) -> tuple[str, list]:
     """Return the exact entries used to build the expression reference."""
     """Prefer matched expression-bank references, then retain profile habits."""
@@ -91,6 +94,8 @@ async def build_expression_context_with_entries(
             "bot_id": bot_id,
             "blocked_openers": blocked_openers or (),
         }
+        if blocked_motifs:
+            kwargs["blocked_motifs"] = tuple(blocked_motifs)
         if scene:
             kwargs["scene"] = scene
         entries = await asyncio.to_thread(retrieve_expressions_for_message, int(group_id), plain_text, **kwargs)

--- a/pallas/product/persona/expression_retrieve.py
+++ b/pallas/product/persona/expression_retrieve.py
@@ -33,13 +33,25 @@ def expression_opener_key(saying: str) -> str:
     return cjk[:4] if len(cjk) >= 2 else plain[:4]
 
 
-def score_expression_for_query(entry: ExpressionEntry, plain_text: str, *, scene: str = "") -> int | None:
+def score_expression_for_query(
+    entry: ExpressionEntry,
+    plain_text: str,
+    *,
+    scene: str = "",
+    target_bot_id: int = 0,
+    blocked_motifs: Iterable[str] | None = None,
+) -> int | None:
     """Return a relevance score, or None for entries that cannot be injected."""
     if entry.status == "rejected":
         return None
 
     score = 100 if entry.status == "active" else 50
     score += min(max(1, int(entry.support)), 10)
+    if target_bot_id:
+        if int(entry.bot_id) == target_bot_id:
+            score += 15
+        elif int(entry.bot_id) == 0:
+            score -= 10
 
     target_stance = infer_expression_affect_stance(plain_text)
     entry_stance = str(entry.affect_hint or "").strip() or infer_expression_affect_stance(entry.saying)
@@ -52,6 +64,9 @@ def score_expression_for_query(entry: ExpressionEntry, plain_text: str, *, scene
     feedback = entry.scene_feedback.get(str(scene), {}) if scene else {}
     if feedback.get("uses"):
         score += max(-6, min(6, int(feedback.get("score", 0))))
+    blocked_tokens = {str(item).strip() for item in (blocked_motifs or []) if str(item).strip()}
+    if blocked_tokens and any(token in entry.saying for token in blocked_tokens):
+        score -= 25
     # 与当前句无关的「已站稳」自生成金句不注入；弱相关则降权
     if kw_hits == 0 and entry.source == "llm_success" and (target_stance == "neutral" or target_stance != entry_stance):
         if entry.status == "active" or int(entry.support) >= 3:
@@ -68,6 +83,7 @@ def retrieve_expressions_for_message(
     bot_id: int = 0,
     scene: str = "",
     blocked_openers: Iterable[str] | None = None,
+    blocked_motifs: Iterable[str] | None = None,
 ) -> list[ExpressionEntry]:
     """Return the highest-ranked non-rejected expressions for a group message."""
     target_bot_id = int(bot_id)
@@ -76,7 +92,13 @@ def retrieve_expressions_for_message(
     for entry in list_group_expressions(int(group_id), limit=100):
         if target_bot_id and entry.bot_id not in {0, target_bot_id}:
             continue
-        score = score_expression_for_query(entry, plain_text, scene=scene)
+        score = score_expression_for_query(
+            entry,
+            plain_text,
+            scene=scene,
+            target_bot_id=target_bot_id,
+            blocked_motifs=blocked_motifs,
+        )
         if score is None:
             continue
         opener = expression_opener_key(entry.saying)

--- a/pallas/product/persona/self_identity.py
+++ b/pallas/product/persona/self_identity.py
@@ -8,7 +8,9 @@ from typing import Any
 from pallas.core.foundation.db import make_bot_config_repository
 from pallas.product.persona.prompt_guard import sanitize_prompt_literal, wrap_stats_block
 
-DEFAULT_SELF_ALIASES: tuple[str, ...] = ("牛牛", "帕拉斯", "Pallas")
+DEFAULT_GENERIC_ALIASES: tuple[str, ...] = ("牛牛",)
+# 兼容旧引用；默认全员通称不再广播「帕拉斯」「Pallas」。
+DEFAULT_SELF_ALIASES: tuple[str, ...] = DEFAULT_GENERIC_ALIASES
 
 _SELF_ALIAS_TEACH_RE = re.compile(
     r"^(?:记住[：:]?\s*)?"
@@ -66,11 +68,13 @@ _ALIAS_BLOCKLIST = frozenset({
 
 # 别名若命中这些子串，视为问句/脏话碎片
 _ALIAS_BAD_SUBSTR = ("哪只", "什么牛", "傻逼", "吗", "谁啊", "咋了", "干嘛")
+_ALIAS_BLOCKLIST_CASEFOLDS = frozenset(item.casefold() for item in _ALIAS_BLOCKLIST)
+_DEFAULT_GENERIC_ALIAS_CASEFOLDS = frozenset(item.casefold() for item in DEFAULT_GENERIC_ALIASES)
 
 
 def _safe_alias(raw: str) -> str | None:
     safe = sanitize_prompt_literal(str(raw or "").strip(), max_len=16)
-    if not safe or safe.casefold() in {item.casefold() for item in _ALIAS_BLOCKLIST}:
+    if not safe or safe.casefold() in _ALIAS_BLOCKLIST_CASEFOLDS:
         return None
     if len(safe) < 2:
         return None
@@ -81,30 +85,47 @@ def _safe_alias(raw: str) -> str | None:
     return safe
 
 
-def extract_self_aliases(
+def shorten_niu_niu_compound_alias(raw: str) -> str | None:
+    text = _safe_alias(raw) or ""
+    if not text or text == "牛牛":
+        return None
+    if text.startswith("牛牛") and len(text) > 2:
+        return _safe_alias(text[2:])
+    if text.endswith("牛牛") and len(text) > 2:
+        return _safe_alias(text[:-2])
+    return None
+
+
+def _append_alias(aliases: list[str], seen: set[str], raw: str) -> None:
+    text = _safe_alias(raw)
+    if not text or text.casefold() in seen:
+        return
+    seen.add(text.casefold())
+    aliases.append(text)
+
+
+def _append_exclusive_alias(aliases: list[str], seen: set[str], raw: str) -> None:
+    text = _safe_alias(raw)
+    if not text or text.casefold() in _DEFAULT_GENERIC_ALIAS_CASEFOLDS:
+        return
+    _append_alias(aliases, seen, text)
+    shortened = shorten_niu_niu_compound_alias(text)
+    if shortened and shortened.casefold() not in _DEFAULT_GENERIC_ALIAS_CASEFOLDS:
+        _append_alias(aliases, seen, shortened)
+
+
+def extract_generic_self_aliases() -> list[str]:
+    return list(DEFAULT_GENERIC_ALIASES)
+
+
+def extract_exclusive_self_aliases(
     bot_persona: dict[str, Any] | None,
     *,
     login_nickname: str | None = None,
 ) -> list[str]:
     aliases: list[str] = []
     seen: set[str] = set()
-
-    def add(raw: str, *, learned: bool = False) -> None:
-        text = _safe_alias(raw) if learned else sanitize_prompt_literal(str(raw or "").strip(), max_len=16)
-        if not text or text.casefold() in seen:
-            return
-        if not learned and text.casefold() in {item.casefold() for item in _ALIAS_BLOCKLIST}:
-            return
-        if learned and _safe_alias(text) is None:
-            return
-        seen.add(text.casefold())
-        aliases.append(text)
-
-    login = _safe_alias(str(login_nickname or ""))
-    if login:
-        add(login)
-    for item in DEFAULT_SELF_ALIASES:
-        add(item)
+    _append_exclusive_alias(aliases, seen, str(login_nickname or ""))
     if not isinstance(bot_persona, dict):
         return aliases
     raw = bot_persona.get("self_aliases")
@@ -113,7 +134,36 @@ def extract_self_aliases(
     if not isinstance(raw, list):
         return aliases
     for item in raw:
-        add(str(item or ""), learned=True)
+        _append_exclusive_alias(aliases, seen, str(item or ""))
+    return aliases
+
+
+def extract_raw_learned_self_aliases(bot_persona: dict[str, Any] | None) -> list[str]:
+    aliases: list[str] = []
+    seen: set[str] = set()
+    if not isinstance(bot_persona, dict):
+        return aliases
+    raw = bot_persona.get("self_aliases")
+    if raw is None:
+        raw = bot_persona.get("alias_names")
+    if not isinstance(raw, list):
+        return aliases
+    for item in raw:
+        _append_alias(aliases, seen, str(item or ""))
+    return aliases
+
+
+def extract_self_aliases(
+    bot_persona: dict[str, Any] | None,
+    *,
+    login_nickname: str | None = None,
+) -> list[str]:
+    aliases: list[str] = []
+    seen: set[str] = set()
+    for item in extract_exclusive_self_aliases(bot_persona, login_nickname=login_nickname):
+        _append_alias(aliases, seen, item)
+    for item in extract_generic_self_aliases():
+        _append_alias(aliases, seen, item)
     return aliases
 
 
@@ -122,18 +172,20 @@ def compile_self_identity_prompt(
     *,
     login_nickname: str | None = None,
 ) -> str:
-    aliases = extract_self_aliases(bot_persona, login_nickname=login_nickname)
-    alias_text = "、".join(aliases[:6])
-    primary_alias = aliases[0] if aliases else "牛牛"
-    login = _safe_alias(str(login_nickname or ""))
-    if login and login != "牛牛":
-        call_line = f"- 群友常叫你「{primary_alias}」等（含「牛牛」）——这些称呼指你本人。"
+    generic_aliases = extract_generic_self_aliases()
+    exclusive_aliases = extract_exclusive_self_aliases(bot_persona, login_nickname=login_nickname)
+    generic_text = "、".join(generic_aliases[:4]) or "牛牛"
+    exclusive_text = "、".join(exclusive_aliases[:6])
+    primary_alias = exclusive_aliases[0] if exclusive_aliases else (generic_aliases[0] if generic_aliases else "牛牛")
+    if exclusive_aliases:
+        call_line = f"- 群友会用通称「{generic_text}」叫你；若喊专属称呼如「{primary_alias}」等，也是在叫你本人。"
     else:
-        call_line = f"- 群友常叫你「{primary_alias}」等——这些称呼指你本人。"
+        call_line = f"- 群友常用通称「{generic_text}」叫你——这些称呼默认都在跟你说话。"
     body = "\n".join([
         "【自称与群称呼】",
         call_line,
-        f"- 常见称呼：{alias_text}。",
+        f"- 通称：{generic_text}。",
+        f"- 专属称呼：{exclusive_text}。" if exclusive_text else "- 当前没有额外专属称呼；学到后也应视为在喊你。",
         "- 有人 @ 你或在句中喊上述名字时，默认是在跟你说话；用第一人称接话，不要当成第三者在聊。",
         "- 禁止把「牛牛」当外人夸奖（错误：「牛牛真棒」）；应理解成在说你，"
         "用「谢谢」「收到」等第一人称回应，勿用「还行吧」「行行行」起手。",
@@ -147,15 +199,25 @@ def compile_repeater_self_identity_prompt(
     *,
     login_nickname: str | None = None,
 ) -> str:
-    aliases = extract_self_aliases(bot_persona, login_nickname=login_nickname)
-    primary_alias = aliases[0] if aliases else "牛牛"
-    if primary_alias == "牛牛":
-        call_line = "- 群友喊「牛牛」等时是在跟你说话；用第一人称接，别把称呼当第三者在聊。"
+    generic_aliases = extract_generic_self_aliases()
+    exclusive_aliases = extract_exclusive_self_aliases(bot_persona, login_nickname=login_nickname)
+    generic_text = "、".join(generic_aliases[:4]) or "牛牛"
+    primary_alias = exclusive_aliases[0] if exclusive_aliases else (generic_aliases[0] if generic_aliases else "牛牛")
+    if not exclusive_aliases:
+        call_line = f"- 群友喊「{generic_text}」等时是在跟你说话；用第一人称接，别把称呼当第三者在聊。"
     else:
-        call_line = f"- 群友喊「{primary_alias}」或「牛牛」等时是在跟你说话；用第一人称接，别把称呼当第三者在聊。"
+        call_line = (
+            f"- 群友喊通称「{generic_text}」或专属称呼「{primary_alias}」等时，"
+            "都可能是在跟你说话；用第一人称接，别把称呼当第三者在聊。"
+        )
     body = "\n".join([
         "【群称呼】",
         call_line,
+        (
+            f"- 你的专属称呼：{'、'.join(exclusive_aliases[:6])}。"
+            if exclusive_aliases
+            else f"- 当前只使用通称「{generic_text}」。"
+        ),
         "- 日常接话不必自我介绍帕拉斯或罗德岛，像群友顺口回一句即可。",
     ])
     return wrap_stats_block("self_identity", body)
@@ -247,7 +309,7 @@ async def merge_self_aliases(bot_id: int, aliases: list[str]) -> bool:
     persona: dict[str, Any] = {}
     if doc is not None and isinstance(getattr(doc, "persona", None), dict):
         persona = dict(doc.persona)
-    merged = extract_self_aliases(persona)
+    merged = extract_raw_learned_self_aliases(persona)
     seen = {item.casefold() for item in merged}
     changed = False
     for alias in cleaned:
@@ -256,7 +318,7 @@ async def merge_self_aliases(bot_id: int, aliases: list[str]) -> bool:
         seen.add(alias.casefold())
         merged.append(alias)
         changed = True
-    stored = [item for item in merged if item not in DEFAULT_SELF_ALIASES][:8]
+    stored = [item for item in merged if item.casefold() not in _DEFAULT_GENERIC_ALIAS_CASEFOLDS][:8]
     try:
         from pallas.core.platform.ingress.alias_route import remember_learned_self_aliases
 

--- a/tests/features/test_compile_persona_prompt.py
+++ b/tests/features/test_compile_persona_prompt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from pallas.product.persona.auto import derive_persona_from_bot_id
+from pallas.product.persona.auto import archetype_for_bot_id, derive_persona_from_bot_id
 from pallas.product.persona.compile_persona_prompt import (
     assemble_persona_system,
     build_bot_behavior_prompt,
@@ -99,6 +99,30 @@ def test_build_bot_behavior_prompt_includes_tone_and_length() -> None:
     assert "tone=dramatic" not in prompt
     assert "短句" in prompt or "短促" in prompt
     assert "客服式完整解释" in prompt
+
+
+def test_bot_behavior_fingerprint_differs_by_archetype() -> None:
+    p_terse = build_bot_behavior_prompt(derive_persona_from_bot_id(0))
+    p_chaotic = build_bot_behavior_prompt(derive_persona_from_bot_id(1))
+
+    assert archetype_for_bot_id(0) != archetype_for_bot_id(1)
+    assert p_terse != p_chaotic
+    assert any(token in p_terse for token in ("少展开", "一句", "少解释", "别起哄加戏"))
+    assert len(p_terse.splitlines()) <= 14
+
+
+def test_compile_persona_prompt_includes_seed_fingerprint_lines() -> None:
+    persona = derive_persona_from_bot_id(2)
+    bundle = compile_persona_prompt(
+        persona,
+        None,
+        bot_id=2,
+        base_system="基础",
+        bot_persona={"seed_override": {"prefs": ["warm", "restrained"]}},
+    )
+    assert "【接话指纹】" in bundle.sections.bot_behavior
+    assert "少反复同一隐喻起手" in bundle.sections.bot_behavior
+    assert "先应一句再吐槽" in bundle.sections.bot_behavior
 
 
 def test_compile_persona_prompt_merges_sections() -> None:

--- a/tests/features/test_expression_retrieve.py
+++ b/tests/features/test_expression_retrieve.py
@@ -165,6 +165,44 @@ def test_retrieve_filters_other_bot_and_builds_reference_block(monkeypatch, tmp_
     assert build_expression_reference_block(entries) == "\n【表达参考】\nventing→这也太黑了。"
 
 
+def test_retrieve_prefers_own_bot_and_demotes_blocked_motifs(monkeypatch, tmp_path) -> None:
+    from pallas.product.persona.expression_retrieve import retrieve_expressions_for_message
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    append_or_merge_expression(
+        make_entry(
+            occasion="聊草料",
+            saying="今天草料直接拉满。",
+            status="active",
+            bot_id=0,
+            support=3,
+        )
+    )
+    append_or_merge_expression(
+        make_entry(
+            occasion="聊草料",
+            saying="今天份额管够，先狠狠干活。",
+            status="active",
+            bot_id=10001,
+            support=3,
+        )
+    )
+
+    entries = retrieve_expressions_for_message(10001, "草料安排上没", limit=2, bot_id=10001)
+    assert [entry.bot_id for entry in entries][:2] == [10001, 0]
+
+    filtered = retrieve_expressions_for_message(
+        10001,
+        "草料安排上没",
+        limit=2,
+        bot_id=10001,
+        blocked_motifs=["草料"],
+    )
+    assert filtered
+    assert filtered[0].bot_id == 10001
+    assert all("草料" not in entry.saying for entry in filtered[:1])
+
+
 @pytest.mark.asyncio
 async def test_context_suffix_respects_inject_config_and_falls_back_to_habits(monkeypatch) -> None:
     from pallas.product.persona import expression_habits as habits
@@ -176,8 +214,18 @@ async def test_context_suffix_respects_inject_config_and_falls_back_to_habits(mo
     )
     retrieve = Mock(return_value=[SimpleNamespace(occasion="吐槽", saying="太难了")])
     monkeypatch.setattr(habits, "retrieve_expressions_for_message", retrieve)
-    assert await habits.build_expression_context_suffix(10001, "太离谱了") == "\n【表达参考】\n吐槽→太难了。"
-    retrieve.assert_called_once_with(10001, "太离谱了", limit=2, bot_id=0, blocked_openers=())
+    assert (
+        await habits.build_expression_context_suffix(10001, "太离谱了", blocked_motifs=["草料"])
+        == "\n【表达参考】\n吐槽→太难了。"
+    )
+    retrieve.assert_called_once_with(
+        10001,
+        "太离谱了",
+        limit=2,
+        bot_id=0,
+        blocked_openers=(),
+        blocked_motifs=("草料",),
+    )
 
     monkeypatch.setattr(
         habits,

--- a/tests/features/test_reply_variation.py
+++ b/tests/features/test_reply_variation.py
@@ -5,7 +5,9 @@ from types import SimpleNamespace
 from pallas.product.llm.reply_variation import (
     build_recent_reply_ending_hint,
     build_recent_reply_variation_hint,
+    build_variation_hint_from_recent_texts,
     classify_repeated_opener,
+    extract_recent_motifs,
     repeated_assistant_openers,
 )
 from pallas.product.persona.self_identity import compile_self_identity_prompt
@@ -75,6 +77,22 @@ def test_build_recent_reply_variation_hint_flags_animal_and_kaomoji() -> None:
     assert "哞~" in hint or "喵~" in hint
     assert "颜文字" in hint
     assert repeated_assistant_openers(turns)
+
+
+def test_motif_hint_from_recent_texts() -> None:
+    hint = build_variation_hint_from_recent_texts([
+        "双倍草料，土木牛牛明天干活都有劲了。",
+        "草料管够就行",
+    ])
+    assert "草料" in hint or "土木" in hint
+
+
+def test_extract_recent_motifs_deduplicates_default_tokens() -> None:
+    motifs = extract_recent_motifs([
+        "双倍草料，土木牛牛明天干活都有劲了。",
+        "漂亮牛牛今天也得吃草料。",
+    ])
+    assert motifs == ["草料", "土木", "漂亮牛牛"]
 
 
 def test_compile_self_identity_prompt_mentions_niu_niu() -> None:

--- a/tests/features/test_self_alias_layers.py
+++ b/tests/features/test_self_alias_layers.py
@@ -1,0 +1,91 @@
+"""self aliases 拆分通称与专属，并支持复合昵称短别名。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from pallas.product.persona.self_identity import (
+    extract_exclusive_self_aliases,
+    extract_generic_self_aliases,
+    extract_self_aliases,
+    merge_self_aliases,
+    shorten_niu_niu_compound_alias,
+)
+
+
+def test_shorten_doubao_niu_niu() -> None:
+    assert shorten_niu_niu_compound_alias("豆包牛牛") == "豆包"
+    assert shorten_niu_niu_compound_alias("牛牛测试机") == "测试机"
+    assert shorten_niu_niu_compound_alias("牛牛") is None
+
+
+def test_extract_includes_short_from_login() -> None:
+    aliases = extract_self_aliases(None, login_nickname="豆包牛牛")
+    assert "豆包牛牛" in aliases
+    assert "豆包" in aliases
+    assert "牛牛" in aliases
+
+
+def test_exclusive_vs_generic_split() -> None:
+    exclusives = extract_exclusive_self_aliases(None, login_nickname="豆包牛牛")
+    generics = extract_generic_self_aliases()
+    assert "豆包牛牛" in exclusives
+    assert "豆包" in exclusives
+    assert "牛牛" not in exclusives
+    assert generics == ["牛牛"]
+
+
+@pytest.mark.asyncio
+async def test_merge_self_aliases_keeps_learned_exclusive_when_filtering_generics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: list[tuple[int, str, dict]] = []
+    remembered: list[tuple[int, list[str]]] = []
+
+    class DummyRepo:
+        async def get(self, _bot_id: int):
+            return SimpleNamespace(persona={"self_aliases": []})
+
+        async def upsert_field(self, bot_id: int, field: str, value: dict) -> None:
+            written.append((bot_id, field, value))
+
+    monkeypatch.setattr("pallas.product.persona.self_identity.make_bot_config_repository", lambda: DummyRepo())
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.alias_route.remember_learned_self_aliases",
+        lambda bot_id, aliases: remembered.append((bot_id, aliases)),
+    )
+
+    ok = await merge_self_aliases(42, ["帕拉斯"])
+
+    assert ok is True
+    assert written == [(42, "persona", {"self_aliases": ["帕拉斯"]})]
+    assert remembered == [(42, ["帕拉斯"])]
+
+
+@pytest.mark.asyncio
+async def test_merge_self_aliases_does_not_persist_derived_short_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: list[tuple[int, str, dict]] = []
+    remembered: list[tuple[int, list[str]]] = []
+
+    class DummyRepo:
+        async def get(self, _bot_id: int):
+            return SimpleNamespace(persona={"self_aliases": ["豆包牛牛"]})
+
+        async def upsert_field(self, bot_id: int, field: str, value: dict) -> None:
+            written.append((bot_id, field, value))
+
+    monkeypatch.setattr("pallas.product.persona.self_identity.make_bot_config_repository", lambda: DummyRepo())
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.alias_route.remember_learned_self_aliases",
+        lambda bot_id, aliases: remembered.append((bot_id, aliases)),
+    )
+
+    ok = await merge_self_aliases(42, ["阿帕"])
+
+    assert ok is True
+    assert written == [(42, "persona", {"self_aliases": ["豆包牛牛", "阿帕"]})]
+    assert remembered == [(42, ["豆包牛牛", "阿帕"])]

--- a/tests/features/test_self_identity_login_nick.py
+++ b/tests/features/test_self_identity_login_nick.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pallas.product.persona.self_identity import (
+    DEFAULT_GENERIC_ALIASES,
     compile_repeater_self_identity_prompt,
     compile_self_identity_prompt,
     extract_self_aliases,
@@ -13,7 +14,20 @@ def test_extract_self_aliases_login_nickname_primary_keeps_niu_niu() -> None:
     aliases = extract_self_aliases(None, login_nickname="小牛")
     assert aliases[0] == "小牛"
     assert "牛牛" in aliases
+
+
+def test_default_generic_aliases_are_niu_niu_only() -> None:
+    assert DEFAULT_GENERIC_ALIASES == ("牛牛",)
+    aliases = extract_self_aliases(None)
+    assert aliases[0] == "牛牛"
+    assert "帕拉斯" not in aliases
+    assert "Pallas" not in aliases
+
+
+def test_login_pallas_keeps_exclusive_pallas() -> None:
+    aliases = extract_self_aliases(None, login_nickname="帕拉斯")
     assert "帕拉斯" in aliases
+    assert "牛牛" in aliases
 
 
 def test_extract_self_aliases_without_login_keeps_default_primary() -> None:
@@ -32,16 +46,35 @@ def test_extract_self_aliases_merges_learned_after_defaults() -> None:
     assert aliases[0] == "小牛"
     assert "牛牛" in aliases
     assert "阿帕" in aliases
-    assert aliases.index("小牛") < aliases.index("牛牛") < aliases.index("阿帕")
+    assert aliases.index("小牛") < aliases.index("阿帕") < aliases.index("牛牛")
 
 
 def test_compile_self_identity_prompt_uses_login_as_primary() -> None:
     prompt = compile_self_identity_prompt(login_nickname="小牛")
     assert "「小牛」" in prompt
     assert "牛牛" in prompt
+    assert "通称" in prompt
+    assert "专属" in prompt
+    assert "通称：牛牛" in prompt
+    assert "专属称呼：小牛" in prompt
 
 
 def test_compile_repeater_self_identity_prompt_uses_login_as_primary() -> None:
     prompt = compile_repeater_self_identity_prompt(login_nickname="小牛")
     assert "「小牛」" in prompt
     assert "牛牛" in prompt or "等" in prompt
+    assert "通称" in prompt
+    assert "专属称呼" in prompt
+    assert "小牛" in prompt
+
+
+def test_compile_repeater_self_identity_prompt_uses_generic_text_without_exclusive(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.extract_generic_self_aliases",
+        lambda: ["测试牛"],
+    )
+    prompt = compile_repeater_self_identity_prompt()
+    assert "测试牛" in prompt
+    assert "牛牛" not in prompt

--- a/tests/features/test_speak_perception.py
+++ b/tests/features/test_speak_perception.py
@@ -15,7 +15,12 @@ from pallas.product.llm.speak_perception import (
 def test_text_mentions_aliases_login_and_default() -> None:
     aliases = ["漂亮牛", "牛牛", "帕拉斯"]
     assert text_mentions_aliases("漂亮牛出来一下", aliases)
-    assert text_mentions_aliases("臭牛牛出来", aliases)
+    # 纯通称需要边界；复合词里的「牛牛」不再算提及。
+    assert not text_mentions_aliases(
+        "臭牛牛出来",
+        aliases,
+        generic_aliases=["牛牛"],
+    )
     assert text_mentions_aliases("帕拉斯在吗", aliases)
     assert not text_mentions_aliases("今天吃牛肉面", aliases)
     assert not text_mentions_aliases("随便聊聊", aliases)
@@ -28,6 +33,36 @@ def test_text_mentions_aliases_skips_short() -> None:
 def test_text_mentions_aliases_strips_cq_at_noise() -> None:
     aliases = ["牛牛"]
     assert text_mentions_aliases("[CQ:at,qq=123] 牛牛出来", aliases)
+
+
+def test_generic_niu_niu_requires_boundary() -> None:
+    assert not text_mentions_aliases(
+        "漂亮牛牛出来",
+        ["牛牛"],
+        min_alias_len=2,
+        generic_aliases=["牛牛"],
+    )
+    assert not text_mentions_aliases(
+        "牛牛测试机出来",
+        ["牛牛"],
+        min_alias_len=2,
+        generic_aliases=["牛牛"],
+    )
+    assert text_mentions_aliases(
+        "牛牛出来",
+        ["牛牛"],
+        min_alias_len=2,
+        generic_aliases=["牛牛"],
+    )
+
+
+def test_exclusive_long_alias_still_matches_substring() -> None:
+    assert text_mentions_aliases(
+        "叫豆包牛牛一声",
+        ["豆包牛牛", "豆包", "牛牛"],
+        min_alias_len=2,
+        generic_aliases=["牛牛"],
+    )
 
 
 def test_evaluate_to_me_always() -> None:

--- a/tests/platform/ingress/test_alias_route.py
+++ b/tests/platform/ingress/test_alias_route.py
@@ -32,7 +32,7 @@ def test_should_yield_when_peer_display_name_mentioned(monkeypatch) -> None:
     assert not should_yield_ingress_for_peer_alias(self_id=2357682124, plain_text=plain)
 
 
-def test_no_yield_when_shared_default_alias(monkeypatch) -> None:
+def test_shared_generic_niu_niu_does_not_exclusive_match(monkeypatch) -> None:
     clear_alias_route_state()
     monkeypatch.setattr(
         "pallas.core.platform.multi_bot.fleet.get_fleet_bot_ids",
@@ -43,9 +43,39 @@ def test_no_yield_when_shared_default_alias(monkeypatch) -> None:
         lambda _bot_id: "",
     )
     plain = "牛牛出来一下"
-    assert fleet_bots_matching_plain(plain) == frozenset({11, 22})
+    assert fleet_bots_matching_plain(plain) == frozenset()
     assert not should_yield_ingress_for_peer_alias(self_id=11, plain_text=plain)
-    assert not should_yield_ingress_for_peer_alias(self_id=22, plain_text=plain)
+
+
+def test_pallas_exclusive_yield(monkeypatch) -> None:
+    clear_alias_route_state()
+    monkeypatch.setattr(
+        "pallas.core.platform.multi_bot.fleet.get_fleet_bot_ids",
+        lambda: frozenset({11, 22, 33}),
+    )
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.resolve_cached_login_nickname",
+        lambda bot_id: {11: "帕拉斯", 22: "豆包牛牛", 33: "牛牛测试机"}.get(int(bot_id), ""),
+    )
+    plain = "帕拉斯出"
+    assert fleet_bots_matching_plain(plain) == frozenset({11})
+    assert should_yield_ingress_for_peer_alias(self_id=22, plain_text=plain)
+    assert not should_yield_ingress_for_peer_alias(self_id=11, plain_text=plain)
+
+
+def test_doubao_short_alias_exclusive(monkeypatch) -> None:
+    clear_alias_route_state()
+    monkeypatch.setattr(
+        "pallas.core.platform.multi_bot.fleet.get_fleet_bot_ids",
+        lambda: frozenset({11, 22}),
+    )
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.resolve_cached_login_nickname",
+        lambda bot_id: {11: "帕拉斯", 22: "豆包牛牛"}.get(int(bot_id), ""),
+    )
+    plain = "豆包来一下"
+    assert fleet_bots_matching_plain(plain) == frozenset({22})
+    assert should_yield_ingress_for_peer_alias(self_id=11, plain_text=plain)
 
 
 def test_no_yield_without_alias_hit(monkeypatch) -> None:

--- a/tests/plugins/llm_chat/test_chat_message_task_meta.py
+++ b/tests/plugins/llm_chat/test_chat_message_task_meta.py
@@ -442,6 +442,153 @@ def test_build_recent_reply_variation_hint_flags_generic_prefix_cluster() -> Non
     assert "最近几轮别再用这些开头：行吧" in hint
 
 
+def test_build_blocked_motifs_prefers_recent_group_bot_texts() -> None:
+    from packages.llm_chat import chat_message as mod
+
+    recent_turns = [
+        LlmChatTurn(role="assistant", content="私窗里还是老说草料", user_id=1, created_at=1),
+    ]
+    recent_group_rows = [
+        {"text": "土木牛牛今天继续搬砖", "user_id": 10001, "bot_id": 10001, "role": "assistant"},
+        {"text": "漂亮牛牛先吃饭", "user_id": 10001, "bot_id": 10001},
+        {"text": "路人甲说随便", "user_id": 2222},
+    ]
+
+    motifs = mod.build_blocked_motifs(
+        recent_turns=recent_turns,
+        recent_group_rows=recent_group_rows,
+        bot_id=10001,
+    )
+
+    assert motifs == ["土木", "漂亮牛牛"]
+
+
+@pytest.mark.asyncio
+async def test_handle_llm_chat_prefers_group_bot_motifs_for_expression_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from packages.llm_chat import chat_message as mod
+
+    event = SimpleNamespace(
+        to_me=True,
+        self_id="10001",
+        group_id=20002,
+        user_id=30003,
+        message_id=40004,
+        time=123456,
+        raw_message="[CQ:at,qq=10001] 你好",
+        get_plaintext=lambda: "你好",
+        get_message=lambda: "[CQ:at,qq=10001] 你好",
+        get_session_id=lambda: "group_20002_30003",
+    )
+    bot = SimpleNamespace(self_id="10001")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(mod, "is_llm_chat_service_enabled", lambda: True)
+    monkeypatch.setattr(
+        mod,
+        "get_llm_chat_config",
+        lambda: SimpleNamespace(
+            llm_chat_system_prompt_path="",
+            llm_chat_min_priority=40,
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "get_llm_config",
+        lambda: SimpleNamespace(
+            llm_memory_rag_enabled=False,
+            llm_relationship_notes_enabled=False,
+            llm_chat_enabled=True,
+            llm_select_enabled=False,
+            llm_polish_lite_enabled=False,
+            llm_polish_enabled=False,
+            llm_chat_cooldown_sec=3,
+            llm_chat_queue_merge=True,
+            llm_current_turn_decision_enabled=False,
+            llm_speak_perception_enabled=False,
+            llm_speak_followup_enabled=False,
+            llm_speak_followup_window_sec=30,
+            llm_speak_followup_max_total_sec=120,
+            llm_reply_style_variants={},
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "build_persona_llm_context",
+        AsyncMock(
+            return_value=(
+                SimpleNamespace(system="sys", metadata=SimpleNamespace(persona={})),
+                None,
+                None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "assemble_direct_chat_context",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                system_prompt="sys",
+                knowledge_retrieval_trace={},
+                hybrid_retrieval_trace={},
+                relationship_trace={},
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "evaluate_llm_reply_gate_result",
+        lambda *_args, **_kwargs: SimpleNamespace(decision="proceed", reason=""),
+    )
+    monkeypatch.setattr(mod, "check_llm_chat_gate", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        mod,
+        "merge_queued_chat",
+        lambda *_args, **_kwargs: SimpleNamespace(text="[CQ:at,qq=10001] 你好", merged=False),
+    )
+    monkeypatch.setattr(
+        mod,
+        "list_user_llm_messages",
+        AsyncMock(
+            return_value=[
+                SimpleNamespace(role="assistant", content="私窗里还是老说草料", user_id=30003, created_at=1),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "pallas.product.llm.repeater_persona_context.load_recent_bot_plain_replies",
+        AsyncMock(return_value=["土木牛牛今天继续搬砖", "漂亮牛牛先吃饭"]),
+    )
+    monkeypatch.setattr(mod, "classify_behavior_scene", lambda **_kwargs: BehaviorScene.PROVOCATION)
+
+    async def fake_build_expression_selection(*_args, **kwargs):
+        captured["blocked_motifs"] = kwargs.get("blocked_motifs")
+        return "", []
+
+    monkeypatch.setattr(mod, "build_llm_chat_expression_selection", fake_build_expression_selection)
+    monkeypatch.setattr(mod, "assemble_tool_bundle", lambda **_kwargs: {"tools_enabled": False, "tool_schemas": []})
+    monkeypatch.setattr(
+        mod,
+        "decide_current_turn_with_model",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                action=mod.CurrentTurnAction.PASS,
+                trace=SimpleNamespace(model_dump=lambda mode="json": {"action": "PASS", "source": "rule"}),
+            )
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "packages.repeater.opportunity_trace",
+        SimpleNamespace(append_conversation_decision_trace=lambda _row: None),
+    )
+
+    await mod.handle_llm_chat(bot, event)
+
+    assert captured["blocked_motifs"] == ["土木", "漂亮牛牛"]
+
+
 @pytest.mark.asyncio
 async def test_handle_llm_chat_skips_empty_to_me_without_reply(monkeypatch: pytest.MonkeyPatch) -> None:
     from packages.llm_chat import chat_message as mod


### PR DESCRIPTION
## 变更
- 自称拆通称/专属：默认不再全员塞「帕拉斯」；登录名拆短别名；学习落盘不写派生短名
- 通称「牛牛」按词界匹配，避免「漂亮牛牛」「牛牛测试机」误伤
- ingress 让出仅认专属命中（「帕拉斯出」「豆包」可独占）
- archetype/seed 接话指纹，拉开同群多号听感
- 表达检索本号优先；群近窗母题（草料/土木等）hint + 降权

## 验证
- 相关单测已过（含别名分层、词界、yield、指纹、母题）
- 历史遗留：`test_reply_gate_uses_persona_min_chars`、部分 `test_chat_message_task_meta` enrich patch（HEAD 上原有）

## 备注
- 方案 C（手写分层）已记 Notion 后排
- 设计稿在本地 `docs/superpowers/`（该目录 gitignore，未纳入 PR）

## Summary by Sourcery

将通用的「牛牛」人格别名与每个机器人专属别名分离，收紧别名匹配和入口路由逻辑，并通过主题（motif）和基于种子的指纹丰富对 LLM 回复风格的控制。

New Features:
- 引入通用与专属两层自我别名，并支持将复合「牛牛」昵称缩写为每个机器人的短别名。
- 增加基于主题的阻止与优先级机制，用于表达检索和 LLM 聊天表达选择，优先当前机器人并避免在短时间窗口内重复使用过度频繁的主题。
- 在人格提示词中暴露原型（archetype）和种子偏好指纹，以区分不同机器人回复的风格与感受。

Bug Fixes:
- 将「牛牛」通用别名的检测限制在正确的词边界上，以避免在复合短语或测试机器名称中出现误判。
- 确保共享通用别名不再导致入口机器人互相争抢路由，而像「帕拉斯」或缩写后的「豆包」这样的专属别名仍保持唯一可路由性。

Enhancements:
- 优化自我身份提示，明确描述通用与专属别名，并澄清它们在正常模式和复读模式下一人称回复中的映射方式。
- 调整语音感知和集群别名路由逻辑，使其依赖专属别名，同时仍能在语境中识别通用别名。
- 改进回复多样性提示，通过在重复的开场语旁展示近期主题，减少短时间窗口内的重复主题。
- 调整表达库评分机制，优先选择由当前机器人创作的条目，并降低包含被阻止主题的条目得分。

Tests:
- 新增围绕自我别名分层、昵称缩写、通用别名边界、入口让渡行为、主题抽取以及表达检索优先级的针对性测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate generic "牛牛" persona alias from per-bot exclusive aliases, tighten alias matching and ingress routing, and enrich LLM reply style control with motifs and seed-based fingerprints.

New Features:
- Introduce generic vs exclusive self-alias layers with support for shortening compound "牛牛" nicknames into per-bot short aliases.
- Add motif-based blocking and prioritization for expression retrieval and LLM chat expression selection, favoring the current bot and avoiding overused short-window motifs.
- Expose archetype and seed preference fingerprints in persona prompts to differentiate reply feel across bots.

Bug Fixes:
- Restrict generic alias detection for "牛牛" to proper word boundaries to avoid false positives in compound phrases or test-machine names.
- Ensure shared generic aliases no longer cause ingress bots to compete, while exclusive aliases like "帕拉斯" or shortened "豆包" remain uniquely routable.

Enhancements:
- Refine self-identity prompts to explicitly describe generic vs exclusive aliases and clarify how they map to first-person replies in normal and repeater modes.
- Adjust speak perception and fleet alias routing to rely on exclusive aliases while still recognizing generic aliases contextually.
- Improve reply variation hints by surfacing recent motifs alongside repeated openers to reduce repetitive short-window themes.
- Tune expression bank scoring to prefer entries authored by the current bot and demote entries containing blocked motifs.

Tests:
- Add focused tests around self-alias layering, nickname shortening, generic alias boundaries, ingress yielding behavior, motif extraction, and expression retrieval prioritization.

</details>