### PR TITLE
fix(llm): Responses usage 解析 input_tokens_details 缓存命中

### DIFF
--- a/pallas/product/llm/token_usage.py
+++ b/pallas/product/llm/token_usage.py
@@ -12,15 +12,32 @@ def usage_from_local_chat_response(data: dict[str, Any]) -> tuple[int, int, int,
     return max(0, prompt), max(0, completion), 0, 0
 
 
+def _cache_from_token_details(details: object) -> tuple[int, int]:
+    """从 prompt/input_tokens_details 取 cache_read / cache_write。"""
+    if not isinstance(details, dict):
+        return 0, 0
+    cache_read = int(
+        details.get("cached_tokens") or details.get("cache_read_tokens") or details.get("cache_read_input_tokens") or 0
+    )
+    cache_write = int(
+        details.get("cache_creation_tokens")
+        or details.get("cache_write_tokens")
+        or details.get("cache_creation_input_tokens")
+        or 0
+    )
+    return max(0, cache_read), max(0, cache_write)
+
+
 def usage_from_remote_chat_response(data: dict[str, Any]) -> tuple[int, int, int, int]:
     """
-    OpenAI / Anthropic / DeepSeek 兼容 usage。
+    OpenAI / Anthropic / DeepSeek 兼容 usage（含 Chat Completions 与 Responses）。
 
     返回 (prompt, completion, cache_read, cache_write)。
-    若上游给出 cache 拆分，prompt 记非缓存输入（prompt_tokens - cache_read，下限 0）；
-    否则整段 prompt_tokens 记为 prompt，cache=0。
+    若上游给出 cache 拆分，prompt 记非缓存输入；优先 ``prompt_cache_miss_tokens``，
+    否则 ``prompt/input_tokens - cache_read``（下限 0）。
+    无 cache 字段时整段 prompt/input 记为 prompt，cache=0。
 
-    DeepSeek 自动缓存无独立 write，仅 ``prompt_cache_hit_tokens`` → cache_read。
+    DeepSeek Chat：``prompt_cache_hit_tokens``；Responses：``input_tokens_details.cached_tokens``。
     """
     usage = data.get("usage")
     if not isinstance(usage, dict):
@@ -29,12 +46,13 @@ def usage_from_remote_chat_response(data: dict[str, Any]) -> tuple[int, int, int
     prompt_raw = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
     completion = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
 
-    details = usage.get("prompt_tokens_details")
     cache_read = 0
     cache_write = 0
-    if isinstance(details, dict):
-        cache_read = int(details.get("cached_tokens") or details.get("cache_read_tokens") or 0)
-        cache_write = int(details.get("cache_creation_tokens") or details.get("cache_write_tokens") or 0)
+    # Chat Completions: prompt_tokens_details；Responses: input_tokens_details
+    for key in ("prompt_tokens_details", "input_tokens_details"):
+        read, write = _cache_from_token_details(usage.get(key))
+        cache_read = max(cache_read, read)
+        cache_write = max(cache_write, write)
 
     # Anthropic Messages：usage.cache_read_input_tokens / cache_creation_input_tokens
     cache_read = max(
@@ -46,11 +64,14 @@ def usage_from_remote_chat_response(data: dict[str, Any]) -> tuple[int, int, int
         int(usage.get("cache_creation_input_tokens") or usage.get("cache_write_tokens") or 0),
     )
 
-    # DeepSeek / 部分 OpenAI 兼容：prompt_cache_hit_tokens（无独立 write）
+    # DeepSeek / 部分 OpenAI 兼容 Chat：prompt_cache_hit_tokens（无独立 write）
     cache_read = max(cache_read, int(usage.get("prompt_cache_hit_tokens") or 0))
 
     if cache_read > 0 or cache_write > 0:
-        prompt = max(0, prompt_raw - cache_read)
+        if "prompt_cache_miss_tokens" in usage:
+            prompt = max(0, int(usage.get("prompt_cache_miss_tokens") or 0))
+        else:
+            prompt = max(0, prompt_raw - cache_read)
     else:
         prompt = max(0, prompt_raw)
 

--- a/tests/product/llm/test_token_metrics.py
+++ b/tests/product/llm/test_token_metrics.py
@@ -194,6 +194,30 @@ def test_hydrate_from_disk_after_restart(tmp_path, monkeypatch: pytest.MonkeyPat
             },
             (2234, 412, 16000, 0),
         ),
+        # OpenAI / DeepSeek Responses：input_tokens_details.cached_tokens
+        (
+            {
+                "usage": {
+                    "input_tokens": 1296,
+                    "input_tokens_details": {"cached_tokens": 1280},
+                    "output_tokens": 4,
+                    "total_tokens": 1300,
+                }
+            },
+            (16, 4, 1280, 0),
+        ),
+        # miss 字段优先于 prompt_raw - cache_read
+        (
+            {
+                "usage": {
+                    "prompt_tokens": 200,
+                    "completion_tokens": 1,
+                    "prompt_cache_hit_tokens": 100,
+                    "prompt_cache_miss_tokens": 95,
+                }
+            },
+            (95, 1, 100, 0),
+        ),
     ],
 )
 def test_usage_parsers(data: dict, expected: tuple[int, int, int, int]) -> None:


### PR DESCRIPTION
切到 Responses 后 usage 走 `input_tokens_details.cached_tokens`，原先只认 Chat 的 `prompt_tokens_details` / `prompt_cache_hit_tokens`，导致缓存命中整天为 0、费用按全量 miss 虚高。

- 解析 Responses `input_tokens_details`
- 有 `prompt_cache_miss_tokens` 时优先用作非缓存输入
- 补单测

## Summary by Sourcery

调整令牌使用解析方式，以在聊天补全和响应中正确统计缓存命中次数，确保在可能的情况下从提示成本中排除已缓存的输入。

Bug Fixes:
- 通过 `input_tokens_details.cached_tokens` 处理 OpenAI/DeepSeek Responses 的用量，使缓存命中情况反映在令牌统计中。
- 在计算未缓存提示令牌时，优先使用 `prompt_cache_miss_tokens`，而不是用 `prompt_raw` 减去 `cache_read`，以避免成本被重复计算。

Enhancements:
- 引入一个共享辅助函数，从提示/输入令牌详情中抽取缓存读写指标，以适配多种服务商格式。

Tests:
- 扩展令牌指标测试，覆盖 Responses 中 `cached_tokens` 的处理以及 `prompt_cache_miss_tokens` 优先级的相关场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust token usage parsing to properly account for cache hits across Chat Completions and Responses, ensuring prompt costs exclude cached input where possible.

Bug Fixes:
- Handle OpenAI/DeepSeek Responses usage via input_tokens_details.cached_tokens so cache hits are reflected in token accounting.
- Prefer prompt_cache_miss_tokens over prompt_raw minus cache_read when computing non-cached prompt tokens to avoid overcounting costs.

Enhancements:
- Introduce a shared helper to extract cache read/write metrics from prompt/input token details for multiple provider formats.

Tests:
- Extend token metrics tests to cover Responses cached_tokens handling and prompt_cache_miss_tokens precedence.

</details>