### PR TITLE
fix(pb_webui): 修复中文 Windows 下 subprocess 文本模式 GBK 解码崩溃

### DIFF
--- a/packages/help/help_theme.py
+++ b/packages/help/help_theme.py
@@ -168,6 +168,8 @@ def resolve_help_font_path() -> Path:
                 ["fc-match", "-f", "%{file}", family],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=5,
             )
@@ -182,6 +184,8 @@ def resolve_help_font_path() -> Path:
                 ["fc-match", "-f", "%{file}", family],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=5,
             )

--- a/packages/pb_webui/bot_git_manage.py
+++ b/packages/pb_webui/bot_git_manage.py
@@ -78,6 +78,8 @@ def git_rev_parse_text(*args: str, timeout_s: float = 8.0) -> str | None:
             cwd=bot_repo_root(),
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_s,
         ).strip()
     except Exception:  # noqa: BLE001
@@ -105,6 +107,8 @@ def list_bot_remote_branches() -> list[str]:
             cwd=bot_repo_root(),
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         )
     except Exception:  # noqa: BLE001
@@ -130,6 +134,8 @@ def get_bot_head_info() -> dict[str, str] | None:
             cwd=bot_repo_root(),
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         ).strip()
     except Exception:  # noqa: BLE001
@@ -142,6 +148,8 @@ def get_bot_head_info() -> dict[str, str] | None:
             cwd=bot_repo_root(),
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         ).strip()
         if "|" in log_line:
@@ -237,6 +245,8 @@ def git_run_sync(*args: str, timeout_s: float = 8.0) -> tuple[int, str, str]:
             cwd=bot_repo_root(),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_s,
             check=False,
         )

--- a/packages/pb_webui/manager.py
+++ b/packages/pb_webui/manager.py
@@ -488,6 +488,8 @@ def inspect_bot_deployment() -> dict[str, str | bool | int]:
                 cwd=root,
                 stderr=subprocess.DEVNULL,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             ).strip()
             == "true"
         )
@@ -511,6 +513,8 @@ def inspect_bot_deployment() -> dict[str, str | bool | int]:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         ).strip()
         info["current_branch"] = branch
     except Exception:  # noqa: BLE001
@@ -522,6 +526,8 @@ def inspect_bot_deployment() -> dict[str, str | bool | int]:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         lines = [ln for ln in porcelain.splitlines() if ln.strip()]
         info["dirty_file_count"] = len(lines)
@@ -554,6 +560,8 @@ def bot_git_head_and_release_shas(latest_tag: str) -> tuple[str, str] | None:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         ).strip()
 
@@ -575,6 +583,8 @@ def bot_git_rev_list_count(revision_range: str) -> int:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         ).strip()
     except Exception:  # noqa: BLE001
@@ -596,6 +606,8 @@ def _git_rev_parse_text(*args: str, timeout_s: float = 8.0) -> str | None:
             cwd=_BOT_ROOT,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout_s,
         ).strip()
     except Exception:  # noqa: BLE001
@@ -639,6 +651,8 @@ def resolve_bot_upstream_ref(*, preferred_branch: str = "") -> str:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=8.0,
         ).strip()
     except Exception:  # noqa: BLE001

--- a/packages/pb_webui/system_home_api.py
+++ b/packages/pb_webui/system_home_api.py
@@ -494,6 +494,8 @@ def cpu_model() -> str | None:
             model = subprocess.check_output(
                 ["sysctl", "-n", "machdep.cpu.brand_string"],
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=1,
             )
             if model := " ".join(model.split()):

--- a/pallas/console/cli/redis_ops.py
+++ b/pallas/console/cli/redis_ops.py
@@ -49,6 +49,8 @@ def docker_command(args: list[str]) -> subprocess.CompletedProcess[str] | None:
             ["docker", *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=30,
         )

--- a/pallas/console/cli/shard_guard.py
+++ b/pallas/console/cli/shard_guard.py
@@ -98,6 +98,8 @@ def _tcp_listen_pids_ss(port: int) -> list[int]:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except FileNotFoundError:
         return []
@@ -131,6 +133,8 @@ def _tcp_listen_pids_netstat(port: int) -> list[int]:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except FileNotFoundError:
         return []

