### PR TITLE
chore(release): v4.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [4.1.21] - 2026-08-01
+
+### 更新公告
+
+- AI Runtime 启停后短轮询再返回状态，控制台更不易卡在「启动中 / 已停止」错态
+- 唱歌可为每个音色单独指定优先推理后端（需配套控制台与较新 AI Runtime）
+- 补充 DDSP 多版本手动安装说明；官方 `pallas` 对应 6.2
+- 捆绑控制台 WebUI **v0.8.14**
+
+### Added
+
+- 控制台 BFF 透传 `speaker_backends`
+
+### Fixed
+
+- Runtime 启停后短轮询 `ai_runtime_status` 再返回
+
+### Changed
+
+- AI Runtime / 唱歌文档：DDSP 多版本与按音色绑定后端
+
 ## [4.1.20] - 2026-08-01
 
 ### 更新公告

--- a/docs/maintainer/install/ai-runtime.md
+++ b/docs/maintainer/install/ai-runtime.md
@@ -108,6 +108,53 @@ AI 镜像仅用于媒体 / RWKV。Ollama 模型默认不预拉（`--profile pull
 
 从 0 安装验收见 [安装验收 Checklist](ga-install-checklist.md)。
 
+### 手动补充 DDSP-SVC 多版本（可选）
+
+默认安装只会检出 **一份** 唱歌推理代码：`app/workers/sing/DDSP-SVC`（对应 **6.2**）。控制台「优先后端」若选 `ddsp_6.3` / `ddsp_6.1`，需要本地另有对应目录；新版本 Runtime 可在缺脚本时后台自动拉取，直连 GitHub 失败时也可按下述**手动**安装。
+
+| 版本 | 优先后端 ID | 本地目录 | Git 分支 |
+| --- | --- | --- | --- |
+| 6.2（默认） | `ddsp_6.2` | `app/workers/sing/DDSP-SVC` | `6.2` |
+| 6.3 | `ddsp_6.3` | `app/workers/sing/DDSP-SVC-6.3` | `6.3` |
+| 6.1 | `ddsp_6.1` | `app/workers/sing/DDSP-SVC-6.1` | `6.1` |
+
+在 **AI Runtime 根目录**执行（同级源码仓，或托管目录如 `data/runtimes/pallas-bot-ai`）。`git clone` 的仓库地址与目标目录须写在**同一条命令**里。
+
+**PowerShell（本机代理；把 `7890` 改成你的端口）——可多行整段粘贴：**
+
+```powershell
+cd F:\Pallas-Bot\Pallas-Bot\data\runtimes\pallas-bot-ai
+$env:HTTPS_PROXY="http://127.0.0.1:7890"
+$env:HTTP_PROXY="http://127.0.0.1:7890"
+Remove-Item -Recurse -Force app\workers\sing\DDSP-SVC-6.3 -ErrorAction SilentlyContinue
+git clone --depth 1 --branch 6.3 https://github.com/PallasBot/DDSP-SVC.git app/workers/sing/DDSP-SVC-6.3
+```
+
+**终端吃不到系统代理时，用镜像（不必设 PROXY）：**
+
+```powershell
+cd F:\Pallas-Bot\Pallas-Bot\data\runtimes\pallas-bot-ai
+Remove-Item -Recurse -Force app\workers\sing\DDSP-SVC-6.3 -ErrorAction SilentlyContinue
+git clone --depth 1 --branch 6.3 https://ghproxy.net/https://github.com/PallasBot/DDSP-SVC.git app/workers/sing/DDSP-SVC-6.3
+```
+
+镜像不可用时可换：`gh-proxy.com`、`github.akams.cn`（写法同为 `https://<镜像>/https://github.com/PallasBot/DDSP-SVC.git`）。装 **6.1** 时把分支改成 `--branch 6.1`、目录改成 `app/workers/sing/DDSP-SVC-6.1`。
+
+Linux / macOS 示例：
+
+```bash
+cd /path/to/pallas-bot-ai   # 或 data/runtimes/pallas-bot-ai
+export HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890
+rm -rf app/workers/sing/DDSP-SVC-6.3
+git clone --depth 1 --branch 6.3 https://github.com/PallasBot/DDSP-SVC.git app/workers/sing/DDSP-SVC-6.3
+```
+
+::: tip
+每份约 1.6G。6.2+ 与旧 checkpoint **不兼容**——权重按哪个版本训的，就优先用哪个后端；不要指望同一份 `.pt` 跨 6.1/6.2/6.3 通吃。装完后在控制台重启媒体服务。
+
+控制台「AI 配置 → 媒体」可为**每个音色**单独指定优先推理（`speaker_backends`）。官方 `pallas`（`config.yaml` 里 `RectifiedFlow`）对应 **6.2**，建议选 `ddsp_6.2`；**6.1** 只给旧扩散权重用，不是现网官方音色。
+:::
+
 ## 接入前核对（媒体）
 
 默认 LLM 聊天只核对 Provider。下列项针对 **媒体任务**。

