### PR TITLE
fix(federate): 本机无命令能力时让出联邦抢占

### DIFF
--- a/pallas/core/platform/federate/peer_bots.py
+++ b/pallas/core/platform/federate/peer_bots.py
@@ -439,6 +439,45 @@ def should_process_federate_group_on_current_deployment(
     return federate_group_owner_deployment(group_id, plain=plain) == deployment_id
 
 
+def should_yield_federate_ingress_for_peer_command(
+    group_id: int,
+    *,
+    plain: str | None = None,
+) -> bool:
+    """本机无能力、但对端显式宣告能覆盖且在本群在场时，不参与联邦抢占。
+
+    典型坑：对端装了决斗、本机没有 → 本机 ``legacy_command_traffic`` 为假，
+    会绕过命令归属直接去抢 ``federate_ingress``，抢走后无 matcher，有能力的端又输掉 claim。
+    """
+    if not federate_ingress_active():
+        return False
+    if not _cache_deployment_ids:
+        return False
+    text = (plain or "").strip()
+    if not text:
+        return False
+    local_caps = collect_local_federate_command_capabilities()
+    if command_capability_covers_plaintext(local_caps, text):
+        return False
+    mine = load_or_create_deployment_id().strip().lower()
+    if not mine:
+        return False
+    for dep in _cache_deployment_ids:
+        if dep == mine:
+            continue
+        if dep not in _cache_deployment_capabilities:
+            continue
+        caps = _cache_deployment_capabilities.get(dep)
+        if caps is None:
+            continue
+        if not command_capability_covers_plaintext(caps, text):
+            continue
+        if not _deployment_present_in_group(dep, int(group_id), mine=mine):
+            continue
+        return True
+    return False
+
+
 async def sync_federate_peer_bot_roster() -> None:
     global _cache_ids, _cache_deployment_present_groups, _cache_updated_mono
     if not federate_ingress_active():

--- a/pallas/core/platform/ingress/gate.py
+++ b/pallas/core/platform/ingress/gate.py
@@ -13,6 +13,7 @@ from pallas.core.platform.federate.ingress import claim_federate_group_message_i
 from pallas.core.platform.federate.peer_bots import (
     federate_peer_bot_ids_contains,
     should_process_federate_group_on_current_deployment,
+    should_yield_federate_ingress_for_peer_command,
     start_federate_peer_bot_sync_loop,
     sync_federate_peer_bot_roster,
     touch_federate_present_group,
@@ -132,6 +133,13 @@ async def ingress_group_message_gate(bot, event) -> None:
 
         # 收到本群消息即记在场，供命令归属只在「本群有号」的部署间取模。
         touch_federate_present_group(int(event.group_id))
+
+        # 本机无能力、对端显式有：即使本地不认作命令，也不得抢 federate claim。
+        if should_yield_federate_ingress_for_peer_command(int(event.group_id), plain=plain):
+            outcome = "federate_peer_command_yield"
+            if metrics:
+                record_ingress_early_discard("federate")
+            raise IgnoredException("federate peer command capability")
 
         # 仅命令走粘性群归属；闲聊 / @LLM 等 chat 车道只靠 claim，避免热群钉死一台。
         if legacy_command_traffic(plain) and not should_process_federate_group_on_current_deployment(

--- a/tests/common/federate/test_peer_bots.py
+++ b/tests/common/federate/test_peer_bots.py
@@ -205,6 +205,49 @@ def test_prefer_local_owner_does_not_steal_incapable_commands(monkeypatch):
     assert mod.should_process_federate_group_on_current_deployment(733291779, plain="牛牛塔罗牌") is False
 
 
+def test_yield_federate_when_peer_covers_command_local_does_not(monkeypatch):
+    """本机无决斗等能力、对端显式有时，即使本机不认作命令也不得参与抢占。"""
+    mod.clear_federate_peer_bot_cache_for_tests()
+    monkeypatch.setattr(mod, "load_or_create_deployment_id", lambda: "dep-local")
+    monkeypatch.setattr(mod, "federate_ingress_active", lambda: True)
+    monkeypatch.setattr(
+        mod,
+        "collect_local_federate_command_capabilities",
+        lambda: frozenset({"牛牛帮助"}),
+    )
+    mod._cache_deployment_ids = frozenset({"dep-peer"})
+    mod._cache_deployment_capabilities = {
+        "dep-peer": frozenset({"牛牛决斗", "八角笼牛"}),
+    }
+    mod._cache_deployment_present_groups = {
+        "dep-peer": frozenset({1076683542}),
+    }
+
+    assert mod.should_yield_federate_ingress_for_peer_command(1076683542, plain="牛牛决斗") is True
+    assert mod.should_yield_federate_ingress_for_peer_command(1076683542, plain="牛牛帮助") is False
+    assert mod.should_yield_federate_ingress_for_peer_command(1076683542, plain="今天吃什么") is False
+
+
+def test_yield_federate_skips_when_capable_peer_not_present_in_group(monkeypatch):
+    mod.clear_federate_peer_bot_cache_for_tests()
+    monkeypatch.setattr(mod, "load_or_create_deployment_id", lambda: "dep-local")
+    monkeypatch.setattr(mod, "federate_ingress_active", lambda: True)
+    monkeypatch.setattr(
+        mod,
+        "collect_local_federate_command_capabilities",
+        lambda: frozenset({"牛牛帮助"}),
+    )
+    mod._cache_deployment_ids = frozenset({"dep-peer"})
+    mod._cache_deployment_capabilities = {
+        "dep-peer": frozenset({"牛牛决斗"}),
+    }
+    mod._cache_deployment_present_groups = {
+        "dep-peer": frozenset({999}),
+    }
+
+    assert mod.should_yield_federate_ingress_for_peer_command(1076683542, plain="牛牛决斗") is False
+
+
 def test_owner_ring_excludes_peer_not_present_in_group(monkeypatch):
     """对端宣告了在场群且不含本群时，不参与命令归属（避免空应答）。"""
     mod.clear_federate_peer_bot_cache_for_tests()

--- a/tests/common/test_ingress_gate_unified.py
+++ b/tests/common/test_ingress_gate_unified.py
@@ -248,6 +248,50 @@ async def test_unified_ingress_non_owner_deployment_skips_command_once_and_feder
 
 
 @pytest.mark.asyncio
+async def test_unified_ingress_yields_peer_covered_command_even_if_not_local_command_traffic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """本机未装决斗插件时不认「牛牛决斗」为本地命令，但仍须让给有能力的对端，不得抢 federate claim。"""
+    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.should_yield_federate_ingress_for_peer_command",
+        lambda _group_id, **_kw: True,
+    )
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_fanout_bypasses_claim", lambda _plain: False)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.legacy_command_traffic", lambda _plain: False)
+    federate = AsyncMock(return_value=True)
+    once = AsyncMock(return_value=True)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.claim_federate_group_message_ingress", federate)
+    monkeypatch.setattr("pallas.core.platform.ingress.claim_gate.try_claim_group_message_once", once)
+    from pallas.core.platform.ingress.gate import ingress_group_message_gate
+
+    class FakeBot:
+        def __init__(self, self_id: int):
+            self.self_id = str(self_id)
+
+    event = GroupMessageEvent.model_construct(
+        time=100,
+        self_id=111,
+        post_type="message",
+        message_type="group",
+        sub_type="normal",
+        user_id=999,
+        group_id=1076683542,
+        message_id=1,
+        message=Message("牛牛决斗"),
+        raw_message="牛牛决斗",
+    )
+
+    with pytest.raises(IgnoredException):
+        await ingress_group_message_gate(FakeBot(111), event)
+    once.assert_not_awaited()
+    federate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_unified_ingress_non_owner_still_claims_chat_traffic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 背景
群内联邦协同时，未装决斗等插件的对端不认「牛牛决斗」为本地命令，会绕过能力环直接抢 `federate_ingress`；抢走后无 matcher，有能力的端又输掉 claim，表现为命令静默。

## 改动
- 新增 `should_yield_federate_ingress_for_peer_command`：本机覆盖不了、对端显式有且在场 → 直接让出
- 入站门控在 claim 前调用
- 补充单测

## 验证
`uv run pytest tests/common/federate/test_peer_bots.py tests/common/test_ingress_gate_unified.py -q`

## Summary by Sourcery

在同一组中存在具备相关命令能力的同伴部署时，阻止不具备该命令能力的本地部署与其争夺联邦入口（federated ingress）。

Bug Fixes:
- 确保当同伴部署显式覆盖某个命令时，即使本地部署不将该命令识别为本地命令，也会将联邦入口让渡给同伴部署，从而避免静默的命令处理失败。

Enhancements:
- 添加同伴能力感知的入口管控逻辑：当非所有者部署缺少某个命令能力，但目标组中存在具备该能力的同伴时，跳过联邦占用（federate claim）。

Tests:
- 扩展联邦同伴机器人测试，用于覆盖基于同伴命令能力和组内存在情况的入口让渡行为。
- 添加统一入口管控测试，以验证在本地部署缺少相应命令能力时，由同伴覆盖的命令会在早期被丢弃，而不是尝试进行联邦占用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent local deployments without a given command capability from competing for federated ingress when a capable peer is present in the group.

Bug Fixes:
- Ensure federated ingress is yielded to peer deployments that explicitly cover a command even when the local deployment does not recognize it as a local command, avoiding silent command handling failures.

Enhancements:
- Add peer capability-aware ingress gating logic that skips federate claim when a non-owner deployment lacks the command capability but a capable peer is present in the target group.

Tests:
- Extend federate peer bot tests to cover yielding behavior based on peer command capabilities and group presence.
- Add unified ingress gate tests to verify that peer-covered commands are discarded early instead of attempting federate claim when the local deployment lacks the corresponding capability.

</details>