### PR TITLE
fix(federate): 缓存联邦账号昵称回退

### DIFF
--- a/pallas/core/platform/federate/peer_bots.py
+++ b/pallas/core/platform/federate/peer_bots.py
@@ -38,6 +38,7 @@ _PRESENT_GROUP_WINDOW_SEC = max(_PUBLISH_TTL_SEC, int(os.getenv("PALLAS_FEDERATE
 _PRESENT_GROUP_PUBLISH_CAP = max(64, int(os.getenv("PALLAS_FEDERATE_PRESENT_GROUP_PUBLISH_CAP", "2000")))
 _NICKNAME_CACHE_TTL_SEC = max(60.0, float(os.getenv("PALLAS_FEDERATE_NICKNAME_CACHE_SEC", "600")))
 _NICKNAME_FAILURE_CACHE_TTL_SEC = max(15.0, min(_NICKNAME_CACHE_TTL_SEC, 60.0))
+_NICKNAME_CACHE_MAX_SIZE = max(1, int(os.getenv("PALLAS_FEDERATE_NICKNAME_CACHE_MAX_SIZE", "1024")))
 _NICKNAME_QUERY_CONCURRENCY = 4
 _NICKNAME_QUERY_TIMEOUT_SEC = 2.0
 _cache_ids: frozenset[int] = frozenset()
@@ -202,6 +203,18 @@ def collect_local_federate_public_online_bot_names(
     return {qq: name for qq in visible_ids if (name := str(display_names.get(str(qq)) or "").strip())}
 
 
+def _prune_local_public_online_nickname_cache(now: float) -> None:
+    expired = [qq for qq, (expires_at, _) in _local_public_online_nickname_cache.items() if expires_at <= now]
+    for qq in expired:
+        _local_public_online_nickname_cache.pop(qq, None)
+    overflow = len(_local_public_online_nickname_cache) - _NICKNAME_CACHE_MAX_SIZE
+    if overflow <= 0:
+        return
+    oldest = sorted(_local_public_online_nickname_cache, key=lambda qq: _local_public_online_nickname_cache[qq][0])
+    for qq in oldest[:overflow]:
+        _local_public_online_nickname_cache.pop(qq, None)
+
+
 async def collect_local_federate_public_online_bot_names_async(
     online_bot_ids: frozenset[int],
     public_bot_ids: frozenset[int],
@@ -209,6 +222,7 @@ async def collect_local_federate_public_online_bot_names_async(
     names = collect_local_federate_public_online_bot_names(online_bot_ids, public_bot_ids)
     visible_ids = online_bot_ids & public_bot_ids
     now = time.monotonic()
+    _prune_local_public_online_nickname_cache(now)
     pending: list[int] = []
     for qq in visible_ids:
         if qq in names:
@@ -242,6 +256,7 @@ async def collect_local_federate_public_online_bot_names_async(
         _local_public_online_nickname_cache[qq] = (time.monotonic() + ttl, nickname)
         if nickname:
             names[qq] = nickname
+    _prune_local_public_online_nickname_cache(time.monotonic())
     return names
 
 

--- a/pallas/core/platform/federate/peer_bots.py
+++ b/pallas/core/platform/federate/peer_bots.py
@@ -36,6 +36,10 @@ _PUBLISH_TTL_SEC = max(60, int(os.getenv("PALLAS_FEDERATE_PEER_BOT_TTL_SEC", "18
 _REFRESH_INTERVAL_SEC = max(15.0, float(os.getenv("PALLAS_FEDERATE_PEER_BOT_REFRESH_SEC", "60")))
 _PRESENT_GROUP_WINDOW_SEC = max(_PUBLISH_TTL_SEC, int(os.getenv("PALLAS_FEDERATE_PRESENT_GROUP_WINDOW_SEC", "300")))
 _PRESENT_GROUP_PUBLISH_CAP = max(64, int(os.getenv("PALLAS_FEDERATE_PRESENT_GROUP_PUBLISH_CAP", "2000")))
+_NICKNAME_CACHE_TTL_SEC = max(60.0, float(os.getenv("PALLAS_FEDERATE_NICKNAME_CACHE_SEC", "600")))
+_NICKNAME_FAILURE_CACHE_TTL_SEC = max(15.0, min(_NICKNAME_CACHE_TTL_SEC, 60.0))
+_NICKNAME_QUERY_CONCURRENCY = 4
+_NICKNAME_QUERY_TIMEOUT_SEC = 2.0
 _cache_ids: frozenset[int] = frozenset()
 _cache_deployment_ids: frozenset[str] = frozenset()
 # None = 对端未宣告（旧版），视为全能；frozenset = 明确能力集
@@ -49,6 +53,7 @@ _cache_deployment_present_groups: dict[str, frozenset[int] | None] = {}
 _cache_deployment_rosters: dict[str, FederatePeerBotRoster] = {}
 _cache_local_roster: FederatePeerBotRoster | None = None
 _local_present_groups: dict[int, float] = {}
+_local_public_online_nickname_cache: dict[int, tuple[float, str]] = {}
 _cache_updated_mono: float = 0.0
 _sync_task: asyncio.Task[None] | None = None
 _last_incompatible_capability_peers: tuple[str, ...] = ()
@@ -77,6 +82,7 @@ def clear_federate_peer_bot_cache_for_tests() -> None:
         _cache_deployment_rosters, \
         _cache_local_roster, \
         _cache_ids, \
+        _local_public_online_nickname_cache, \
         _cache_updated_mono, \
         _local_present_groups, \
         _sync_task, \
@@ -92,6 +98,7 @@ def clear_federate_peer_bot_cache_for_tests() -> None:
     _cache_deployment_rosters = {}
     _cache_local_roster = None
     _local_present_groups = {}
+    _local_public_online_nickname_cache = {}
     _cache_updated_mono = 0.0
     _sync_task = None
     _last_incompatible_capability_peers = ()
@@ -193,6 +200,49 @@ def collect_local_federate_public_online_bot_names(
         return {}
     visible_ids = online_bot_ids & public_bot_ids
     return {qq: name for qq in visible_ids if (name := str(display_names.get(str(qq)) or "").strip())}
+
+
+async def collect_local_federate_public_online_bot_names_async(
+    online_bot_ids: frozenset[int],
+    public_bot_ids: frozenset[int],
+) -> dict[int, str]:
+    names = collect_local_federate_public_online_bot_names(online_bot_ids, public_bot_ids)
+    visible_ids = online_bot_ids & public_bot_ids
+    now = time.monotonic()
+    pending: list[int] = []
+    for qq in visible_ids:
+        if qq in names:
+            continue
+        cached = _local_public_online_nickname_cache.get(qq)
+        if cached is not None and cached[0] > now:
+            if cached[1]:
+                names[qq] = cached[1]
+            continue
+        pending.append(qq)
+    if not pending:
+        return names
+
+    from pallas.product.persona.self_identity import resolve_login_nickname
+
+    sem = asyncio.Semaphore(_NICKNAME_QUERY_CONCURRENCY)
+
+    async def resolve_one(qq: int) -> tuple[int, str]:
+        async with sem:
+            try:
+                nickname = await asyncio.wait_for(
+                    resolve_login_nickname(qq),
+                    timeout=_NICKNAME_QUERY_TIMEOUT_SEC,
+                )
+            except Exception:
+                nickname = ""
+            return qq, str(nickname or "").strip()
+
+    for qq, nickname in await asyncio.gather(*(resolve_one(qq) for qq in pending)):
+        ttl = _NICKNAME_CACHE_TTL_SEC if nickname else _NICKNAME_FAILURE_CACHE_TTL_SEC
+        _local_public_online_nickname_cache[qq] = (time.monotonic() + ttl, nickname)
+        if nickname:
+            names[qq] = nickname
+    return names
 
 
 def command_capability_covers_plaintext(capabilities: frozenset[str] | None, plain: str) -> bool:
@@ -587,16 +637,22 @@ def get_federate_peer_bot_rosters() -> tuple[FederatePeerBotRoster, ...]:
     return tuple(_cache_deployment_rosters[key] for key in sorted(_cache_deployment_rosters))
 
 
-async def _build_local_federate_bot_roster() -> FederatePeerBotRoster:
+async def _build_local_federate_bot_roster(*, resolve_login_nicknames: bool = True) -> FederatePeerBotRoster:
     deployment_id = load_or_create_deployment_id().strip().lower()
     bot_ids = get_catalog_bot_ids()
     public_bot_ids = await collect_local_federate_public_bot_ids(bot_ids)
     online_bot_ids = collect_local_federate_online_bot_ids() & bot_ids
     visible_online_ids = online_bot_ids & public_bot_ids & bot_ids
-    public_online_bot_names = collect_local_federate_public_online_bot_names(
-        online_bot_ids,
-        public_bot_ids & bot_ids,
-    )
+    if resolve_login_nicknames:
+        public_online_bot_names = await collect_local_federate_public_online_bot_names_async(
+            online_bot_ids,
+            public_bot_ids & bot_ids,
+        )
+    else:
+        public_online_bot_names = collect_local_federate_public_online_bot_names(
+            online_bot_ids,
+            public_bot_ids & bot_ids,
+        )
     return FederatePeerBotRoster(
         deployment_id=deployment_id,
         deployment_name=local_federate_deployment_name() or f"部署 {deployment_id or '本机'}",
@@ -610,7 +666,7 @@ async def _build_local_federate_bot_roster() -> FederatePeerBotRoster:
 async def get_federate_bot_rosters() -> tuple[FederatePeerBotRoster, ...]:
     global _cache_local_roster
     if _cache_local_roster is None:
-        _cache_local_roster = await _build_local_federate_bot_roster()
+        _cache_local_roster = await _build_local_federate_bot_roster(resolve_login_nicknames=False)
     return (_cache_local_roster, *get_federate_peer_bot_rosters())
 
 
@@ -793,7 +849,7 @@ async def sync_federate_peer_bot_roster() -> None:
         _cache_deployment_rosters = {}
         _cache_updated_mono = time.monotonic()
         return
-    local_roster = await _build_local_federate_bot_roster()
+    local_roster = await _build_local_federate_bot_roster(resolve_login_nicknames=True)
     _cache_local_roster = local_roster
     await asyncio.to_thread(
         publish_local_federate_peer_bot_ids_sync,

--- a/tests/common/federate/test_peer_bots.py
+++ b/tests/common/federate/test_peer_bots.py
@@ -196,6 +196,24 @@ def test_federate_roster_read_does_not_trigger_login_nickname_lookup(monkeypatch
     resolver.assert_not_awaited()
 
 
+def test_prune_local_public_online_nickname_cache_removes_expired_and_oldest(monkeypatch):
+    mod.clear_federate_peer_bot_cache_for_tests()
+    monkeypatch.setattr(mod, "_NICKNAME_CACHE_MAX_SIZE", 2)
+    mod._local_public_online_nickname_cache.update({
+        10001: (99.0, "过期牛"),
+        10002: (101.0, "旧牛"),
+        10003: (102.0, "新牛一"),
+        10004: (103.0, "新牛二"),
+    })
+
+    mod._prune_local_public_online_nickname_cache(100.0)
+
+    assert mod._local_public_online_nickname_cache == {
+        10003: (102.0, "新牛一"),
+        10004: (103.0, "新牛二"),
+    }
+
+
 def test_refresh_federate_peer_bot_ids_sync_reads_other_deployments(monkeypatch):
     client = MagicMock()
     client.scan_iter.return_value = iter([

--- a/tests/common/federate/test_peer_bots.py
+++ b/tests/common/federate/test_peer_bots.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from pallas.core.platform.federate import peer_bots as mod
 
@@ -135,6 +135,65 @@ def test_federate_bot_rosters_include_local_deployment(monkeypatch):
             public_online_bot_names={},
         ),
     )
+
+
+def test_local_roster_uses_login_nickname_when_protocol_display_name_missing(monkeypatch):
+    mod.clear_federate_peer_bot_cache_for_tests()
+    resolver = AsyncMock(return_value="QQ 原昵称")
+    monkeypatch.setattr(mod, "load_or_create_deployment_id", lambda: "dep-local")
+    monkeypatch.setattr(mod, "get_catalog_bot_ids", lambda: frozenset({10001}))
+    monkeypatch.setattr(mod, "collect_local_federate_online_bot_ids", lambda: frozenset({10001}))
+    monkeypatch.setattr(mod, "collect_local_federate_public_bot_ids", AsyncMock(return_value=frozenset({10001})))
+    monkeypatch.setattr(mod, "collect_local_federate_public_online_bot_names", lambda *_: {})
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.resolve_login_nickname",
+        resolver,
+    )
+
+    roster = asyncio.run(mod._build_local_federate_bot_roster())
+
+    assert roster.public_online_bot_names == {10001: "QQ 原昵称"}
+    resolver.assert_awaited_once_with(10001)
+
+
+def test_local_roster_caches_fallback_nickname_and_skips_hidden_or_offline_accounts(monkeypatch):
+    mod.clear_federate_peer_bot_cache_for_tests()
+    resolver = AsyncMock(return_value="QQ 原昵称")
+    monkeypatch.setattr(mod, "load_or_create_deployment_id", lambda: "dep-local")
+    monkeypatch.setattr(mod, "get_catalog_bot_ids", lambda: frozenset({10001, 10002, 10003}))
+    monkeypatch.setattr(mod, "collect_local_federate_online_bot_ids", lambda: frozenset({10001, 10002}))
+    monkeypatch.setattr(mod, "collect_local_federate_public_bot_ids", AsyncMock(return_value=frozenset({10001, 10003})))
+    monkeypatch.setattr(mod, "collect_local_federate_public_online_bot_names", lambda *_: {})
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.resolve_login_nickname",
+        resolver,
+    )
+
+    first = asyncio.run(mod._build_local_federate_bot_roster())
+    second = asyncio.run(mod._build_local_federate_bot_roster())
+
+    assert first.public_online_bot_names == {10001: "QQ 原昵称"}
+    assert second.public_online_bot_names == {10001: "QQ 原昵称"}
+    resolver.assert_awaited_once_with(10001)
+
+
+def test_federate_roster_read_does_not_trigger_login_nickname_lookup(monkeypatch):
+    mod.clear_federate_peer_bot_cache_for_tests()
+    resolver = AsyncMock(return_value="QQ 原昵称")
+    monkeypatch.setattr(mod, "load_or_create_deployment_id", lambda: "dep-local")
+    monkeypatch.setattr(mod, "get_catalog_bot_ids", lambda: frozenset({10001}))
+    monkeypatch.setattr(mod, "collect_local_federate_online_bot_ids", lambda: frozenset({10001}))
+    monkeypatch.setattr(mod, "collect_local_federate_public_bot_ids", AsyncMock(return_value=frozenset({10001})))
+    monkeypatch.setattr(mod, "collect_local_federate_public_online_bot_names", lambda *_: {})
+    monkeypatch.setattr(
+        "pallas.product.persona.self_identity.resolve_login_nickname",
+        resolver,
+    )
+
+    rosters = asyncio.run(mod.get_federate_bot_rosters())
+
+    assert rosters[0].public_online_bot_names == {}
+    resolver.assert_not_awaited()
 
 
 def test_refresh_federate_peer_bot_ids_sync_reads_other_deployments(monkeypatch):


### PR DESCRIPTION
联邦名册在后台同步时为缺少协议显示名的公开在线账号补齐 QQ 昵称，并限并发、超时与缓存。\n\n状态命令仅消费 Redis 名册快照，不触发昵称查询。

## Summary by Sourcery

缓存并重用登录昵称，作为缺少协议显示名称的公共在线联合账户的后备方案，同时确保通讯录读取不会触发昵称解析。

新功能：
- 为缺少协议显示名称的公共在线联合账户添加带并发限制、超时和基于 TTL 的缓存的异步昵称解析。

错误修复：
- 通过仅在后台同步期间解析昵称，防止联合通讯录读取触发登录昵称查询。

测试：
- 添加测试，覆盖昵称后备使用、在通讯录重建过程中的缓存行为，以及确保联合通讯录读取不会触发登录昵称解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache and reuse login nicknames as a fallback for public online federate accounts lacking protocol display names, while ensuring roster reads do not trigger nickname resolution.

New Features:
- Add asynchronous nickname resolution with concurrency limits, timeouts, and TTL-based caching for public online federate accounts missing protocol display names.

Bug Fixes:
- Prevent federate roster reads from triggering login nickname lookups by only resolving nicknames during background sync.

Tests:
- Add tests covering nickname fallback usage, caching behavior across roster rebuilds, and ensuring federate roster reads do not invoke login nickname resolution.

</details>