### PR TITLE
chore(release): v4.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [4.1.18] - 2026-08-01
+
+### 更新公告
+
+- 控制台可断开外置协议账号的本机 OneBot WS；连接列表带出 WS 端口
+- 短窗自动母题去重，表达库换说法更稳
+- 社区统计 `/v1/stats` 回退时能推断语料是否开启
+- 捆绑控制台 WebUI **v0.8.13**
+
+### Added
+
+- `POST /pallas/api/bots/{qq}/disconnect-ws` 断开本机 WS
+- 连接列表 `ws_port` / `shard_id` 供控制台展示
+
+### Fixed
+
+- 社区统计 `/v1/stats` 回退时推断 `corpus_enabled`
+
+### Changed
+
+- LLM 短窗自动母题去重并强化表达库换说法
+
 ## [4.1.17] - 2026-07-31
 
 ### 更新公告

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.1.16-6-gdd053aac-dirty",
+    "version": "v4.1.17-2-g671bbe76-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -20175,6 +20175,79 @@
             }
           }
         },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pallas/api/bots/{qq}/disconnect-ws": {
+      "post": {
+        "tags": [
+          "Pallas-Bot 控制台"
+        ],
+        "summary": " Bot Disconnect Ws",
+        "description": "关闭本进程对该 QQ 的 OneBot WS（不停止外置协议端进程）。",
+        "operationId": "_bot_disconnect_ws_pallas_api_bots__qq__disconnect_ws_post",
+        "parameters": [
+          {
+            "name": "qq",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Qq"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Token"
+            }
+          },
+          {
+            "name": "X-Pallas-Token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Pallas-Token"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",

--- a/packages/pb_webui/instances_configs_api.py
+++ b/packages/pb_webui/instances_configs_api.py
@@ -410,3 +410,24 @@ def register_instances_configs_router(
             raise HTTPException(status_code=500, detail=str(e)) from e
         drop_read_cache(("db_overview", "user_configs_list"))
         return JSONResponse({"ok": True, "data": data})
+
+    @router.post(f"{x}/bots/{{qq}}/disconnect-ws", include_in_schema=True)
+    async def _bot_disconnect_ws(
+        qq: int,
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        """关闭本进程对该 QQ 的 OneBot WS（不停止外置协议端进程）。"""
+        check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        if qq < 1:
+            raise HTTPException(status_code=400, detail="无效的 QQ")
+        from pallas.core.platform.shard.presence import close_local_bot_connection
+
+        closed = await close_local_bot_connection(int(qq))
+        if not closed:
+            raise HTTPException(
+                status_code=404,
+                detail="当前进程未找到该账号的 WS 连接（可能已断开，或不在本机）",
+            )
+        drop_read_cache(("instances", "bots", "home-overview"))
+        return JSONResponse({"ok": True, "data": {"qq": int(qq), "closed": True}})

--- a/packages/pb_webui/system_home_api.py
+++ b/packages/pb_webui/system_home_api.py
@@ -86,6 +86,47 @@ def _ensure_bot_session_hooks() -> None:
             pass
 
 
+def _resolve_local_onebot_ws_port() -> int | None:
+    """本进程 OneBot 反向 WS 监听端口（分片 worker / unified 的 PORT）。"""
+    try:
+        from pallas.core.platform.shard.worker_port import current_worker_port
+
+        wp = current_worker_port()
+        if wp is not None and 1 <= int(wp) <= 65535:
+            return int(wp)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        port = getattr(get_driver().config, "port", None)
+        if port is not None:
+            p = int(port)
+            if 1 <= p <= 65535:
+                return p
+    except Exception:  # noqa: BLE001
+        pass
+    raw = (os.environ.get("PORT") or "").strip()
+    if raw.isdigit():
+        p = int(raw)
+        if 1 <= p <= 65535:
+            return p
+    return None
+
+
+def _local_shard_id_for_bots() -> int | None:
+    try:
+        from pallas.core.platform.shard import context as shard_ctx
+        from pallas.core.platform.shard.registry.config import get_shard_registry_settings
+
+        if not shard_ctx.sharding_active():
+            return None
+        s = get_shard_registry_settings()
+        if s.role != "worker":
+            return None
+        return int(s.shard_id)
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _list_bots_dict() -> list[dict[str, Any]]:
 
     if shard_hub_console():
@@ -93,6 +134,8 @@ def _list_bots_dict() -> list[dict[str, Any]]:
 
         return list_connected_bots_for_webui()
 
+    ws_port = _resolve_local_onebot_ws_port()
+    shard_id = _local_shard_id_for_bots()
     rows: list[dict[str, Any]] = []
     for key, bot in get_bots().items():
         self_id: str
@@ -107,12 +150,16 @@ def _list_bots_dict() -> list[dict[str, Any]]:
                 adapter = str(a.get_name())
         except Exception:  # noqa: BLE001
             pass
-        rows.append({
+        row: dict[str, Any] = {
             "connection_key": str(key),
             "self_id": self_id,
             "adapter": adapter,
             "connected_at_unix": _BOT_SESSION_CONNECTED_UNIX.get(str(key)),
-        })
+            "ws_port": ws_port,
+        }
+        if shard_id is not None:
+            row["shard_id"] = shard_id
+        rows.append(row)
     return rows
 
 

--- a/pallas/__init__.py
+++ b/pallas/__init__.py
@@ -1,3 +1,3 @@
 """Pallas Bot 内核包（pallas-core）。"""
 
-__version__ = "4.1.17"
+__version__ = "4.1.18"

--- a/pallas/core/platform/shard/presence.py
+++ b/pallas/core/platform/shard/presence.py
@@ -462,14 +462,26 @@ def list_connected_bots_for_webui() -> list[dict[str, Any]]:
         rec = bots[key]
         qq = str(rec.get("qq") or key)
         nick = str(rec.get("nickname") or "").strip() or names.get(qq, "")
+        shard_id = rec.get("shard_id")
+        ws_port: int | None = None
+        if shard_id is not None:
+            try:
+                from pallas.core.platform.shard.registry.store import worker_port_for_shard
+
+                p = int(worker_port_for_shard(int(shard_id)))
+                if 1 <= p <= 65535:
+                    ws_port = p
+            except Exception:  # noqa: BLE001
+                ws_port = None
         rows.append({
             "connection_key": str(rec.get("connection_key") or qq),
             "self_id": qq,
             "adapter": str(rec.get("adapter") or ""),
             "connected_at_unix": rec.get("connected_at_unix"),
-            "shard_id": rec.get("shard_id"),
+            "shard_id": shard_id,
             "nickname": nick,
             "online": True,
+            "ws_port": ws_port,
         })
     return rows
 

--- a/pallas/product/community_stats/public_stats.py
+++ b/pallas/product/community_stats/public_stats.py
@@ -115,6 +115,11 @@ def _parse_stats_body(body: Any, stats_url: str) -> dict[str, Any]:
         out["corpus"] = corpus_out
     if "corpus_enabled" in body:
         out["corpus_enabled"] = bool(body["corpus_enabled"])
+    elif corpus_out:
+        # /v1/stats 不含 corpus_enabled；有语料聚合块即视为中心已开共享语料
+        out["corpus_enabled"] = True
+    elif "corpus" in body and body["corpus"] is None:
+        out["corpus_enabled"] = False
     federation_out = _parse_federation_block(body.get("federation"))
     if federation_out:
         out["federation"] = federation_out

--- a/pallas/product/llm/reply_variation.py
+++ b/pallas/product/llm/reply_variation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import Counter
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -29,13 +30,72 @@ _SIGH_OPENER_RE = re.compile(r"^(欸|哎|唉|呃|额)+")
 _ANIMAL_OPENER_RE = re.compile(r"^(哞~|喵~|喵呜~|哞呜~)")
 _TILDE_OPENER_RE = re.compile(r"^([\u4e00-\u9fff]{1,2})~")
 _KAOMOJI_SUFFIX_RE = re.compile(r"\(\*[^)]{1,16}\*\)\s*$")
+_CJK_RUN_RE = re.compile(r"[\u4e00-\u9fff]+")
+_ECHO_QUESTION_RE = re.compile(r"^[\u4e00-\u9fffA-Za-z0-9]{1,8}[？?]")
 
 _USER_WAIT_SUFFIXES = ("?", "？", "...", "…", "、")
 _USER_WAIT_TOKENS = ("等等", "等下", "先别", "我补一句", "还有", "然后")
 _STRUCTURE_MARKERS = ("先", "别", "可以", "不用", "慢慢", "一下", "这事", "你先")
 _GENERIC_PREFIX_MIN_LEN = 3
 _GENERIC_PREFIX_MAX_LEN = 4
+# 兼容旧测试/调用；母题去重已改为短窗统计，不再依赖手维名单。
 DEFAULT_MOTIF_TOKENS = ("草料", "土木", "漂亮牛牛")
+_MOTIF_WINDOW = 6
+_MOTIF_MIN_DOCS = 2
+_MOTIF_LIMIT = 4
+_MOTIF_NGRAM_MIN = 2
+_MOTIF_NGRAM_MAX = 4
+_MOTIF_STOPWORDS = frozenset({
+    "我们",
+    "你们",
+    "他们",
+    "这个",
+    "那个",
+    "什么",
+    "怎么",
+    "不是",
+    "就是",
+    "可以",
+    "没有",
+    "还是",
+    "一个",
+    "自己",
+    "然后",
+    "因为",
+    "所以",
+    "如果",
+    "已经",
+    "真的",
+    "有点",
+    "一下",
+    "这样",
+    "那样",
+    "这么",
+    "那么",
+    "怎样",
+    "为何",
+    "为啥",
+    "知道",
+    "觉得",
+    "感觉",
+    "其实",
+    "不过",
+    "但是",
+    "而且",
+    "或者",
+    "牛牛",
+    "博士",
+    "帕拉斯",
+    "今天",
+    "明天",
+    "昨天",
+    "现在",
+    "时候",
+    "东西",
+    "地方",
+    "问题",
+    "事情",
+})
 
 
 def should_wait_for_more(user_text: str) -> bool:
@@ -51,11 +111,47 @@ def has_kaomoji_suffix(text: str) -> bool:
     return bool(_KAOMOJI_SUFFIX_RE.search(str(text or "").strip()))
 
 
+def _motif_ngrams_for_text(text: str) -> set[str]:
+    grams: set[str] = set()
+    for run in _CJK_RUN_RE.findall(str(text or "")):
+        max_n = min(_MOTIF_NGRAM_MAX, len(run))
+        for size in range(_MOTIF_NGRAM_MIN, max_n + 1):
+            for index in range(len(run) - size + 1):
+                gram = run[index : index + size]
+                if gram in _MOTIF_STOPWORDS:
+                    continue
+                if any(stop in gram and stop != gram for stop in ("什么", "怎么", "怎样")):
+                    continue
+                grams.add(gram)
+    return grams
+
+
 def extract_recent_motifs(texts: list[str]) -> list[str]:
-    recent_texts = [str(item or "").strip() for item in texts[-6:] if str(item or "").strip()]
-    if not recent_texts:
+    """从近窗 assistant 回复里统计重复中文片段，自动当成本轮母题（无需手维黑名单）。"""
+    recent_texts = [str(item or "").strip() for item in texts[-_MOTIF_WINDOW:] if str(item or "").strip()]
+    if len(recent_texts) < _MOTIF_MIN_DOCS:
         return []
-    return [token for token in DEFAULT_MOTIF_TOKENS if any(token in text for text in recent_texts)]
+
+    doc_freq: Counter[str] = Counter()
+    for text in recent_texts:
+        for gram in _motif_ngrams_for_text(text):
+            doc_freq[gram] += 1
+
+    candidates = [(gram, count) for gram, count in doc_freq.items() if count >= _MOTIF_MIN_DOCS]
+    # 先高文档频，再偏长，抓住「牛角」这类真正发粘核心
+    candidates.sort(key=lambda item: (-item[1], -len(item[0]), item[0]))
+    picked: list[str] = []
+    for gram, _count in candidates:
+        if any(gram in chosen or chosen in gram for chosen in picked):
+            continue
+        picked.append(gram)
+        if len(picked) >= _MOTIF_LIMIT:
+            break
+    return picked
+
+
+def count_echo_question_openers(texts: list[str]) -> int:
+    return sum(1 for text in texts if _ECHO_QUESTION_RE.match(str(text or "").strip()))
 
 
 def repeated_assistant_openers(turns: list[LlmChatTurn], *, limit: int = 3) -> list[str]:
@@ -162,7 +258,7 @@ def build_recent_reply_variation_hint(turns: list[LlmChatTurn]) -> str:
     hints: list[str] = []
     motifs = extract_recent_motifs(assistant_texts)
     if motifs:
-        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs))
+        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs) + "；换隐喻或直接短怼")
     openers = repeated_assistant_openers(turns)
     if openers:
         hints.append("最近几轮别再用这些开头：" + "、".join(openers))
