### PR TITLE
fix(cli): 修复 Windows 重启时的子进程解码异常

### DIFF
--- a/pallas/console/cli/process_util.py
+++ b/pallas/console/cli/process_util.py
@@ -236,8 +236,8 @@ def _windows_stop_pid(pid: int, *, force: bool, timeout_s: float) -> None:
         subprocess.run(  # noqa: S603
             ["taskkill", *flags],
             check=False,
-            capture_output=True,
-            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
     except OSError:
         return
@@ -252,8 +252,8 @@ def _windows_stop_pid(pid: int, *, force: bool, timeout_s: float) -> None:
         subprocess.run(  # noqa: S603
             ["taskkill", "/PID", str(pid), "/T", "/F"],
             check=False,
-            capture_output=True,
-            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
     except OSError:
         pass

--- a/tests/common/test_process_util_bash.py
+++ b/tests/common/test_process_util_bash.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 from pallas.console.cli import process_util
 
@@ -66,3 +67,15 @@ def test_bash_missing_message_mentions_git_and_system32() -> None:
     if process_util.is_windows():
         assert "Git" in msg
         assert "System32" in msg
+
+
+def test_windows_stop_pid_discards_taskkill_output(monkeypatch) -> None:
+    run = Mock()
+    monkeypatch.setattr(process_util.subprocess, "run", run)
+
+    process_util._windows_stop_pid(123, force=True, timeout_s=1.0)
+
+    kwargs = run.call_args.kwargs
+    assert kwargs["stdout"] is process_util.subprocess.DEVNULL
+    assert kwargs["stderr"] is process_util.subprocess.DEVNULL
+    assert "text" not in kwargs


### PR DESCRIPTION
修复 Windows 自动重启时 taskkill 捕获 UTF-8 输出被 GBK 解码导致的异常，并补充回归测试。

## Summary by Sourcery

通过在进程终止期间抑制 `taskkill` 输出，使 Windows 自动重启更加健壮。

错误修复：
- 当 `taskkill` 输出的编码与预期的区域设置不同导致 Windows 进程终止失败时，进行防护。

测试：
- 添加回归测试，验证在不进行文本解码的情况下丢弃 Windows `taskkill` 输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Windows automatic restarts robust by suppressing taskkill output during process termination.

Bug Fixes:
- Prevent Windows process termination from failing when taskkill emits output encoded differently than the expected locale.

Tests:
- Add a regression test verifying that Windows taskkill output is discarded without text decoding.

</details>