### PR TITLE
fix(help): 功能详情正文按段换行

### DIFF
--- a/packages/help/draw_function_detail.py
+++ b/packages/help/draw_function_detail.py
@@ -15,10 +15,37 @@ from .help_draw_assets import draw_page_footer_bar, draw_page_header_band, draw_
 from .help_draw_common import new_canvas, strip_help_markdown, truncate_pixels
 from .plugin_visuals import help_font
 
+_DOC_BODY_WRAP = 52
+
 
 def _chip_width(draw: ImageDraw.ImageDraw, text: str, font) -> int:
     bbox = draw.textbbox((0, 0), text, font=font)
     return (bbox[2] - bbox[0]) + 20
+
+
+def wrap_doc_body_lines(content: str, *, width: int = _DOC_BODY_WRAP) -> list[str]:
+    """按空行分段 soft-wrap；保留段结构，避免把「可用音色」等另起段糊回一段。"""
+    lines: list[str] = []
+    for block in (content or "").split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        stripped = [ln.strip() for ln in block.splitlines() if ln.strip()]
+        if stripped and all(ln.startswith(("·", "•", "- ", "* ")) for ln in stripped):
+            lines.extend(stripped)
+            continue
+        for ln in stripped:
+            if ln.startswith(("·", "•", "- ", "* ")):
+                lines.append(ln)
+                continue
+            wrapped = textwrap.wrap(
+                ln,
+                width=max(12, width),
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+            lines.extend(wrapped or [ln])
+    return lines or ["暂无"]
 
 
 def _layout_height(data: FunctionDetailData) -> int:
@@ -34,11 +61,11 @@ def _layout_height(data: FunctionDetailData) -> int:
         body += 28
     if data.detail:
         content = strip_help_markdown((data.detail or "").strip() or "暂无")
-        lines = [ln for ln in textwrap.fill(content, width=52).splitlines() if ln.strip()] or ["暂无"]
+        lines = wrap_doc_body_lines(content)
         body += 30 + 28 + len(lines) * 26 + 16
     for _title, content in data.extra_sections:
         text = strip_help_markdown((content or "").strip() or "暂无")
-        lines = [ln for ln in textwrap.fill(text, width=52).splitlines() if ln.strip()] or ["暂无"]
+        lines = wrap_doc_body_lines(text)
         body += 30 + 28 + len(lines) * 26 + 16
     return body + ht.PAGE_FOOTER_H + ht.PAGE_CHROME_GAP + ht.DETAIL_PAD * 2
 
@@ -152,8 +179,7 @@ def _draw_doc_section(hc, *, x: int, y: int, max_x: int, title: str, body: str) 
     draw.text((x, y), title, fill=ht.TEXT_TITLE, font=help_font(20))
     cursor = y + u(30)
     content = strip_help_markdown((body or "").strip() or "暂无")
-    wrapped = textwrap.fill(content, width=52)
-    lines = [ln for ln in wrapped.splitlines() if ln.strip()] or ["暂无"]
+    lines = wrap_doc_body_lines(content)
     line_h = u(26)
     box_pad = u(14)
     box_h = box_pad * 2 + len(lines) * line_h

--- a/tests/plugins/help/test_draw_plugin_detail.py
+++ b/tests/plugins/help/test_draw_plugin_detail.py
@@ -1,8 +1,15 @@
 from types import SimpleNamespace
 
-from packages.help.draw_function_detail import draw_function_detail_image
+from packages.help.draw_function_detail import draw_function_detail_image, wrap_doc_body_lines
 from packages.help.draw_plugin_detail import draw_plugin_detail_image
 from packages.help.plugin_detail_data import FunctionDetailData, HelpFunctionRow, PluginDetailData
+
+
+def test_wrap_doc_body_lines_keeps_paragraph_breaks() -> None:
+    lines = wrap_doc_body_lines("继续上次未完成的歌曲。\n\n可用音色：牛牛、帕拉斯；兔兔。")
+    assert lines[0] == "继续上次未完成的歌曲。"
+    assert any(ln.startswith("可用音色：") for ln in lines)
+    assert "pallas" not in "\n".join(lines)
 
 
 def test_draw_plugin_detail_image() -> None:


### PR DESCRIPTION
帮助功能详情图按空行分段 soft-wrap，避免「可用音色」等另起段被压成一团；配合 ai-media v4.3.5 帮助文案。

## Summary by Sourcery

改进帮助函数详细文本的换行方式，以尊重段落分隔，并将新逻辑集成到布局和渲染中。

New Features:
- 为帮助文档正文引入具备段落感知能力的软换行机制，包括对项目符号列表的特殊处理。

Enhancements:
- 在函数详情和额外帮助部分应用新的换行逻辑，以在更新后的帮助文案下保持视觉布局的一致性。

Tests:
- 添加测试以验证帮助文档的换行能够保留段落分隔，并且不会破坏特定内容，例如可用的语音名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve wrapping of help function detail text to respect paragraph breaks and integrate the new logic into layout and rendering.

New Features:
- Introduce paragraph-aware soft-wrapping for help documentation body text, including special handling for bullet lists.

Enhancements:
- Apply the new wrapping logic in function detail and extra help sections to keep visual layout consistent with updated help copy.

Tests:
- Add tests to verify that help documentation wrapping preserves paragraph breaks and does not mangle specific content such as available voice names.

</details>