@@ -195,6 +291,9 @@ def build_recent_reply_variation_hint(turns: list[LlmChatTurn]) -> str:
 
         if any(item in SOFT_AGREE_OPENERS for item in sticky):
             hints.insert(1, "别用行行行/好好好/还行吧起手，直接接话题")
+
+    if count_echo_question_openers(recent4) >= 2:
+        hints.insert(0, "最近老用「复读对方词？」起手，这轮直接接话，别再复读反问")
 
     recent = assistant_texts[-3:]
     from pallas.product.persona.soft_agree_fillers import match_soft_agree_opener
@@ -247,7 +346,7 @@ def build_variation_hint_from_recent_texts(recent_texts: list[str]) -> str:
     hints: list[str] = []
     motifs = extract_recent_motifs(texts)
     if motifs:
-        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs))
+        hints.append("最近几轮别老围着这些短窗母题打转：" + "、".join(motifs) + "；换隐喻或直接短怼")
     openers: list[str] = []
     for text in reversed(texts[-6:]):
         opener = classify_repeated_opener(text)
@@ -259,6 +358,8 @@ def build_variation_hint_from_recent_texts(recent_texts: list[str]) -> str:
         hints.append("最近几轮别再用这些开头：" + "、".join(openers))
 
     recent = texts[-3:]
