### PR TITLE
fix(ingress): 主持活动优先处理决斗 QTE 别名

### DIFF
--- a/pallas/core/platform/ingress/gate.py
+++ b/pallas/core/platform/ingress/gate.py
@@ -26,7 +26,10 @@ from pallas.core.platform.ingress.claim_gate import (
 from pallas.core.platform.ingress.dream_host_gate import dream_session_ingress_passes
 from pallas.core.platform.ingress.fanout_bypass import ingress_fanout_bypasses_claim
 from pallas.core.platform.ingress.fast_path import ingress_once_claim_safe_before_host_gates
-from pallas.core.platform.ingress.hosted_activity_gate import hosted_activity_ingress_passes
+from pallas.core.platform.ingress.hosted_activity_gate import (
+    hosted_activity_claim_is_hosted,
+    hosted_activity_ingress_passes,
+)
 from pallas.core.platform.ingress.matcher_activation import legacy_command_traffic
 from pallas.core.platform.ingress.notice_gate import ingress_notice_gate
 from pallas.core.platform.multi_bot.at_targets import group_at_qq_ids, message_at_fleet_bot
@@ -160,19 +163,24 @@ async def ingress_group_message_gate(bot, event) -> None:
                 record_ingress_early_discard("not_at_target")
             raise IgnoredException("not at-target bot")
 
-        from pallas.core.platform.ingress.alias_route import should_yield_ingress_for_peer_alias
-
-        if should_yield_ingress_for_peer_alias(self_id=self_id, plain_text=plain):
-            outcome = "peer_alias_yield"
-            if metrics:
-                record_ingress_early_discard("peer_alias")
-            raise IgnoredException("peer alias target")
-
         safe_before_host_gates = ingress_once_claim_safe_before_host_gates(
             int(event.group_id),
             plain,
             at_fleet_bot=at_fleet,
         )
+
+        from pallas.core.platform.ingress.alias_route import should_yield_ingress_for_peer_alias
+
+        alias_target_is_hosted = hosted_activity_claim_is_hosted(
+            int(event.group_id),
+            plain,
+            at_fleet_bot=at_fleet,
+        )
+        if not alias_target_is_hosted and should_yield_ingress_for_peer_alias(self_id=self_id, plain_text=plain):
+            outcome = "peer_alias_yield"
+            if metrics:
+                record_ingress_early_discard("peer_alias")
+            raise IgnoredException("peer alias target")
         if safe_before_host_gates:
             try:
                 for mark in await run_ingress_message_claim(

--- a/pallas/core/platform/ingress/hosted_activity_gate.py
+++ b/pallas/core/platform/ingress/hosted_activity_gate.py
@@ -10,7 +10,10 @@ from nonebot import get_loaded_plugins
 from pallas.core.foundation.command_prefix import matches_command_prefix
 from pallas.core.platform.ingress.plugin_command_plaintext import extract_command_prefixes_from_menu_data
 from pallas.core.platform.multi_bot.dedup import needs_group_host_bot_gate
-from pallas.core.platform.shard.coord.group_gate import is_owned_gate_holder_sync
+from pallas.core.platform.shard.coord.group_gate import (
+    is_owned_gate_holder_sync,
+    read_owned_gate_bot_id_sync,
+)
 from pallas.core.platform.shard.coord.hosted_activity_coord import coord_session_active, hosted_activity_live
 
 _SPECS_CACHE: tuple[HostedActivityIngressSpec, ...] | None = None
@@ -112,7 +115,9 @@ def spec_matches_speak_traffic(
     text = (plain or "").strip()
     if _matches_prefix(text, spec.command_prefixes):
         return False
-    if not coord_session_active(spec.activity_namespace, group_id, session_flag=spec.session_flag):
+    session_active = coord_session_active(spec.activity_namespace, group_id, session_flag=spec.session_flag)
+    owner_active = read_owned_gate_bot_id_sync(spec.plugin_key, int(group_id)) is not None
+    if not session_active and not owner_active:
         return False
     if spec.speak_at_fleet_bot_only:
         return at_fleet_bot
@@ -146,6 +151,30 @@ def spec_host_gate_passes(
         return True
 
     return is_owned_gate_holder_sync(spec.plugin_key, int(group_id), int(bot_id))
+
+
+def hosted_activity_claim_is_hosted(
+    group_id: int,
+    plain: str,
+    *,
+    at_fleet_bot: bool = False,
+) -> bool:
+    """当前消息是否属于一场存活的主持活动。"""
+    gid = int(group_id)
+    text = (plain or "").strip()
+    for spec in loaded_hosted_activity_specs():
+        in_room = spec_matches_in_room_command(spec, plain)
+        speak = spec_matches_speak_traffic(spec, gid, plain, at_fleet_bot=at_fleet_bot)
+        open_or_end = _matches_prefix(text, spec.always_pass_prefixes)
+        if not in_room and not speak and not open_or_end:
+            continue
+        if hosted_activity_live(
+            activity_namespace=spec.activity_namespace,
+            plugin_key=spec.plugin_key,
+            group_id=gid,
+        ):
+            return True
+    return False
 
 
 def hosted_activity_ingress_passes(

--- a/tests/platform/ingress/test_fast_path.py
+++ b/tests/platform/ingress/test_fast_path.py
@@ -104,3 +104,58 @@ async def test_unified_ingress_early_once_claim_before_host_checks(monkeypatch: 
         await ingress_group_message_gate(FakeBot(222), event)
     hosted.assert_not_called()
     dream.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hosted_activity_owner_precedes_peer_alias_yield(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.shard_ctx.sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_fanout_bypasses_claim", lambda _plain: False)
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.ingress_once_claim_safe_before_host_gates",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.should_process_federate_group_on_current_deployment",
+        lambda _gid, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.alias_route.should_yield_ingress_for_peer_alias",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.hosted_activity_claim_is_hosted",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.hosted_activity_ingress_passes",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.dream_session_ingress_passes", AsyncMock(return_value=True))
+    monkeypatch.setattr("pallas.core.platform.ingress.gate.run_ingress_message_claim", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.gate.claim_federate_group_message_ingress",
+        AsyncMock(return_value=True),
+    )
+
+    from pallas.core.platform.ingress.gate import ingress_group_message_gate
+
+    class FakeBot:
+        self_id = "111"
+
+    event = GroupMessageEvent.model_construct(
+        time=100,
+        self_id=111,
+        post_type="message",
+        message_type="group",
+        sub_type="normal",
+        user_id=999,
+        group_id=733291779,
+        message_id=1,
+        message=Message("帕拉斯"),
+        raw_message="帕拉斯",
+    )
+
+    await ingress_group_message_gate(FakeBot(), event)

--- a/tests/platform/ingress/test_hosted_activity_gate.py
+++ b/tests/platform/ingress/test_hosted_activity_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pallas.core.platform.ingress.hosted_activity_gate import (
     HostedActivityIngressSpec,
+    hosted_activity_claim_is_hosted,
     hosted_activity_ingress_passes,
     spec_host_gate_passes,
     spec_matches_in_room_command,
@@ -44,6 +45,23 @@ def test_hosted_ingress_passes_when_no_host_gate(monkeypatch) -> None:
         lambda: False,
     )
     assert hosted_activity_ingress_passes(1, 100, "牛牛加入") is True
+
+
+def test_hosted_activity_claim_detects_live_plaintext_traffic(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.loaded_hosted_activity_specs",
+        lambda: (SPY_SPEC,),
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.hosted_activity_live",
+        lambda **_k: True,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.coord_session_active",
+        lambda _ns, _gid, **_kwargs: True,
+    )
+    assert hosted_activity_claim_is_hosted(100, "帕拉斯", at_fleet_bot=True) is True
+    assert hosted_activity_claim_is_hosted(100, "帕拉斯", at_fleet_bot=False) is False
 
 
 def test_hosted_ingress_open_end_pass_without_room(monkeypatch) -> None:
@@ -125,10 +143,26 @@ def test_hosted_ingress_no_room_passes_join(monkeypatch) -> None:
     assert spec_host_gate_passes(SPY_SPEC, 99, 100, "牛牛加入", at_fleet_bot=False) is True
 
 
+def test_spec_speak_traffic_accepts_owned_gate_without_session_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.coord_session_active",
+        lambda _ns, _gid, **_: False,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.read_owned_gate_bot_id_sync",
+        lambda _plugin, _gid: 42,
+    )
+    assert spec_matches_speak_traffic(SPY_SPEC, 7, "帕拉斯", at_fleet_bot=True) is True
+
+
 def test_spec_speak_traffic_at_bot_only(monkeypatch) -> None:
     monkeypatch.setattr(
         "pallas.core.platform.ingress.hosted_activity_gate.coord_session_active",
         lambda ns, gid, **_: gid == 7,
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hosted_activity_gate.read_owned_gate_bot_id_sync",
+        lambda _plugin, _gid: None,
     )
     assert spec_matches_speak_traffic(SPY_SPEC, 7, "随便说说", at_fleet_bot=True) is True
     assert spec_matches_speak_traffic(SPY_SPEC, 7, "随便说说", at_fleet_bot=False) is False


### PR DESCRIPTION
活跃主持活动优先于牛牛别名分流，避免决斗 QTE 答案被提前丢弃。

补充主持活动和「帕拉斯」答案回归测试。

## Summary by Sourcery

在入口组消息处理过程中，优先处理托管活动（hosted activity），而不是让出给对等别名（peer alias）路由，以避免过早丢弃决斗 QTE 流量，并扩展托管活动测试以覆盖 Pallas 流量和具备所有权感知的门控逻辑。

Bug Fixes（错误修复）:
- 确保当目标消息属于正在运行的托管活动时，组消息入口不会让出给对等别名路由。

Enhancements（增强）:
- 新增 `hosted_activity_claim_is_hosted` 辅助方法，用于在别名路由之前检测正在运行的托管活动流量，并将其集成到入口门控中。
- 当某个群组拥有一个“owned gate bot”时，即使没有激活会话标志，也允许匹配托管活动的 speak 流量，通过同步查询“owned gate”持有者实现。

Tests（测试）:
- 新增入口快速路径测试，以验证在 Pallas 消息中，托管活动所有者优先于对等别名让出的行为。
- 扩展托管活动门控测试，以覆盖 `hosted_activity_claim_is_hosted` 的行为，以及在有/无 owned gate 持有者情况下的 speak 流量匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize hosted activity handling over peer alias yielding in ingress group message processing to avoid prematurely discarding duel QTE traffic, and extend hosted activity tests to cover Pallas traffic and ownership-aware gating.

Bug Fixes:
- Ensure group message ingress does not yield to peer alias routing when the target message belongs to a live hosted activity.

Enhancements:
- Add hosted_activity_claim_is_hosted helper to detect live hosted activity traffic before alias routing and integrate it into the ingress gate.
- Allow hosted activity speak-traffic matching when a group has an owned gate bot even without an active session flag by consulting the owned gate holder synchronously.

Tests:
- Add ingress fast-path test to verify hosted activity owner precedence over peer alias yielding for Pallas messages.
- Extend hosted activity gate tests to cover hosted_activity_claim_is_hosted behavior and speak-traffic matching with and without owned gate holders.

</details>