### PR TITLE
docs(ai-runtime): 注明 GPU 线 cu128 与 RTX 50 支持

### DIFF
--- a/docs/maintainer/install/ai-runtime.md
+++ b/docs/maintainer/install/ai-runtime.md
@@ -77,6 +77,8 @@ uv run pallas ai setup
 | Bot 非默认端口 | `--bot-port <port>` |
 | 媒体 + NVIDIA torch | `uv run pallas ai setup --gpu` |
 
+`--gpu` 安装 AI Runtime 的 **torch 2.7.1 + cu128**（支持 RTX 50 / `sm_120`）；驱动需支持 CUDA 12.8。从旧 cu124 环境升级后请「仅重装依赖」或再跑一次带 `--gpu` 的 setup。
+
 本地 Ollama 推理（若仍用遗留 LLM worker）用 Ollama 自带 GPU，与 `--gpu`（本仓 PyTorch）无关。
 
 ### 无 GPU / 纯第三方 API


### PR DESCRIPTION
补充 AI Runtime `--gpu` 使用 torch 2.7.1 + cu128（含 RTX 50 / sm_120）及重装说明。

## Summary by Sourcery

Documentation:
- 澄清 `--gpu` 会安装带有 cu128 的 torch 2.7.1，支持 RTX 50 / sm_120，并说明对 CUDA 12.8 驱动的要求以及从 cu124 升级的步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify that `--gpu` installs torch 2.7.1 with cu128, supporting RTX 50 / sm_120, and note CUDA 12.8 driver requirement and upgrade steps from cu124.

</details>