### PR TITLE
docs: 更新协作约定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ packages/<name>/
   - `chore:` 构建/工具链/依赖
   - `docs:` 文档
 - **自动化 Agent 创建 git commit 前**：先给出**提交信息草案**供维护者确认，**得到确认后再提交**。
+- **普通 dev→main PR 的 CHANGELOG**：WebUI 与 Bot 发版解耦、Bot 降频后，`dev`→`main` 多为不含 `chore(release)` 的功能 PR。此类 PR 应随批写好 `## [Unreleased]`（只写 `### Added` / `### Fixed` / `### Changed` 明细，不写更新公告、不改版本号），素材随批落到 `main`，供真正发版时整理公告。完整约定见 `docs/skills/pallas-release/SKILL.md` 的「普通 dev→main PR 的 CHANGELOG 约定」。
 
 ### Git 操作边界
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* feat(ingress): 旁路记录群消息到 message 表
+* feat(llm): 提取引用(reply)的原消息图片并入视觉上下文
+* feat(llm): 聊天看图复用配置的视觉模型，主模型不支持图片时用它描述图片
+* feat(llm): 会话历史图片用视觉模型描述供摘要识图，并对齐带图时间线测试
+* feat(llm): 注入当前时间并提供时间工具
+* feat(llm): 增加 turn telemetry 调用链观测
+* feat(tools): 新增事件级 LLM persona AB harness
+* feat(work_jobs): MemoryWorkJobStore 支持完成保留映射
+* feat(work_jobs): PostgresWorkJobStore 支持完成保留映射并对完成写入通知
+* feat(work_jobs): MongoWorkJobStore 支持完成保留映射
+* feat(work_jobs): 完成保留装配注入并事件驱动 delivery dispatcher
+* feat(webui): 后端首屏预热梯次化并用信号量限外部请求
+* feat(release): 按 Bot commit 选择兼容 WebUI
+* feat(greeting): 戳一戳回应增加时段次数上限
+
+### Fixed
+
+* fix(llm): 支持 Responses API 视觉内容
+* fix(llm): 图片拉取优先本地缓存避免每次先裸GET失败
+* fix(llm): 视觉图片拉取失败时回退到图片缓存
+* fix(llm): 图片拉取复用参考图下载层（curl_cffi指纹+Referer）
+* fix(llm): 图片进历史延迟识别，需摘要识图时才调视觉模型
+* fix(llm): 图片识别附群聊上下文，减少识图答错
+* fix(llm): 识别问句附加独立判断指示，避免识图被罗德岛背景带偏答成方舟干员
+* fix(llm): 引用图提取优先复用event.reply.message，避免消息库id匹配失败丢图
+* fix(llm): 引用图提取改绑用户实际reply目标而非bot的QUOTE决策
+* fix(llm): 引用图查询支持负数message_id，修复消息id对不上
+* fix(llm): 修复群聊图片视觉上下文
+* fix(llm): 完善群聊历史图片视觉链路
+* fix(llm-chat): 放行视觉消息并注入群聊图片时间线
+* fix(llm): 识别问句看图时跳过时间线历史图注入，聚焦当前图
+* fix(llm): 无图识别问句不再注入表情推荐工具域
+* fix(llm): 带图识图不再注入方舟/表情工具域
+* fix(llm): 识别问句超限回复拆多泡避免答案被截断
+* fix(llm): 识别问句多段超限回复按断点重切避免答案被截断
+* fix(llm): 多泡回复超长时按单泡保留而非整段静默
+* fix(llm): 识别提示约束认不出时诚实说明不硬编角色
+* fix(llm): base_url 识别任意版本段（/v1、/v4、/openai）不再误追加 /v1
+* fix(llm): 扩大群聊历史工具裁剪窗口
+* fix(llm): 支持按已登记模型配置能力与思考强度
+* fix(ai-callback): 修复 work 辅进程任务回调 404
+* fix(webui): 校验兼容版本后更新控制台
+* fix(ingress): 日志行右对齐且回复不截断
+* fix(ingress): info日志显示reply引用，便于排查用户是否引用消息
+* fix(help): MAA 远控插件二三级帮助显示对接地址
+
+### Changed
+
+* refactor(ingress): 群消息日志按级别分离
+* refactor(logging): debug 日志中文叙事改英文并补齐业务词表
+
+### Docs
+
+* docs(architecture): 补充引用图提取与图片延迟识别上下文链路
+
 ## [4.3.12] - 2026-08-25
 
 ### 更新公告

--- a/docs/developer/architecture/llm-context-injection.md
+++ b/docs/developer/architecture/llm-context-injection.md
@@ -115,6 +115,10 @@
 
 Provider 已显式声明 `image` 时，`vision_messages` 在请求前下载这些历史图片，使用内部 Chat 风格 `text` / `image_url` 内容块，作为一条 user 消息插入当前 user 消息之前；请求适配层再按 Provider 的请求方式转换为 Responses 的 `input_text` / `input_image` 或 Anthropic 的 `text` / `image` / `source` 块。文本 Provider 不下载、不调用视觉助手，只看到文字时间线和 `[图片]` 占位。`session_store` 的 `【群环境摘录】` 不在这条能力范围内。
 