--- a/docs/plugins/sing/README.md
+++ b/docs/plugins/sing/README.md
@@ -12,7 +12,7 @@
 uv run pallas ext install pallas-plugin-ai-media
 ```
 
-另需部署 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)，并在控制台配置媒体服务。见 [LLM 对话、媒体与 AI Runtime](../../guide/ai-runtime-choice.md)。
+另需部署 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)，并在控制台配置媒体服务。见 [LLM 对话、媒体与 AI Runtime](../../guide/ai-runtime-choice.md)。默认仅带 DDSP **6.2**；若要用 6.3 / 6.1，见 [AI Runtime 安装 · 手动补充 DDSP](../../maintainer/install/ai-runtime.md#手动补充-ddsp-svc-多版本可选)。
 
 自 `pallas-plugin-ai-media` **4.1.0** 起，本包仅含唱歌与 TTS；酒后对话已由本体 [llm_chat](../llm_chat/README.md) 承接。
 

--- a/packages/pb_webui/common_config_api.py
+++ b/packages/pb_webui/common_config_api.py
@@ -953,8 +953,15 @@ def register_common_config_router(
         from pallas.product.llm.ops_api import put_sing_defaults
 
         payload = body if isinstance(body, dict) else {}
-        if payload.get("default_speaker") is None and payload.get("preferred_backend") is None:
-            raise HTTPException(status_code=400, detail="至少提供 default_speaker 或 preferred_backend")
+        if (
+            payload.get("default_speaker") is None
+            and payload.get("preferred_backend") is None
+            and payload.get("speaker_backends") is None
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="至少提供 default_speaker、preferred_backend 或 speaker_backends",
+            )
         try:
             data = await put_sing_defaults(payload)
         except PermissionError as e:

--- a/pallas/__init__.py
+++ b/pallas/__init__.py
@@ -1,3 +1,3 @@
 """Pallas Bot 内核包（pallas-core）。"""
 
-__version__ = "4.1.20"
+__version__ = "4.1.21"

--- a/pallas/console/cli/ai_supervisor.py
+++ b/pallas/console/cli/ai_supervisor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -279,6 +280,24 @@ def run_ctl(ai_root: Path, *args: str, timeout_sec: float = 120.0) -> tuple[int,
     return int(completed.returncode), header + out
 
 
+def poll_ai_runtime_status(
+    *,
+    ai_root: Path,
+    want_running: bool,
+    timeout_sec: float = 30.0,
+    interval_sec: float = 1.0,
+) -> dict[str, Any]:
+    """ctl 返回后进程/探活常滞后；短轮询再返回，避免控制台立刻读到旧状态。"""
+    deadline = time.monotonic() + max(0.0, float(timeout_sec))
+    status = ai_runtime_status(ai_root=ai_root)
+    while bool(status.get("running")) != bool(want_running):
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(max(0.05, float(interval_sec)))
+        status = ai_runtime_status(ai_root=ai_root)
+    return status
+
+
 def start_ai_runtime(*, ai_root: Path | None = None, with_media: bool = True) -> dict[str, Any]:
     """启动媒体服务（media worker + API）。
 
@@ -300,7 +319,8 @@ def start_ai_runtime(*, ai_root: Path | None = None, with_media: bool = True) ->
             }
     if is_managed_ai_root(root):
         mark_ai_root_managed(root)
-    status = ai_runtime_status(ai_root=root)
+    # media 冷启动（尤其 Windows+torch）常需数十秒；此处只短等，前端继续轮询
+    status = poll_ai_runtime_status(ai_root=root, want_running=True, timeout_sec=20.0, interval_sec=1.0)
     return {
         "ok": True,
         "error": None,
@@ -314,7 +334,11 @@ def stop_ai_runtime(*, ai_root: Path | None = None) -> dict[str, Any]:
     if root is None:
         return {"ok": False, "error": "未检测到本地 AI Runtime", "output_tail": ""}
     code, out = run_ctl(root, "stop", "all")
-    status = ai_runtime_status(ai_root=root)
+    status = (
+        poll_ai_runtime_status(ai_root=root, want_running=False, timeout_sec=12.0, interval_sec=0.8)
+        if code == 0
+        else ai_runtime_status(ai_root=root)
+    )
     return {
         "ok": code == 0,
         "error": None if code == 0 else f"ctl stop all 退出码 {code}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pallas-bot"
-version = "4.1.20"
+version = "4.1.21"
 description = "《明日方舟》帕拉斯 Bot"
 authors = [{ name = "MistEO" }]
 maintainers = [

--- a/tests/common/test_ai_supervisor.py
+++ b/tests/common/test_ai_supervisor.py
@@ -154,3 +154,24 @@ def test_start_ai_runtime_calls_ctl(tmp_path, monkeypatch) -> None:
     again = ai_supervisor.start_ai_runtime(ai_root=root, with_media=True)
     assert again["ok"] is True
     assert calls[-2:] == [("start", "media"), ("start", "api")]
+
+
+def test_poll_ai_runtime_status_waits_until_running(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "ai"
+    root.mkdir()
+    hits = {"n": 0}
+
+    def fake_status(**_kwargs):  # noqa: ANN001
+        hits["n"] += 1
+        return {"running": hits["n"] >= 3, "can_manage": True}
+
+    monkeypatch.setattr(ai_supervisor, "ai_runtime_status", fake_status)
+    monkeypatch.setattr(ai_supervisor.time, "sleep", lambda _s: None)
+    st = ai_supervisor.poll_ai_runtime_status(
+        ai_root=root,
+        want_running=True,
+        timeout_sec=5.0,
+        interval_sec=0.1,
+    )
+    assert st["running"] is True
+    assert hits["n"] >= 3


### PR DESCRIPTION
- AI Runtime 启停后短轮询再返回状态
- 透传 speaker_backends；DDSP / 按音色后端文档
- 捆绑控制台 WebUI v0.8.14

## Summary by Sourcery

提升 AI Runtime 启动/停止的可靠性，扩展歌声后端配置，并为 4.1.21 版本更新文档和版本号。

New Features:
- 允许通过传递的 `speaker_backends` 设置为每个声线配置首选歌声后端。

Bug Fixes:
- 通过在启动和停止操作后对状态进行短轮询，减少控制台对 AI Runtime 状态的误报。

Enhancements:
- 记录手动安装多个 DDSP-SVC 版本的步骤，并澄清官方声线的后端与版本映射关系。
- 更新歌唱插件文档，将 DDSP 6.2 作为默认版本，并添加指向多版本 DDSP 安装指南的链接。
- 在本次发行版中捆绑控制台 WebUI v0.8.14。

Documentation:
- 扩展 AI Runtime 维护者文档，加入 DDSP 多版本安装步骤，以及针对不同检查点的后端推荐。

Tests:
- 添加测试，验证 `poll_ai_runtime_status` 会在运行时报告为“running”之前一直等待，然后再返回。

Chores:
- 将核心包和项目版本号提升到 4.1.21。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve AI Runtime start/stop reliability, extend singing backend configuration, and update docs and versioning for the 4.1.21 release.

New Features:
- Allow configuring preferred singing backend per voice via propagated speaker_backends settings.

Bug Fixes:
- Reduce console misreporting of AI Runtime state by short-polling status after start and stop operations.

Enhancements:
- Document manual installation of multiple DDSP-SVC versions and clarify backend-version mapping for official voices.
- Update singing plugin docs to reference DDSP 6.2 as default and link to multi-version DDSP installation guidance.
- Bundle console WebUI v0.8.14 with this release.

Documentation:
- Expand AI Runtime maintainer documentation with DDSP multi-version installation steps and backend recommendations for different checkpoints.

Tests:
- Add tests verifying poll_ai_runtime_status waits until the runtime reports running before returning.

Chores:
- Bump core package and project versions to 4.1.21.

</details>