+    if count_echo_question_openers(texts[-4:]) >= 2:
+        hints.insert(0, "最近老用「复读对方词？」起手，这轮直接接话，别再复读反问")
     animal_openers = sum(1 for text in recent if _ANIMAL_OPENER_RE.match(text))
     if animal_openers >= 2:
         hints.append("最近开头动物口癖太多，别再用哞~/喵~ 起手")

--- a/pallas/product/persona/expression_habits.py
+++ b/pallas/product/persona/expression_habits.py
@@ -99,7 +99,11 @@ async def build_expression_context_with_entries(
         if scene:
             kwargs["scene"] = scene
         entries = await asyncio.to_thread(retrieve_expressions_for_message, int(group_id), plain_text, **kwargs)
-        reference = build_expression_reference_block(entries, limit=cfg.llm_expression_retrieve_limit)
+        reference = build_expression_reference_block(
+            entries,
+            limit=cfg.llm_expression_retrieve_limit,
+            blocked_motifs=blocked_motifs,
+        )
         if reference:
             return reference, entries
     return build_expression_habits_suffix(style_profile), []

--- a/pallas/product/persona/expression_learn.py
+++ b/pallas/product/persona/expression_learn.py
@@ -45,12 +45,16 @@ def is_saying_safe_for_expression(text: str) -> bool:
 
 def infer_expression_occasion(text: str, stance: str) -> str:
     plain = str(text or "").strip()
+    if any(cue in plain for cue in ("打死", "撞死", "杀掉", "滚出来", "滚", "蠢东西", "笨蛋", "废物", "去死")):
+        return OccasionTag.PROVOCATION
     if stance == "complain":
         if any(cue in plain for cue in ("加班", "上班", "下班")):
             return OccasionTag.VENTING
         if "抽卡" in plain:
             return OccasionTag.VENTING
         return OccasionTag.VENTING
+    if any(cue in plain for cue in ("哈哈", "笑死", "草", "整活", "玩梗")):
+        return OccasionTag.BANTER
     if stance == "warm":
         return OccasionTag.WARM_REPLY
     if stance == "echo":
@@ -69,6 +73,9 @@ def propose_expression_from_utterance(
 ) -> ExpressionEntry | None:
     saying = clean_expression_saying(text)
     if not is_saying_safe_for_expression(saying):
+        return None
+    # 自生成「复读词？」模板不再回灌表达库，避免短窗母题自我强化
+    if source == "llm_success" and re.match(r"^[\u4e00-\u9fffA-Za-z0-9]{1,8}[？?]", saying):
         return None
     stance = infer_expression_affect_stance(saying)
     occasion = infer_expression_occasion(saying, stance)

--- a/pallas/product/persona/expression_retrieve.py
+++ b/pallas/product/persona/expression_retrieve.py
@@ -45,6 +45,10 @@ def score_expression_for_query(
     if entry.status == "rejected":
         return None
 
+    blocked_tokens = {str(item).strip() for item in (blocked_motifs or []) if str(item).strip()}
+    if blocked_tokens and any(token in entry.saying for token in blocked_tokens):
+        return None
+
     score = 100 if entry.status == "active" else 50
     score += min(max(1, int(entry.support)), 10)
     if target_bot_id:
@@ -52,6 +56,13 @@ def score_expression_for_query(
             score += 15
         elif int(entry.bot_id) == 0:
             score -= 10
+
+    # 短窗母题发粘时，优先群友观察说法，少灌自生成金句
+    if blocked_tokens:
+        if entry.source == "group_observe":
+            score += 25
+        elif entry.source == "llm_success":
+            score -= 15
 
     target_stance = infer_expression_affect_stance(plain_text)
     entry_stance = str(entry.affect_hint or "").strip() or infer_expression_affect_stance(entry.saying)
@@ -64,9 +75,6 @@ def score_expression_for_query(
     feedback = entry.scene_feedback.get(str(scene), {}) if scene else {}
     if feedback.get("uses"):
         score += max(-6, min(6, int(feedback.get("score", 0))))
-    blocked_tokens = {str(item).strip() for item in (blocked_motifs or []) if str(item).strip()}
-    if blocked_tokens and any(token in entry.saying for token in blocked_tokens):
-        score -= 25
     # 与当前句无关的「已站稳」自生成金句不注入；弱相关则降权
     if kw_hits == 0 and entry.source == "llm_success" and (target_stance == "neutral" or target_stance != entry_stance):
         if entry.status == "active" or int(entry.support) >= 3:
@@ -133,7 +141,12 @@ def retrieve_expressions_for_message(
     return picked
 
 
-def build_expression_reference_block(entries: Iterable[ExpressionEntry], *, limit: int = 5) -> str:
+def build_expression_reference_block(
+    entries: Iterable[ExpressionEntry],
+    *,
+    limit: int = 5,
+    blocked_motifs: Iterable[str] | None = None,
+) -> str:
     lines: list[str] = []
     seen_openers: set[str] = set()
     for entry in entries:
@@ -146,7 +159,13 @@ def build_expression_reference_block(entries: Iterable[ExpressionEntry], *, limi
             continue
         if opener:
             seen_openers.add(opener)
-        lines.append(f"{occasion}→{saying}")
+        lines.append(f"当「{occasion}」时可参考「{saying}」")
         if len(lines) >= max(1, int(limit)):
             break
-    return f"\n【表达参考】\n{chr(10).join(lines)}。" if lines else ""
+    if not lines:
+        return ""
+    motif_tokens = [str(item).strip() for item in (blocked_motifs or []) if str(item).strip()]
+    header = "【表达参考】按场合换说法"
+    if motif_tokens:
+        header += "，勿复读：" + "、".join(motif_tokens[:4])
+    return f"\n{header}。\n" + "\n".join(lines) + "。"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pallas-bot"
-version = "4.1.17"
+version = "4.1.18"
 description = "《明日方舟》帕拉斯 Bot"
 authors = [{ name = "MistEO" }]
 maintainers = [

--- a/tests/common/test_community_stats.py
+++ b/tests/common/test_community_stats.py
@@ -124,6 +124,30 @@ def test_parse_stats_body():
     )
     assert data["deployments_total"] == 10
     assert data["online_ttl_sec"] == 900
+    assert "corpus_enabled" not in data
+
+
+def test_parse_stats_body_infers_corpus_enabled_from_corpus_block():
+    data = _parse_stats_body(
+        {
+            "deployments_total": 10,
+            "deployments_online": 3,
+            "bots_online_sum": 7,
+            "corpus": {
+                "contexts_total": 1,
+                "answers_total": 2,
+                "answer_hits_sum": 5,
+                "enrollments_total": 3,
+                "enrollments_online": 2,
+                "enrollments_recent_24h": 1,
+                "read_enabled_total": 3,
+                "contribute_enabled_total": 2,
+            },
+        },
+        "https://stats.example/v1/stats",
+    )
+    assert data["corpus_enabled"] is True
+    assert data["corpus"]["enrollments_total"] == 3
 
 
 @pytest.mark.asyncio

--- a/tests/features/test_expression_learn.py
+++ b/tests/features/test_expression_learn.py
@@ -46,6 +46,26 @@ def test_propose_expression_builds_clean_affect_aligned_draft() -> None:
     assert len(entry.saying) <= 20
 
 
+def test_propose_skips_llm_success_echo_question_template() -> None:
+    learn = expression_learn()
+    assert (
+        learn.propose_expression_from_utterance(
+            "兑？我这牛角可不能兑",
+            source="llm_success",
+            channel="group",
+        )
+        is None
+    )
+    assert (
+        learn.propose_expression_from_utterance(
+            "够得着再说",
+            source="llm_success",
+            channel="group",
+        )
+        is not None
+    )
+
+
 def test_note_expression_respects_config_and_merges_llm_success_weight(monkeypatch, tmp_path) -> None:
     learn = expression_learn()
     monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))

--- a/tests/features/test_expression_retrieve.py
+++ b/tests/features/test_expression_retrieve.py
@@ -162,7 +162,9 @@ def test_retrieve_filters_other_bot_and_builds_reference_block(monkeypatch, tmp_
     entries = retrieve_expressions_for_message(10001, "抽卡又歪了", limit=5, bot_id=10001)
 
     assert [entry.saying for entry in entries] == ["这也太黑了"]
-    assert build_expression_reference_block(entries) == "\n【表达参考】\nventing→这也太黑了。"
+    block = build_expression_reference_block(entries)
+    assert "当「venting」时可参考「这也太黑了」" in block
+    assert block.startswith("\n【表达参考】")
 
 
 def test_retrieve_prefers_own_bot_and_demotes_blocked_motifs(monkeypatch, tmp_path) -> None:
@@ -199,8 +201,40 @@ def test_retrieve_prefers_own_bot_and_demotes_blocked_motifs(monkeypatch, tmp_pa
         blocked_motifs=["草料"],
     )
     assert filtered
-    assert filtered[0].bot_id == 10001
-    assert all("草料" not in entry.saying for entry in filtered[:1])
+    assert all("草料" not in entry.saying for entry in filtered)
+
+
+def test_retrieve_prefers_group_observe_when_motifs_sticky(monkeypatch, tmp_path) -> None:
+    from pallas.product.persona.expression_retrieve import retrieve_expressions_for_message
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    append_or_merge_expression(
+        make_entry(
+            occasion="banter",
+            saying="够得着再说。",
+            status="shadow",
+            source="group_observe",
+            support=1,
+        )
+    )
+    append_or_merge_expression(
+        make_entry(
+            occasion="banter",
+            saying="牛角给你当棒球棍。",
+            status="active",
+            source="llm_success",
+            support=8,
+        )
+    )
+    entries = retrieve_expressions_for_message(
+        10001,
+        "你打一下试试",
+        limit=2,
+        blocked_motifs=["牛角"],
+    )
+    assert entries
+    assert entries[0].saying == "够得着再说。"
+    assert all("牛角" not in entry.saying for entry in entries)
 
 
 @pytest.mark.asyncio
@@ -214,10 +248,9 @@ async def test_context_suffix_respects_inject_config_and_falls_back_to_habits(mo
     )
     retrieve = Mock(return_value=[SimpleNamespace(occasion="吐槽", saying="太难了")])
     monkeypatch.setattr(habits, "retrieve_expressions_for_message", retrieve)
-    assert (
-        await habits.build_expression_context_suffix(10001, "太离谱了", blocked_motifs=["草料"])
-        == "\n【表达参考】\n吐槽→太难了。"
-    )
+    suffix = await habits.build_expression_context_suffix(10001, "太离谱了", blocked_motifs=["草料"])
+    assert "当「吐槽」时可参考「太难了」" in suffix
+    assert "勿复读：草料" in suffix
     retrieve.assert_called_once_with(
         10001,
         "太离谱了",

--- a/tests/features/test_reply_variation.py
+++ b/tests/features/test_reply_variation.py
@@ -83,16 +83,35 @@ def test_motif_hint_from_recent_texts() -> None:
     hint = build_variation_hint_from_recent_texts([
         "双倍草料，土木牛牛明天干活都有劲了。",
         "草料管够就行",
+        "再来一份草料垫垫肚子。",
     ])
-    assert "草料" in hint or "土木" in hint
+    assert "草料" in hint
 
 
-def test_extract_recent_motifs_deduplicates_default_tokens() -> None:
+def test_extract_recent_motifs_detects_repeated_ngrams() -> None:
     motifs = extract_recent_motifs([
         "双倍草料，土木牛牛明天干活都有劲了。",
         "漂亮牛牛今天也得吃草料。",
+        "草料管够就行。",
     ])
-    assert motifs == ["草料", "土木", "漂亮牛牛"]
+    assert "草料" in motifs
+
+
+def test_extract_recent_motifs_catches_sticky_horn_without_blacklist() -> None:
+    motifs = extract_recent_motifs([
+        "兑？我这牛角可不能兑，留着顶门用呢。",
+        "撞死你？那我得先热热身，牛角可金贵着呢。",
+        "牛角割了可没法再长，我留着顶门用呢。",
+        "嘿，说我蠢？牛角给你当棒球棍耍是吧。",
+    ])
+    assert "牛角" in motifs
+    hint = build_variation_hint_from_recent_texts([
+        "兑？我这牛角可不能兑，留着顶门用呢。",
+        "撞死你？那我得先热热身，牛角可金贵着呢。",
+        "牛角割了可没法再长，我留着顶门用呢。",
+    ])
+    assert "复读对方词" in hint
+    assert "牛角" in hint
 
 
 def test_compile_self_identity_prompt_mentions_niu_niu() -> None:


### PR DESCRIPTION
## 更新公告

- 控制台可断开外置协议账号的本机 OneBot WS；连接列表带出 WS 端口
- 短窗自动母题去重，表达库换说法更稳
- 社区统计 `/v1/stats` 回退时能推断语料是否开启
- 捆绑控制台 WebUI **v0.8.13**

## Summary by Sourcery

发布 v4.1.18，包含控制台 OneBot WS 管理、改进的短窗口母题处理以优化 LLM 回复和表达建议，以及更健壮的社区统计语料库检测。

New Features:
- 暴露 `POST /pallas/api/bots/{qq}/disconnect-ws` 接口，使控制台能够断开本地 OneBot WS 连接，而无需停止外部协议客户端。
- 在控制台 WebUI 的机器人连接列表中加入 `ws_port` 和 `shard_id` 元数据。

Bug Fixes:
- 当 `/v1/stats` 未显式提供 `corpus_enabled` 标志时，通过语料统计块是否存在来推断 `corpus_enabled` 的取值。

Enhancements:
- 重构短窗口母题检测，自动抽取重复中文 n-gram，去重粘连母题，并优化回复多样性提示。
- 强化表达检索和评分逻辑，避免被封禁的母题，在母题粘连时优先采用群聊中观察到的说法而非自生成内容，并改进展示给 LLM 的参考块结构。
- 优化表达学习，更好地推断场景（如挑衅、斗嘴），并在 LLM 回复成功时跳过保存“回声式问句”模板。
- 在表达参考渲染中传播被封禁的母题，以便提醒 LLM 在建议措辞中不要重复这些内容。

Documentation:
- 更新 `CHANGELOG.md`，添加 4.1.18 版本说明，包括控制台 WS 控制、母题/表达改进以及统计行为变更。

Tests:
- 扩展并调整表达检索、学习和习惯相关测试，以覆盖新的评分、封禁和参考块格式。
- 增加针对改进母题抽取、回声式问句开头处理以及社区统计中 `corpus_enabled` 推断的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Release v4.1.18 with console OneBot WS management, improved short-window motif handling for LLM replies and expression suggestions, and more robust community stats corpus detection.

New Features:
- Expose POST /pallas/api/bots/{qq}/disconnect-ws to let the console disconnect local OneBot WS connections without stopping the external protocol client.
- Include ws_port and shard_id metadata in bot connection listings for the console WebUI.

Bug Fixes:
- Infer corpus_enabled from the presence or absence of the corpus stats block when /v1/stats does not explicitly provide the flag.

Enhancements:
- Rework short-window motif detection to automatically extract repeated Chinese n-grams, de-duplicate sticky motifs, and refine reply variation hints.
- Strengthen expression retrieval and scoring to avoid blocked motifs, favor group-observed sayings over self-generated ones when motifs are sticky, and improve the shape of reference blocks shown to the LLM.
- Refine expression learning to better infer occasions (e.g., provocation and banter) and skip saving echo-question templates from successful LLM replies.
- Propagate blocked motifs into expression reference rendering so the LLM is reminded not to repeat them in suggested phrasings.

Documentation:
- Update CHANGELOG.md with the 4.1.18 release notes, including console WS controls, motif/expression improvements, and stats behavior changes.

Tests:
- Extend and adjust tests for expression retrieval, learning, and habits to cover new scoring, blocking, and reference block formats.
- Add tests for improved motif extraction, echo-question opener handling, and community stats corpus_enabled inference.

</details>