--- a/pallas/core/foundation/bot_version.py
+++ b/pallas/core/foundation/bot_version.py
@@ -51,6 +51,8 @@ def get_bot_current_version() -> dict[str, str]:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         ).strip()
     except Exception:  # noqa: BLE001
         pass
@@ -60,6 +62,8 @@ def get_bot_current_version() -> dict[str, str]:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         ).strip()
     except Exception:  # noqa: BLE001
         pass
@@ -105,6 +109,8 @@ def get_pallas_bot_version_for_health() -> str:
             cwd=root,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=3.0,
         ).strip()
         if desc:

--- a/pallas/core/platform/bot_runtime/plugin_loader.py
+++ b/pallas/core/platform/bot_runtime/plugin_loader.py
@@ -150,6 +150,8 @@ def plugin_directory_git_origin(plugin_dir: Path) -> str:
             cwd=plugin_dir,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=2,
             check=False,
         )

--- a/pallas/core/shared/utils/git_mirror.py
+++ b/pallas/core/shared/utils/git_mirror.py
@@ -408,6 +408,8 @@ def run_git_command_sync(*args: str, cwd: str | None = None) -> tuple[int, str, 
             cwd=cwd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_GIT_CMD_TIMEOUT_S,
             check=False,
         )

--- a/pallas/product/llm/tools/mcp_bootstrap.py
+++ b/pallas/product/llm/tools/mcp_bootstrap.py
@@ -165,6 +165,8 @@ class _StdioMcpSession(_McpSessionBase):
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,
             "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
             "bufsize": 1,
         }
         if sys.platform == "win32":


### PR DESCRIPTION
## 背景

中文 Windows（GBK 区域设置）下，`subprocess.check_output/run/Popen(..., text=True)` 未显式指定 `encoding` 时，会使用 locale 编码（GBK/cp936）解码子进程 stdout。当 git 命令（含中文提交信息 / tag 标题 / 文件名）或 MCP stdio 子进程输出 UTF-8 字节时，内部读取线程 `_readerthread` 抛出：

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 54: illegal multibyte sequence
```

## 改动

为所有生产代码中的 subprocess 文本模式调用补充 `encoding="utf-8", errors="replace"`（与 `pallas/core/foundation/db/backup.py`、`pallas/console/cli/ai_install.py` 既有约定一致），共 10 个文件：

- `pallas/core/foundation/bot_version.py` — git 版本探测（启动 / health 高频路径）
- `packages/pb_webui/bot_git_manage.py`、`packages/pb_webui/manager.py` — 控制台 Bot 更新 / git 历史
- `packages/pb_webui/system_home_api.py` — macOS sysctl
- `packages/help/help_theme.py` — fc-match 字体探测
- `pallas/core/shared/utils/git_mirror.py` — git 镜像命令
- `pallas/core/platform/bot_runtime/plugin_loader.py` — 插件 git origin 探测
- `pallas/product/llm/tools/mcp_bootstrap.py` — MCP stdio 会话（含 stderr 排空线程）
- `pallas/console/cli/redis_ops.py`、`pallas/console/cli/shard_guard.py` — CLI 工具

> `pallas/console/cli/process_util.py`（taskkill）未包含在本 PR：上游 `49e798ea` 已用 `stdout/stderr=DEVNULL` 方案修复并附测试，本 PR 合入时按上游方案解决冲突。

## 验证

- `ruff check pallas/ packages/` ✅
- `ruff format --check pallas/ packages/` ✅

## Summary by Sourcery

确保在 Windows 以及其他本地化环境的生产代码中，以健壮且一致的方式对子进程输出进行解码。

Bug Fixes:
- 防止在中文 Windows 区域设置中，当 UTF-8 输出包含非 GBK 字符时，子进程文本模式解码失败。

Enhancements:
- 在 Git、MCP、系统工具和 CLI 操作中，对生产环境的子进程文本处理进行标准化，明确使用 UTF-8，并在输出不可解码时采用替换策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure subprocess output is decoded robustly and consistently across production code on Windows and other localized environments.

Bug Fixes:
- Prevent subprocess text-mode decoding failures on Chinese Windows locales when UTF-8 output contains non-GBK characters.

Enhancements:
- Standardize production subprocess text handling to explicitly use UTF-8 with replacement for undecodable output across Git, MCP, system utilities, and CLI operations.

</details>