+**当前/被引用的图片**有两处来源，都会并入 `vision_image_urls` 作为当前图处理：一是当前消息自带的 `[CQ:image]`；二是被引用的原消息图片（用户 reply 一条带图消息时，`chat_message.py` 从 `event.reply.message` 提取，经 `ChatSubmitRequest.referenced_message` 传给 `client.py` 并入 `vision_image_urls`）。引用图不依赖消息库回查，优先复用收包时已填充的 `event.reply`；消息库（`find_by_message_ids`）与 OneBot `get_msg` 仅作兜底。回查支持负数的 `message_id`（QQ 新版）。
+
+**识别问句聚焦当前图**：当当前消息含图且属于识别问句（「这是谁/这是什么/啥梗」等，见 `tools.select.is_recognition_question`）时，不注入历史时间线图，避免模型被「刚才群聊中的图片」带偏、把当前图答成历史图或方舟干员。非识别问句的带图消息仍会注入最近的历史时间线图作群聊上下文。
+
 ## messages 序列（走请求消息）
 
 `build_llm_chat_messages`（`session_store.py`）按顺序组装：
@@ -158,6 +162,8 @@ Provider 已显式声明 `image` 时，`vision_messages` 在请求前下载这�
 ### 长会话压缩
 
 会话太长时先压再注入（`session_summary.py`）：当该用户消息数 ≥ `llm_session_summary_threshold`（默认 24）且距上次压缩超过冷却期（默认 600s），用低成本模型把窗口外历史压成 ≤120 字中文，写入一条 `user` 记录的【此前对话摘要】，并只保留最近 `llm_session_summary_keep_messages`（默认 16）条。**读取时摘要始终保留在窗口内**——若摘要滑出当前窗口，会弹出它、保留最近 `N-1` 条、把摘要放回最前。压缩发生在投递成功后异步执行。
+
+**图片进历史的延迟识别**：含 `[CQ:image]` 的 user 消息进会话历史时，不立即调用视觉模型识别（避免每张图都产生一次 LLM 成本），而是存成 `[图片]:url=X` 占位符（`vision_content.placeholder_with_image_urls`），保留图片 URL。到会话摘要压缩需要理解历史图时，`session_summary._summary_messages` 才从占位符提取 URL、查图片缓存并对占位符段做一次视觉描述（`vision_messages.describe_placeholder_images`），占位符外的文字保留。开关 `llm_session_vision_describe_enabled` 控制此行为；关闭时直接退化为纯 `[图片]` 占位（丢 URL）。
 
 ### 字符预算
 

--- a/docs/skills/pallas-release/SKILL.md
+++ b/docs/skills/pallas-release/SKILL.md
@@ -39,6 +39,16 @@ description: >
 - 开 Bot 发版 PR 前：本地 `dev` **先快进 / 对齐** `origin/main`（避免 `dev` 落后于 `main` 的纯文档/合入提交漏在 PR 外或把无关 diff 搅进来），再叠本版功能与发版提交。
 - 本版尚未合入 `dev` 的功能（如 feature 分支）：先合入 / cherry-pick 到 `dev`，再做发版提交。
 
+## 普通 dev→main PR 的 CHANGELOG 约定
+
+`dev`→`main` 多为**不含** `chore(release)` 的普通功能 PR（把一批功能推进 `main`）。此类 PR 的 CHANGELOG 素材应**随批记录**，供后续发版引用：
+
+- 每个普通 dev→main PR，在它那批功能提交里写好 `## [Unreleased]`（只写 `### Added` / `### Fixed` / `### Changed` 明细，**不写** `### 更新公告`，也不改版本号），随 PR 一起合入 `main`。更新公告留到真正发版时再依据明细整理。
+- 该 `Unreleased` 记录独立提交或并入功能提交均可（维护者常 amend 进最新功能提交）；关键是**每次普通 PR 都带一次**，素材随批落到 `main`。
+- 发版时把 `main` 上累积的 `Unreleased` 段标题转正式段 `## [X.Y.Z]`，补充 `### 更新公告`，版本号在 `chore(release)` 里改。
+
+这样发版面对的是一份已分好类的素材，无需再从几十条 commit 重新归纳。
+
 ## `dev` 上的提交形态（必守）
 
 发版准备完成后，`origin/main..dev` 应满足：


### PR DESCRIPTION
合并 dev 到 main：补充引用图提取与图片延迟识别上下文链路文档，更新协作约定（普通 dev→main PR 随批记录 CHANGELOG Unreleased）。

## Summary by Sourcery

完善协作与发版约定，并补充图片视觉上下文链路文档及本批变更记录。

Enhancements:
- 补充引用图片提取、当前图识别聚焦及历史图片延迟识别的 LLM 上下文链路文档。

Documentation:
- 完善 LLM 上下文注入架构文档，说明引用图、群聊历史图片和延迟视觉识别的处理规则。
- 新增普通 dev→main PR 随批维护 CHANGELOG Unreleased 素材的协作与发版约定。

Chores:
- 为本批功能、修复和变更整理 CHANGELOG Unreleased 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

完善协作与发版约定，并补充图片视觉上下文链路文档及本批变更记录。

Enhancements:
- 补充引用图片提取、当前图识别聚焦及历史图片延迟识别的 LLM 上下文链路文档。

Documentation:
- 完善 LLM 上下文注入架构文档，说明引用图、群聊历史图片和延迟视觉识别的处理规则。
- 新增普通 dev→main PR 随批维护 CHANGELOG Unreleased 素材的协作与发版约定。

Chores:
- 为本批功能、修复和变更整理 CHANGELOG Unreleased 条目。

</details>