### PR TITLE
fix(ai_callback): 回调原子 claim 避免重复投递

### DIFF
--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -469,6 +469,19 @@ class TaskManager:
             return cls._tasks.get(task_id)
 
     @classmethod
+    async def claim_task(cls, task_id: str) -> dict | None:
+        """原子取出并移除任务，避免并发回调重复投递。"""
+        await cls.refresh()
+        async with cls._lock:
+            task = cls._tasks.pop(task_id, None)
+        if task is None:
+            return None
+        from pallas.core.platform.shard.coord.ai_task_registry import remove_ai_task
+
+        await asyncio.to_thread(remove_ai_task, task_id)
+        return task
+
+    @classmethod
     async def remove_task(cls, task_id: str):
         await cls.refresh()
         async with cls._lock:

--- a/pallas/core/platform/ai_callback/runner.py
+++ b/pallas/core/platform/ai_callback/runner.py
@@ -20,7 +20,7 @@ from pallas.core.platform.ai_callback.task_types import (
     DRAW_IMAGE_TASK_TYPE,
     VOICE_TASK_TYPES,
 )
-from pallas.core.platform.shard.coord.ai_task_registry import get_ai_task_record, remove_ai_task
+from pallas.core.platform.shard.coord.ai_task_registry import claim_ai_task_record
 from pallas.product.llm.delivery import (
     deliver_llm_callback_success,
     deliver_llm_chat_result,
@@ -39,10 +39,11 @@ __all__ = [
 
 
 async def resolve_callback_task(task_id: str) -> dict | None:
-    task = await TaskManager.get_task(task_id)
+    """原子领取回调任务；重复回调将拿不到任务（404），避免重复发语音/图。"""
+    task = await TaskManager.claim_task(task_id)
     if task:
         return task
-    rec = get_ai_task_record(task_id)
+    rec = claim_ai_task_record(task_id)
     if not rec:
         return None
     return {
@@ -132,8 +133,6 @@ async def run_ai_callback(
     if status == "failed":
         track_llm_callback(task, "callback_fail")
         invoke_media_task_failure(task)
-        await TaskManager.remove_task(task_id)
-        remove_ai_task(task_id)
         if bot is not None and group_id:
             fail_msg = failure_reply_for_task(task)
             if fail_msg:
@@ -243,8 +242,6 @@ async def run_ai_callback(
             except Exception:
                 logger.exception("enqueue drunk tts failed task={}", task_id)
 
-        await TaskManager.remove_task(task_id)
-        remove_ai_task(task_id)
         logger.info(
             "AI callback completed task={} delivered={} bot_id={} group_id={} task_type={}",
             task_id,

--- a/pallas/core/platform/shard/coord/ai_task_registry.py
+++ b/pallas/core/platform/shard/coord/ai_task_registry.py
@@ -90,6 +90,38 @@ def remove_ai_task_redis_sync(task_id: str) -> None:
         return
 
 
+def claim_ai_task_redis_sync(task_id: str) -> dict[str, Any] | None:
+    """原子读取并删除 Redis 中的 AI 任务登记。"""
+    from pallas.core.platform.coord.redis_claim import get_coord_redis_client
+    from pallas.core.platform.coord.redis_settings import coord_redis_enabled
+
+    if not coord_redis_enabled():
+        return None
+    client = get_coord_redis_client()
+    if client is None:
+        return None
+    key = ai_task_redis_key(task_id)
+    try:
+        getdel = getattr(client, "getdel", None)
+        if callable(getdel):
+            raw = getdel(key)
+        else:
+            raw = client.get(key)
+            if raw is not None:
+                client.delete(key)
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        data = json.loads(str(raw))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _is_stale(rec: dict[str, Any]) -> bool:
     start = float(rec.get("start_time") or 0)
     return start <= 0 or (time.time() - start) > ai_task_ttl_sec()
@@ -151,6 +183,18 @@ def get_ai_task_record(task_id: str) -> dict[str, Any] | None:
     rec = read_ai_task_redis_sync(task_id)
     if not rec or _is_stale(rec):
         remove_ai_task(task_id)
+        return None
+    return rec
+
+
+def claim_ai_task_record(task_id: str) -> dict[str, Any] | None:
+    """原子领取分片任务登记；已被领取或过期则返回 None。"""
+    if not shard_ctx.sharding_active():
+        return None
+    rec = claim_ai_task_redis_sync(task_id)
+    if not rec:
+        return None
+    if _is_stale(rec):
         return None
     return rec
 

--- a/tests/common/test_ai_task_registry.py
+++ b/tests/common/test_ai_task_registry.py
@@ -61,6 +61,32 @@ async def test_task_manager_keeps_ai_task_beyond_legacy_10min(monkeypatch) -> No
     assert "task-1" in TaskManager._tasks
 
 
+async def test_task_manager_claim_task_is_one_shot(monkeypatch) -> None:
+    import time
+
+    start = time.time()
+    TaskManager._tasks = {
+        "task-claim": {
+            "bot_id": "123456",
+            "group_id": 42,
+            "start_time": start,
+        }
+    }
+    monkeypatch.setattr("pallas.core.platform.shard.coord.ai_task_registry.ai_task_ttl_sec", lambda: 86400.0)
+    monkeypatch.setattr(
+        "pallas.core.platform.shard.coord.ai_task_registry.remove_ai_task",
+        lambda _task_id: None,
+    )
+
+    first = await TaskManager.claim_task("task-claim")
+    second = await TaskManager.claim_task("task-claim")
+
+    assert first is not None
+    assert first["group_id"] == 42
+    assert second is None
+    assert "task-claim" not in TaskManager._tasks
+
+
 def test_ai_task_registry_uses_redis(fake_coord_redis, monkeypatch) -> None:
     now = 1000.0
     monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
@@ -81,6 +107,28 @@ def test_ai_task_registry_uses_redis(fake_coord_redis, monkeypatch) -> None:
 
     mod.remove_ai_task("task-redis")
     assert mod.get_ai_task_record("task-redis") is None
+
+
+def test_claim_ai_task_record_is_one_shot(fake_coord_redis, monkeypatch) -> None:
+    now = 1500.0
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
+    monkeypatch.setattr(mod, "current_worker_port", lambda: 7973)
+    monkeypatch.setattr(mod, "get_shard_registry_settings", lambda: SimpleNamespace(shard_id=3))
+    monkeypatch.setattr(mod, "get_shard_registry", lambda: SimpleNamespace(shard_for_bot=lambda _bot_id: None))
+    monkeypatch.setattr(mod.time, "time", lambda: now)
+
+    mod.register_ai_task(
+        "task-claim-redis",
+        {"bot_id": "123456", "group_id": 42, "start_time": now},
+    )
+
+    first = mod.claim_ai_task_record("task-claim-redis")
+    second = mod.claim_ai_task_record("task-claim-redis")
+
+    assert first is not None
+    assert first["worker_port"] == 7973
+    assert second is None
+    assert mod.get_ai_task_record("task-claim-redis") is None
 
 
 def test_ai_task_registry_requires_redis_when_sharding(monkeypatch) -> None:

--- a/tests/platform/test_ai_callback_runner.py
+++ b/tests/platform/test_ai_callback_runner.py
@@ -55,22 +55,18 @@ async def test_run_ai_callback_falls_back_to_shared_registry(monkeypatch: pytest
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
         ai_callback_runner,
-        "get_ai_task_record",
+        "claim_ai_task_record",
         lambda _task_id: {"bot_id": "111", "group_id": 222},
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-1", status="success", text="hello")
 
     assert result == {"message": "ok"}
-    remove_task.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -82,7 +78,7 @@ async def test_run_ai_callback_appends_user_and_assistant_on_llm_chat_success(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -93,9 +89,6 @@ async def test_run_ai_callback_appends_user_and_assistant_on_llm_chat_success(
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     calls: list[tuple] = []
 
@@ -123,7 +116,7 @@ async def test_run_ai_callback_skips_summary_writeback_when_policy_disabled(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -134,8 +127,6 @@ async def test_run_ai_callback_skips_summary_writeback_when_policy_disabled(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(llm_delivery, "append_llm_message", AsyncMock(return_value=True))
     monkeypatch.setattr(llm_delivery, "can_write_runtime_state_summary", lambda: False)
 
@@ -163,7 +154,7 @@ async def test_run_ai_callback_records_llm_task_metrics(monkeypatch: pytest.Monk
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -173,8 +164,6 @@ async def test_run_ai_callback_records_llm_task_metrics(monkeypatch: pytest.Monk
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     await ai_callback_runner.run_ai_callback("task-1", status="success", text="润色后")
     snap = llm_task_metrics_snapshot()
@@ -192,7 +181,7 @@ async def test_run_ai_callback_records_llm_route_metrics(monkeypatch: pytest.Mon
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -203,8 +192,6 @@ async def test_run_ai_callback_records_llm_route_metrics(monkeypatch: pytest.Mon
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     await ai_callback_runner.run_ai_callback("task-route-1", status="success", text="选句结果")
     snap = llm_task_metrics_snapshot()
@@ -222,7 +209,7 @@ async def test_run_ai_callback_records_pipeline_route_from_task(monkeypatch: pyt
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -235,8 +222,6 @@ async def test_run_ai_callback_records_pipeline_route_from_task(monkeypatch: pyt
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         "pallas.product.llm.delivery.evaluate_repeater_callback_text",
         AsyncMock(return_value=True),
@@ -258,7 +243,7 @@ async def test_run_ai_callback_resolves_empty_route_by_task_type(monkeypatch: py
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -270,8 +255,6 @@ async def test_run_ai_callback_resolves_empty_route_by_task_type(monkeypatch: py
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         "pallas.product.llm.delivery.evaluate_repeater_callback_text",
         AsyncMock(return_value=True),
@@ -290,7 +273,7 @@ async def test_run_ai_callback_appends_behavior_run(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -305,8 +288,6 @@ async def test_run_ai_callback_appends_behavior_run(monkeypatch: pytest.MonkeyPa
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(llm_delivery, "append_llm_message", AsyncMock(return_value=True))
     recorded: list[object] = []
     monkeypatch.setattr(llm_delivery, "append_behavior_run", lambda run: recorded.append(run))
@@ -328,7 +309,7 @@ async def test_run_ai_callback_attaches_agent_trace_to_behavior_run(monkeypatch:
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -343,8 +324,6 @@ async def test_run_ai_callback_attaches_agent_trace_to_behavior_run(monkeypatch:
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(llm_delivery, "append_llm_message", AsyncMock(return_value=True))
     recorded: list[object] = []
     monkeypatch.setattr(llm_delivery, "append_behavior_run", lambda run: recorded.append(run))
@@ -372,7 +351,7 @@ async def test_run_ai_callback_appends_repeater_feedback_when_enabled(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -387,8 +366,6 @@ async def test_run_ai_callback_appends_repeater_feedback_when_enabled(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -421,7 +398,7 @@ async def test_run_ai_callback_learns_delivered_llm_reply_without_breaking_feedb
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -432,8 +409,6 @@ async def test_run_ai_callback_learns_delivered_llm_reply_without_breaking_feedb
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     learned: list[tuple[int, str, dict]] = []
 
     def note(group_id, text, **meta):
@@ -459,7 +434,7 @@ async def test_run_ai_callback_appends_repeater_task_feedback_when_enabled(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -472,8 +447,6 @@ async def test_run_ai_callback_appends_repeater_task_feedback_when_enabled(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -505,7 +478,7 @@ async def test_run_ai_callback_disabled_repeater_feedback_does_not_append(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -517,8 +490,6 @@ async def test_run_ai_callback_disabled_repeater_feedback_does_not_append(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -542,7 +513,7 @@ async def test_run_ai_callback_feedback_write_failure_does_not_break_success(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -554,9 +525,6 @@ async def test_run_ai_callback_feedback_write_failure_does_not_break_success(
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -572,7 +540,6 @@ async def test_run_ai_callback_feedback_write_failure_does_not_break_success(
 
     assert result == {"message": "ok"}
     bot.call_api.assert_awaited_once()
-    remove_task.assert_awaited_once_with("task-feedback-fail-1")
 
 
 @pytest.mark.asyncio
@@ -582,7 +549,7 @@ async def test_run_ai_callback_delivery_failure_does_not_append_repeater_feedbac
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: MagicMock())
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -594,8 +561,6 @@ async def test_run_ai_callback_delivery_failure_does_not_append_repeater_feedbac
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -618,17 +583,13 @@ async def test_run_ai_callback_send_timeout_returns_failed(monkeypatch: pytest.M
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(return_value={"bot_id": "111", "group_id": 222}),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-1", status="success", text="hello")
 
     assert result == {"message": "failed"}
-    remove_task.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -638,7 +599,7 @@ async def test_run_ai_callback_llm_chat_duplicate_reply_uses_fallback(monkeypatc
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -649,9 +610,6 @@ async def test_run_ai_callback_llm_chat_duplicate_reply_uses_fallback(monkeypatc
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "should_suppress_llm_duplicate_reply",
@@ -665,7 +623,6 @@ async def test_run_ai_callback_llm_chat_duplicate_reply_uses_fallback(monkeypatc
     call_kwargs = bot.call_api.await_args.kwargs
     assert call_kwargs["group_id"] == 222
     assert call_kwargs["message"] == "语料候选"
-    remove_task.assert_awaited_once_with("task-dup-1")
 
 
 @pytest.mark.asyncio
@@ -676,7 +633,7 @@ async def test_run_ai_callback_get_bot_failed(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(ai_callback_runner, "get_bot", raise_get_bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(return_value={"bot_id": "111", "group_id": 222}),
     )
 
@@ -692,7 +649,7 @@ async def test_run_ai_callback_drunk_chat_failed_is_silent(monkeypatch: pytest.M
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -701,15 +658,11 @@ async def test_run_ai_callback_drunk_chat_failed_is_silent(monkeypatch: pytest.M
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-drunk-fail", status="failed")
 
     assert result == {"message": "ok"}
     bot.call_api.assert_not_awaited()
-    remove_task.assert_awaited_once_with("task-drunk-fail")
 
 
 @pytest.mark.asyncio
@@ -719,7 +672,7 @@ async def test_run_ai_callback_llm_chat_failed_is_silent(monkeypatch: pytest.Mon
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -728,15 +681,11 @@ async def test_run_ai_callback_llm_chat_failed_is_silent(monkeypatch: pytest.Mon
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-llm-chat-fail", status="failed")
 
     assert result == {"message": "ok"}
     bot.call_api.assert_not_awaited()
-    remove_task.assert_awaited_once_with("task-llm-chat-fail")
 
 
 @pytest.mark.asyncio
@@ -746,7 +695,7 @@ async def test_run_ai_callback_repeater_fallback_failed_is_silent(monkeypatch: p
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -755,15 +704,11 @@ async def test_run_ai_callback_repeater_fallback_failed_is_silent(monkeypatch: p
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-1", status="failed")
 
     assert result == {"message": "ok"}
     bot.call_api.assert_not_awaited()
-    remove_task.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -775,7 +720,7 @@ async def test_run_ai_callback_repeater_polish_failed_is_silent(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -785,15 +730,11 @@ async def test_run_ai_callback_repeater_polish_failed_is_silent(
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     result = await ai_callback_runner.run_ai_callback("task-1", status="failed")
 
     assert result == {"message": "ok"}
     bot.call_api.assert_not_awaited()
-    remove_task.assert_awaited_once_with("task-1")
 
 
 @pytest.mark.asyncio
@@ -805,7 +746,7 @@ async def test_run_ai_callback_repeater_fallback_success_rejected_is_silent(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -814,8 +755,6 @@ async def test_run_ai_callback_repeater_fallback_success_rejected_is_silent(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "evaluate_repeater_callback_text",
@@ -837,7 +776,7 @@ async def test_run_ai_callback_repeater_polish_success_rejected_uses_fallback_te
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -847,8 +786,6 @@ async def test_run_ai_callback_repeater_polish_success_rejected_uses_fallback_te
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "evaluate_repeater_callback_text",
@@ -872,7 +809,7 @@ async def test_run_ai_callback_chat_output_filter_blocks_service_tone(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -882,8 +819,6 @@ async def test_run_ai_callback_chat_output_filter_blocks_service_tone(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(
         llm_delivery,
         "get_llm_config",
@@ -912,7 +847,7 @@ async def test_run_ai_callback_polish_lite_output_filter_uses_fallback(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -922,8 +857,6 @@ async def test_run_ai_callback_polish_lite_output_filter_uses_fallback(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     monkeypatch.setattr(llm_delivery, "evaluate_repeater_callback_text", AsyncMock(return_value=True))
 
     result = await ai_callback_runner.run_ai_callback(
@@ -957,7 +890,7 @@ async def test_run_ai_callback_draw_image_failed_records_runtime_failure(monkeyp
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -967,8 +900,6 @@ async def test_run_ai_callback_draw_image_failed_records_runtime_failure(monkeyp
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     record_failure = MagicMock()
     monkeypatch.setattr("pallas_plugin_draw.runtime_state.record_ai_runtime_failure", record_failure)
 
@@ -1002,7 +933,7 @@ async def test_run_ai_callback_draw_image_success(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -1013,9 +944,6 @@ async def test_run_ai_callback_draw_image_success(monkeypatch: pytest.MonkeyPatc
             }
         ),
     )
-    remove_task = AsyncMock()
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", remove_task)
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
     bump_usage = MagicMock()
     monkeypatch.setattr("pallas_plugin_draw.draw_usage_store.bump_pallas_draw_usage", bump_usage)
     persist = MagicMock()
@@ -1033,7 +961,6 @@ async def test_run_ai_callback_draw_image_success(monkeypatch: pytest.MonkeyPatc
     bump_usage.assert_called_once_with((222, 333), True)
     persist.assert_called_once_with(png, 222, 333)
     record_success.assert_called_once()
-    remove_task.assert_awaited_once_with("draw-task-1")
 
 
 @pytest.mark.asyncio
@@ -1050,7 +977,7 @@ async def test_run_ai_callback_sing_sends_voice_without_progress_metadata(
     monkeypatch.setattr(ai_callback_runner, "get_bot", lambda _bot_id: bot)
     monkeypatch.setattr(
         ai_callback_runner.TaskManager,
-        "get_task",
+        "claim_task",
         AsyncMock(
             return_value={
                 "bot_id": "111",
@@ -1059,8 +986,6 @@ async def test_run_ai_callback_sing_sends_voice_without_progress_metadata(
             }
         ),
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     mp3 = b"ID3" + (b"x" * 64)
     upload = UploadFile(filename="sing.mp3", file=BytesIO(mp3))
@@ -1092,10 +1017,10 @@ async def test_run_ai_callback_sing_registry_fallback_uses_registered_bot(monkey
         return bot
 
     monkeypatch.setattr(ai_callback_runner, "get_bot", fake_get_bot)
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "get_task", AsyncMock(return_value=None))
+    monkeypatch.setattr(ai_callback_runner.TaskManager, "claim_task", AsyncMock(return_value=None))
     monkeypatch.setattr(
         ai_callback_runner,
-        "get_ai_task_record",
+        "claim_ai_task_record",
         lambda _task_id: {
             "bot_id": "2927116873",
             "group_id": 626266902,
@@ -1103,8 +1028,6 @@ async def test_run_ai_callback_sing_registry_fallback_uses_registered_bot(monkey
             "task_type": "sing",
         },
     )
-    monkeypatch.setattr(ai_callback_runner.TaskManager, "remove_task", AsyncMock())
-    monkeypatch.setattr(ai_callback_runner, "remove_ai_task", lambda _task_id: None)
 
     mp3 = b"ID3" + (b"x" * 64)
     upload = UploadFile(filename="sing.mp3", file=BytesIO(mp3))
@@ -1138,3 +1061,20 @@ async def test_send_group_voice_uses_message_segment_record() -> None:
     message = call_kwargs["message"]
     assert isinstance(message, MessageSegment)
     assert message.type == "record"
+
+
+@pytest.mark.asyncio
+async def test_run_ai_callback_duplicate_claim_returns_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(
+        ai_callback_runner.TaskManager,
+        "claim_task",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(ai_callback_runner, "claim_ai_task_record", lambda _task_id: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ai_callback_runner.run_ai_callback("task-dup-voice", status="success", text="ok")
+
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
回调开始时原子领取并移除任务（本地 TaskManager + 分片 Redis 登记），并发或 AI 侧超时重试不再二次发语音/图。

## Summary by Sourcery

确保 AI 回调任务以原子方式被领取，这样重复或并发的回调就不会重新发送媒体回复。

New Features:
- 在 TaskManager 中添加一次性 `claim_task` 方法，以原子方式获取并移除本地回调任务。
- 为分片的、基于 Redis 的 AI 任务添加 `claim_ai_task_record`，使用原子的“获取并删除”操作。
- 当收到针对已被领取或已过期任务的 AI 回调时返回 HTTP 404。

Bug Fixes:
- 防止在并发回调或 AI 端重试时重复处理 AI 回调，从而避免重复发送语音或图片消息。

Enhancements:
- 通过移除显式的任务清理调用、改用原子领取语义来简化 AI 回调运行器。
- 使用在可用时启用 `GETDEL` 并根据 TTL 校验记录的原子领取函数，改进 Redis 中的 AI 任务注册表。

Tests:
- 更新 AI 回调运行器测试，以使用 `claim_task` / `claim_ai_task_record` 的语义和预期行为。
- 添加测试，验证 `TaskManager.claim_task` 和 `claim_ai_task_record` 是一次性的，并会从本地/Redis 注册表中移除其任务。
- 添加测试，确保重复的 AI 回调领取会返回 404 响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure AI callback tasks are claimed atomically so that repeated or concurrent callbacks do not re-deliver media replies.

New Features:
- Add one-shot claim_task on TaskManager to atomically retrieve and remove local callback tasks.
- Add claim_ai_task_record for sharded Redis-backed AI tasks using an atomic get-and-delete operation.
- Return HTTP 404 when an AI callback is received for a task that has already been claimed or expired.

Bug Fixes:
- Prevent duplicate AI callback processing that could re-send voice or image messages on concurrent callbacks or AI-side retries.

Enhancements:
- Simplify AI callback runner by removing explicit task cleanup calls in favor of atomic claiming semantics.
- Improve Redis AI task registry with an atomic claim function that uses GETDEL when available and validates records against TTL.

Tests:
- Update AI callback runner tests to use claim_task/claim_ai_task_record semantics and expectations.
- Add tests verifying TaskManager.claim_task and claim_ai_task_record are one-shot and remove their tasks from local/Redis registries.
- Add a test ensuring duplicate AI callback claims result in a 404 response.

</details>