### PR TITLE
feat: 入站调度观测与记忆图谱能力更新

### DIFF
--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.3.12-136-g57533b89-dirty",
+    "version": "v4.3.13-3-gdbf7b65c-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -32053,6 +32053,124 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "IngressDispatchConversationScheduler": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "default": false
+          },
+          "pending": {
+            "type": "integer",
+            "title": "Pending",
+            "default": 0
+          },
+          "pending_peak": {
+            "type": "integer",
+            "title": "Pending Peak",
+            "default": 0
+          },
+          "active": {
+            "type": "integer",
+            "title": "Active",
+            "default": 0
+          },
+          "active_peak": {
+            "type": "integer",
+            "title": "Active Peak",
+            "default": 0
+          },
+          "wait_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wait Ms P95"
+          },
+          "run_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Ms P95"
+          },
+          "passive_repeater_pending": {
+            "type": "integer",
+            "title": "Passive Repeater Pending",
+            "default": 0
+          },
+          "passive_repeater_active": {
+            "type": "integer",
+            "title": "Passive Repeater Active",
+            "default": 0
+          },
+          "passive_repeater_run_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passive Repeater Run Ms P95"
+          },
+          "passive_repeater_active_oldest_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passive Repeater Active Oldest Ms"
+          },
+          "passive_llm_pending": {
+            "type": "integer",
+            "title": "Passive Llm Pending",
+            "default": 0
+          },
+          "passive_llm_active": {
+            "type": "integer",
+            "title": "Passive Llm Active",
+            "default": 0
+          },
+          "passive_llm_run_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passive Llm Run Ms P95"
+          },
+          "passive_llm_active_oldest_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passive Llm Active Oldest Ms"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "title": "IngressDispatchConversationScheduler"
+      },
       "IngressDispatchData": {
         "properties": {
           "sharded": {
@@ -32067,6 +32185,12 @@
             },
             "type": "array",
             "title": "Workers"
+          },
+          "hotpath": {
+            "$ref": "#/components/schemas/IngressDispatchHotpath"
+          },
+          "conversation_scheduler": {
+            "$ref": "#/components/schemas/IngressDispatchConversationScheduler"
           }
         },
         "additionalProperties": true,
@@ -32220,6 +32344,68 @@
           "work_completed"
         ],
         "title": "IngressDispatchHistoryPoint"
+      },
+      "IngressDispatchHotpath": {
+        "properties": {
+          "repeater_event_gate_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeater Event Gate Ms P95"
+          },
+          "repeater_scrub_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeater Scrub Ms P95"
+          },
+          "repeater_prepare_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeater Prepare Ms P95"
+          },
+          "repeater_answer_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeater Answer Ms P95"
+          },
+          "repeater_cooldown_ms_p95": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repeater Cooldown Ms P95"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "title": "IngressDispatchHotpath"
       },
       "InjectionGovernanceManageRequest": {
         "properties": {

--- a/packages/pb_webui/console_openapi_models.py
+++ b/packages/pb_webui/console_openapi_models.py
@@ -248,11 +248,45 @@ class SystemRestartAvailabilityData(BaseModel):
     deployment_mode: str = ""
 
 
+class IngressDispatchHotpath(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    repeater_event_gate_ms_p95: float | None = None
+    repeater_scrub_ms_p95: float | None = None
+    repeater_prepare_ms_p95: float | None = None
+    repeater_answer_ms_p95: float | None = None
+    repeater_cooldown_ms_p95: float | None = None
+
+
+class IngressDispatchConversationScheduler(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool = False
+    pending: int = 0
+    pending_peak: int = 0
+    active: int = 0
+    active_peak: int = 0
+    wait_ms_p95: float | None = None
+    run_ms_p95: float | None = None
+    passive_repeater_pending: int = 0
+    passive_repeater_active: int = 0
+    passive_repeater_run_ms_p95: float | None = None
+    passive_repeater_active_oldest_ms: float | None = None
+    passive_llm_pending: int = 0
+    passive_llm_active: int = 0
+    passive_llm_run_ms_p95: float | None = None
+    passive_llm_active_oldest_ms: float | None = None
+
+
 class IngressDispatchData(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     sharded: bool = False
     workers: list[dict[str, Any]] = Field(default_factory=list)
+    hotpath: IngressDispatchHotpath = Field(default_factory=IngressDispatchHotpath)
+    conversation_scheduler: IngressDispatchConversationScheduler = Field(
+        default_factory=IngressDispatchConversationScheduler,
+    )
 
 
 class IngressDispatchHistoryPoint(BaseModel):

--- a/packages/repeater/fanout_reply.py
+++ b/packages/repeater/fanout_reply.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from itertools import starmap
 
 from pallas.api.logging import format_plugin_event
+from pallas.api.platform import GROUP_ONLINE_TTL_SEC
 from pallas.core.foundation.config import BotConfig
 from pallas.core.platform.bot_runtime.send_unavailable import BOT_SEND_UNAVAILABLE_ERRORS, log_bot_send_unavailable
 from pallas.core.platform.multi_bot.dedup import try_claim_group_message_once
@@ -29,7 +30,7 @@ from .model import Chat, ChatData
 from .responder import ReplyBundle, Responder
 
 _FANOUT_PLUGIN = "repeater_fanout"
-_FANOUT_BOT_IDS_CACHE_TTL = 2.0
+_FANOUT_BOT_IDS_CACHE_TTL = GROUP_ONLINE_TTL_SEC
 _FANOUT_BOT_IDS_CACHE: dict[int, tuple[float, list[int]]] = {}
 # 复读/接话的每群冷却（秒）。比 BotConfig 默认 5s 略长，进一步压一压刷屏感。
 REPEATER_REPLY_COOLDOWN = 8

--- a/packages/repeater/message_runtime_handler.py
+++ b/packages/repeater/message_runtime_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -108,24 +109,32 @@ class RepeaterDirectHandler:
         from packages.repeater.event_gate import build_repeater_event_context
         from packages.repeater.model import Chat
         from packages.repeater.reply_preparation import prepare_repeater_reply
+        from pallas.core.platform.ingress.hotpath_metrics import record_stage_duration
         from pallas.product.message_scrub import is_message_scrub_blocked_async
 
+        repeater_context_started = time.perf_counter()
         repeater_context = await build_repeater_event_context(int(bot.self_id), event)
+        record_stage_duration("repeater_event_gate", (time.perf_counter() - repeater_context_started) * 1000.0)
         if repeater_context is None:
             return HandlingOutcome(handled=True)
+        scrub_started = time.perf_counter()
         if await is_message_scrub_blocked_async(
             plain_text=repeater_context.plain_body,
             raw_message=repeater_context.norm_raw,
         ):
+            record_stage_duration("repeater_scrub", (time.perf_counter() - scrub_started) * 1000.0)
             return HandlingOutcome(handled=True)
+        record_stage_duration("repeater_scrub", (time.perf_counter() - scrub_started) * 1000.0)
 
         chat = Chat(event)
+        prepare_started = time.perf_counter()
         prepared = await prepare_repeater_reply(
             event,
             chat,
             plain_body=repeater_context.plain_body,
             sharding_active=repeater_context.sharding_active,
         )
+        record_stage_duration("repeater_prepare", (time.perf_counter() - prepare_started) * 1000.0)
         if event.is_tome():
             return HandlingOutcome(
                 handled=False,
@@ -147,7 +156,9 @@ class RepeaterDirectHandler:
                 deferred_actions=(capture_action,) + fanout_outcome.deferred_actions,
             )
 
+        answer_started = time.perf_counter()
         answers = await chat.answer_from_bundle(prepared.bundle)
+        record_stage_duration("repeater_answer", (time.perf_counter() - answer_started) * 1000.0)
         if answers is None:
             return HandlingOutcome(
                 handled=True,
@@ -159,7 +170,9 @@ class RepeaterDirectHandler:
         from pallas.core.foundation.config import BotConfig
         from pallas.core.platform.ingress.hotpath_metrics import record_reply_local_dispatched
 
+        cooldown_started = time.perf_counter()
         await BotConfig(int(event.self_id), int(event.group_id)).refresh_cooldown("repeat")
+        record_stage_duration("repeater_cooldown", (time.perf_counter() - cooldown_started) * 1000.0)
         record_reply_local_dispatched()
         local_outcome = build_repeater_local_reply_outcome(int(event.self_id), int(event.group_id), answers)
         return replace(local_outcome, deferred_actions=(capture_action,) + local_outcome.deferred_actions)

--- a/packages/repeater/message_runtime_handler.py
+++ b/packages/repeater/message_runtime_handler.py
@@ -113,28 +113,34 @@ class RepeaterDirectHandler:
         from pallas.product.message_scrub import is_message_scrub_blocked_async
 
         repeater_context_started = time.perf_counter()
-        repeater_context = await build_repeater_event_context(int(bot.self_id), event)
-        record_stage_duration("repeater_event_gate", (time.perf_counter() - repeater_context_started) * 1000.0)
+        try:
+            repeater_context = await build_repeater_event_context(int(bot.self_id), event)
+        finally:
+            record_stage_duration("repeater_event_gate", (time.perf_counter() - repeater_context_started) * 1000.0)
         if repeater_context is None:
             return HandlingOutcome(handled=True)
         scrub_started = time.perf_counter()
-        if await is_message_scrub_blocked_async(
-            plain_text=repeater_context.plain_body,
-            raw_message=repeater_context.norm_raw,
-        ):
+        try:
+            scrub_blocked = await is_message_scrub_blocked_async(
+                plain_text=repeater_context.plain_body,
+                raw_message=repeater_context.norm_raw,
+            )
+        finally:
             record_stage_duration("repeater_scrub", (time.perf_counter() - scrub_started) * 1000.0)
+        if scrub_blocked:
             return HandlingOutcome(handled=True)
-        record_stage_duration("repeater_scrub", (time.perf_counter() - scrub_started) * 1000.0)
 
         chat = Chat(event)
         prepare_started = time.perf_counter()
-        prepared = await prepare_repeater_reply(
-            event,
-            chat,
-            plain_body=repeater_context.plain_body,
-            sharding_active=repeater_context.sharding_active,
-        )
-        record_stage_duration("repeater_prepare", (time.perf_counter() - prepare_started) * 1000.0)
+        try:
+            prepared = await prepare_repeater_reply(
+                event,
+                chat,
+                plain_body=repeater_context.plain_body,
+                sharding_active=repeater_context.sharding_active,
+            )
+        finally:
+            record_stage_duration("repeater_prepare", (time.perf_counter() - prepare_started) * 1000.0)
         if event.is_tome():
             return HandlingOutcome(
                 handled=False,
@@ -157,8 +163,10 @@ class RepeaterDirectHandler:
             )
 
         answer_started = time.perf_counter()
-        answers = await chat.answer_from_bundle(prepared.bundle)
-        record_stage_duration("repeater_answer", (time.perf_counter() - answer_started) * 1000.0)
+        try:
+            answers = await chat.answer_from_bundle(prepared.bundle)
+        finally:
+            record_stage_duration("repeater_answer", (time.perf_counter() - answer_started) * 1000.0)
         if answers is None:
             return HandlingOutcome(
                 handled=True,
@@ -171,8 +179,10 @@ class RepeaterDirectHandler:
         from pallas.core.platform.ingress.hotpath_metrics import record_reply_local_dispatched
 
         cooldown_started = time.perf_counter()
-        await BotConfig(int(event.self_id), int(event.group_id)).refresh_cooldown("repeat")
-        record_stage_duration("repeater_cooldown", (time.perf_counter() - cooldown_started) * 1000.0)
+        try:
+            await BotConfig(int(event.self_id), int(event.group_id)).refresh_cooldown("repeat")
+        finally:
+            record_stage_duration("repeater_cooldown", (time.perf_counter() - cooldown_started) * 1000.0)
         record_reply_local_dispatched()
         local_outcome = build_repeater_local_reply_outcome(int(event.self_id), int(event.group_id), answers)
         return replace(local_outcome, deferred_actions=(capture_action,) + local_outcome.deferred_actions)

--- a/pallas/console/webui/field_labels.py
+++ b/pallas/console/webui/field_labels.py
@@ -187,6 +187,7 @@ FIELD_LABELS: dict[str, str] = {
     "llm_memory_auto_person_facts_daily_budget": "个人偏好总结每日上限",
     "llm_memory_graph_extract_enabled": "记忆图谱抽取",
     "llm_memory_graph_extract_on_write": "写入后自动抽取图谱",
+    "llm_memory_graph_extract_daily_budget": "图谱抽取每日上限",
     "llm_memory_hiergraph_max_layers": "分层图谱最大层数",
     "llm_memory_decay_half_life_days": "记忆淡出半衰期（天）",
     "llm_memory_decay_min_importance": "记忆淡出重要性下限",

--- a/pallas/core/platform/ingress/conversation_scheduler.py
+++ b/pallas/core/platform/ingress/conversation_scheduler.py
@@ -557,6 +557,8 @@ def conversation_scheduler_status() -> dict[str, int | float | bool | None]:
         base[f"passive_{pool_name}_pending"] = int(stat.get("pending") or 0)
         base[f"passive_{pool_name}_active"] = int(stat.get("active") or 0)
         base[f"passive_{pool_name}_dropped"] = int(stat.get("dropped") or 0)
+        base[f"passive_{pool_name}_run_ms_p95"] = stat.get("run_ms_p95")
+        base[f"passive_{pool_name}_active_oldest_ms"] = stat.get("active_oldest_ms")
     return base
 
 

--- a/pallas/core/platform/ingress/dispatch_metrics.py
+++ b/pallas/core/platform/ingress/dispatch_metrics.py
@@ -77,6 +77,7 @@ def record_group_message_ingress(
     matchers_considered: int,
     matchers_selected: int,
     matchers_run: int,
+    record_p95: bool = True,
 ) -> None:
     _rollover_if_needed()
     _state["group_messages"] += 1
@@ -87,6 +88,8 @@ def record_group_message_ingress(
     _state["matchers_considered"] += max(0, matchers_considered)
     _state["matchers_selected"] += max(0, matchers_selected)
     _state["matchers_run"] += max(0, matchers_run)
+    if not record_p95:
+        return
     now = time.monotonic()
     if duration_ms >= 0:
         _ingress_ms_samples.append((now, float(duration_ms)))

--- a/pallas/core/platform/ingress/hotpath_metrics.py
+++ b/pallas/core/platform/ingress/hotpath_metrics.py
@@ -48,6 +48,11 @@ _COUNTERS = (
     "reply_query_uncached",
 )
 _STAGE_KEYS = (
+    "repeater_event_gate",
+    "repeater_scrub",
+    "repeater_prepare",
+    "repeater_answer",
+    "repeater_cooldown",
     "db_find",
     "persona",
     "affect",
@@ -115,6 +120,11 @@ def _append_stage(name: str, duration_ms: float | None) -> None:
     if samples is None:
         return
     samples.append(float(duration_ms))
+
+
+def record_stage_duration(name: str, duration_ms: float) -> None:
+    _rollover_if_needed()
+    _append_stage(name, duration_ms)
 
 
 def record_route_resolve_ms(duration_ms: float) -> None:

--- a/pallas/core/platform/ingress/matcher_dispatch.py
+++ b/pallas/core/platform/ingress/matcher_dispatch.py
@@ -432,7 +432,12 @@ async def patched_handle_event_now(bot: Bot, event: Event) -> None:
             else:
                 log.success(nb_message.escape_tag(f" Bot {bot.self_id} | {event_log}"))
         elif inbound_event_log_as_debug(event_type):
-            log.debug(nb_message.escape_tag(f" {bot.type} {bot.self_id} | {event_log}"))
+            log.debug(
+                " {} {} | {}",
+                nb_message.escape_tag(bot.type),
+                nb_message.escape_tag(bot.self_id),
+                nb_message.escape_tag(event_log),
+            )
         else:
             log.success(nb_message.escape_tag(f" {bot.type} {bot.self_id} | {event_log}"))
 

--- a/pallas/core/platform/ingress/matcher_dispatch.py
+++ b/pallas/core/platform/ingress/matcher_dispatch.py
@@ -528,6 +528,7 @@ async def patched_handle_event_now(bot: Bot, event: Event) -> None:
                         matchers_considered=0,
                         matchers_selected=0,
                         matchers_run=0,
+                        record_p95=False,
                     )
                     await nb_message._apply_event_postprocessors(bot, event, state, stack, dependency_cache)
                     return
@@ -542,6 +543,7 @@ async def patched_handle_event_now(bot: Bot, event: Event) -> None:
                             matchers_considered=0,
                             matchers_selected=0,
                             matchers_run=0,
+                            record_p95=False,
                         )
                         await nb_message._apply_event_postprocessors(bot, event, state, stack, dependency_cache)
                         return

--- a/pallas/core/platform/ingress/passive_pool.py
+++ b/pallas/core/platform/ingress/passive_pool.py
@@ -19,6 +19,8 @@ class PassiveWorkPool:
         self._dropped = 0
         self._active = 0
         self._wait_samples_ms: deque[float] = deque(maxlen=256)
+        self._run_samples_ms: deque[float] = deque(maxlen=256)
+        self._active_started: set[float] = set()
         self._tasks: set[asyncio.Task[None]] = set()
         self._stopping = False
         self._sem = asyncio.Semaphore(self.max_concurrency)
@@ -38,17 +40,21 @@ class PassiveWorkPool:
             await self._sem.acquire()
             self._pending = max(0, self._pending - 1)
             self._active += 1
-            self._wait_samples_ms.append((time.monotonic() - queued_at) * 1000.0)
-            task = asyncio.create_task(self._run(work), name=f"passive_{self.name}")
+            started_at = time.monotonic()
+            self._active_started.add(started_at)
+            self._wait_samples_ms.append((started_at - queued_at) * 1000.0)
+            task = asyncio.create_task(self._run(work, started_at), name=f"passive_{self.name}")
             self._tasks.add(task)
             task.add_done_callback(self._tasks.discard)
         except asyncio.CancelledError:
             raise
 
-    async def _run(self, work: Work) -> None:
+    async def _run(self, work: Work, started_at: float) -> None:
         try:
             await work()
         finally:
+            self._run_samples_ms.append((time.monotonic() - started_at) * 1000.0)
+            self._active_started.discard(started_at)
             self._active = max(0, self._active - 1)
             self._changed.set()
             self._sem.release()
@@ -59,6 +65,12 @@ class PassiveWorkPool:
         if ordered:
             index = max(0, min(len(ordered) - 1, int(len(ordered) * 0.95)))
             wait_p95 = round(ordered[index], 2)
+        run_ordered = sorted(self._run_samples_ms)
+        run_p95 = None
+        if run_ordered:
+            index = max(0, min(len(run_ordered) - 1, int(len(run_ordered) * 0.95)))
+            run_p95 = round(run_ordered[index], 2)
+        oldest = min(self._active_started, default=None)
         return {
             "name": self.name,
             "pending": self._pending,
@@ -66,6 +78,8 @@ class PassiveWorkPool:
             "active": self._active,
             "dropped": self._dropped,
             "wait_ms_p95": wait_p95,
+            "run_ms_p95": run_p95,
+            "active_oldest_ms": round((time.monotonic() - oldest) * 1000.0, 2) if oldest is not None else None,
         }
 
     async def stop(self) -> None:

--- a/pallas/core/platform/multi_bot/group_online_cache.py
+++ b/pallas/core/platform/multi_bot/group_online_cache.py
@@ -7,8 +7,11 @@ import time
 
 from nonebot import get_bots, logger
 
+from pallas.core.foundation.logging import log_rate_limited
+
 GROUP_ONLINE_TTL_SEC = 45.0
 GROUP_ONLINE_CACHE_MAX = 512
+_GROUP_MEMBER_PROBE_TIMEOUT_SEC = 3.0
 NS_FLEET = "fleet"
 NS_LOCAL_CONNECTED = "local_connected"
 
@@ -116,13 +119,36 @@ async def resolve_local_connected_bots_in_group(group_id: int, *, force_probe: b
 
     bots = get_bots()
     out: list[int] = []
+    deadline = time.monotonic() + _GROUP_MEMBER_PROBE_TIMEOUT_SEC
     for key in sorted(bots.keys(), key=lambda x: int(x) if str(x).isdigit() else 0):
         try:
             bid = int(key)
         except ValueError:
             continue
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            log_rate_limited(
+                logger,
+                "warning",
+                f"group_online_cache.probe_exhausted.{gid}",
+                "group online cache: probe budget exhausted for group [{}]",
+                gid,
+            )
+            break
         try:
-            await bots[key].get_group_member_info(group_id=gid, user_id=bid)
+            await asyncio.wait_for(
+                bots[key].get_group_member_info(group_id=gid, user_id=bid),
+                timeout=remaining,
+            )
+        except TimeoutError:
+            log_rate_limited(
+                logger,
+                "warning",
+                f"group_online_cache.probe_exhausted.{gid}",
+                "group online cache: probe budget exhausted for group [{}]",
+                gid,
+            )
+            break
         except Exception as e:
             logger.debug("group online cache: probe {} failed for group [{}]: {}", bid, gid, e)
             continue

--- a/pallas/core/platform/multi_bot/group_online_cache.py
+++ b/pallas/core/platform/multi_bot/group_online_cache.py
@@ -48,6 +48,7 @@ async def store_cached_group_bot_ids(
     ids: tuple[int, ...] | list[int],
     *,
     namespace: str,
+    ttl_sec: float | None = None,
 ) -> None:
     gid = int(group_id)
     now = time.time()
@@ -60,7 +61,7 @@ async def store_cached_group_bot_ids(
                 bucket.pop(k, None)
             if len(bucket) >= GROUP_ONLINE_CACHE_MAX:
                 bucket.clear()
-        bucket[gid] = (now + GROUP_ONLINE_TTL_SEC, tup)
+        bucket[gid] = (now + (ttl_sec if ttl_sec is not None else GROUP_ONLINE_TTL_SEC), tup)
 
 
 def remember_local_group_bot(group_id: int, bot_id: int) -> None:

--- a/pallas/product/llm/config.py
+++ b/pallas/product/llm/config.py
@@ -303,6 +303,7 @@ class LlmConfig(BaseModel):
     llm_memory_auto_person_facts_daily_budget: int = Field(default=200, ge=0, le=100000)
     llm_memory_graph_extract_enabled: bool = Field(default=True)
     llm_memory_graph_extract_on_write: bool = Field(default=True)
+    llm_memory_graph_extract_daily_budget: int = Field(default=200, ge=0, le=100000)
     llm_memory_hiergraph_max_layers: int = Field(default=3, ge=1, le=6)
     llm_memory_decay_half_life_days: float = Field(default=30.0, ge=0.0, le=3650.0)
     llm_memory_decay_min_importance: float = Field(default=0.6, ge=0.0, le=1.0)
@@ -563,6 +564,7 @@ def get_llm_config() -> LlmConfig:
             llm_sticker_habit_backfill_days=_env_int("LLM_STICKER_HABIT_BACKFILL_DAYS", 7),
             llm_memory_graph_extract_enabled=_env_bool("LLM_MEMORY_GRAPH_EXTRACT_ENABLED", True),
             llm_memory_graph_extract_on_write=_env_bool("LLM_MEMORY_GRAPH_EXTRACT_ON_WRITE", True),
+            llm_memory_graph_extract_daily_budget=_env_int("LLM_MEMORY_GRAPH_EXTRACT_DAILY_BUDGET", 200),
             llm_memory_hiergraph_max_layers=_env_int("LLM_MEMORY_HIERGRAPH_MAX_LAYERS", 3),
             llm_memory_decay_half_life_days=_env_float("LLM_MEMORY_DECAY_HALF_LIFE_DAYS", 30.0),
             llm_memory_decay_min_importance=_env_float("LLM_MEMORY_DECAY_MIN_IMPORTANCE", 0.6),

--- a/pallas/product/llm/memory/graph/extract.py
+++ b/pallas/product/llm/memory/graph/extract.py
@@ -86,13 +86,20 @@ def _graph_extract_budget_ok() -> bool:
     return _graph_extract_daily_budget_used < limit
 
 
-def _bump_graph_extract_budget() -> None:
+def _reserve_graph_extract_budget(count: int = 1) -> bool:
+    count = max(1, int(count))
+    limit = int(get_llm_config().llm_memory_graph_extract_daily_budget)
+    if limit <= 0:
+        return True
     global _graph_extract_budget_day, _graph_extract_daily_budget_used
     today = time.strftime("%Y-%m-%d")
     if _graph_extract_budget_day != today:
         _graph_extract_budget_day = today
         _graph_extract_daily_budget_used = 0
-    _graph_extract_daily_budget_used += 1
+    if _graph_extract_daily_budget_used + count > limit:
+        return False
+    _graph_extract_daily_budget_used += count
+    return True
 
 
 def _resolve_extract_task_and_model() -> tuple[str, str]:
@@ -255,7 +262,7 @@ async def extract_from_text(
     raw_text = str(text or "").strip()
     if not raw_text:
         return {"entities_upserted": 0, "edges_upserted": 0, "error": "empty text"}
-    if not _graph_extract_budget_ok():
+    if not _reserve_graph_extract_budget():
         return {"entities_upserted": 0, "edges_upserted": 0, "error": "daily budget exhausted"}
     if not is_memory_graph_store_available():
         return {"entities_upserted": 0, "edges_upserted": 0, "error": "store unavailable"}
@@ -277,7 +284,6 @@ async def extract_from_text(
         payload=payload,
         episode_id=episode_id,
     )
-    _bump_graph_extract_budget()
     return {"entities_upserted": entities_n, "edges_upserted": edges_n, "raw": raw}
 
 
@@ -325,6 +331,13 @@ async def extract_from_episodes(
     errors: list[str] = []
     if targets:
         scope_key = make_scope_key(bot_id=bot_id, group_id=group_id)
+        if not _reserve_graph_extract_budget(len(targets)):
+            return {
+                "episodes": len(targets),
+                "entities_upserted": 0,
+                "edges_upserted": 0,
+                "error": "daily budget exhausted",
+            }
         try:
             raw = await _call_extract_batch([t[1] for t in targets], scope_key=scope_key)
             parsed = parse_llm_json(raw)
@@ -344,18 +357,7 @@ async def extract_from_episodes(
                 total_entities += entities_n
                 total_edges += edges_n
         else:
-            logger.debug("Memory graph batch extract unreliable, falling back per-episode for scope [{}]", scope_key)
-            for ep_group_id, content, episode_id in targets:
-                result = await extract_from_text(
-                    bot_id=bot_id,
-                    group_id=ep_group_id,
-                    text=content,
-                    episode_id=episode_id,
-                )
-                total_entities += int(result.get("entities_upserted") or 0)
-                total_edges += int(result.get("edges_upserted") or 0)
-                if result.get("error"):
-                    errors.append(str(result["error"]))
+            errors.append("batch result unreliable")
 
     out: dict[str, Any] = {
         "episodes": len(targets),

--- a/pallas/product/llm/memory/graph/extract.py
+++ b/pallas/product/llm/memory/graph/extract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from nonebot import logger
@@ -56,10 +57,42 @@ _BATCH_EXTRACT_USER = """scope={scope_key}
 请按 [0],[1],[2]… 输出严格 JSON 数组。"""
 
 _EXTRACT_EPISODE_TEXT_LIMIT = 800
-_EXTRACT_COOLDOWN_SEC = 30
+# 写入后自动抽取属于后台富化而非热路径，冷却 5 分钟 + 每日预算闸控制调用量
+_EXTRACT_COOLDOWN_SEC = 300
 
 _extract_cooldown = WriteCooldown()
 _last_extract_sig: dict[tuple[int, int], str] = {}
+_graph_extract_budget_day = ""
+_graph_extract_daily_budget_used = 0
+
+
+def clear_extract_state_for_tests() -> None:
+    _extract_cooldown.clear()
+    _last_extract_sig.clear()
+    global _graph_extract_budget_day, _graph_extract_daily_budget_used
+    _graph_extract_budget_day = ""
+    _graph_extract_daily_budget_used = 0
+
+
+def _graph_extract_budget_ok() -> bool:
+    limit = int(get_llm_config().llm_memory_graph_extract_daily_budget)
+    if limit <= 0:
+        return True
+    global _graph_extract_budget_day, _graph_extract_daily_budget_used
+    today = time.strftime("%Y-%m-%d")
+    if _graph_extract_budget_day != today:
+        _graph_extract_budget_day = today
+        _graph_extract_daily_budget_used = 0
+    return _graph_extract_daily_budget_used < limit
+
+
+def _bump_graph_extract_budget() -> None:
+    global _graph_extract_budget_day, _graph_extract_daily_budget_used
+    today = time.strftime("%Y-%m-%d")
+    if _graph_extract_budget_day != today:
+        _graph_extract_budget_day = today
+        _graph_extract_daily_budget_used = 0
+    _graph_extract_daily_budget_used += 1
 
 
 def _resolve_extract_task_and_model() -> tuple[str, str]:
@@ -222,6 +255,8 @@ async def extract_from_text(
     raw_text = str(text or "").strip()
     if not raw_text:
         return {"entities_upserted": 0, "edges_upserted": 0, "error": "empty text"}
+    if not _graph_extract_budget_ok():
+        return {"entities_upserted": 0, "edges_upserted": 0, "error": "daily budget exhausted"}
     if not is_memory_graph_store_available():
         return {"entities_upserted": 0, "edges_upserted": 0, "error": "store unavailable"}
 
@@ -242,6 +277,7 @@ async def extract_from_text(
         payload=payload,
         episode_id=episode_id,
     )
+    _bump_graph_extract_budget()
     return {"entities_upserted": entities_n, "edges_upserted": edges_n, "raw": raw}
 
 
@@ -348,6 +384,8 @@ async def maybe_extract_after_episode_write(
             return
         key = (int(bot_id), int(group_id or 0))
         if _last_extract_sig.get(key) == raw_text:
+            return
+        if not _graph_extract_budget_ok():
             return
         if not _extract_cooldown.ok(key, _EXTRACT_COOLDOWN_SEC):
             return

--- a/pallas/product/llm/webui_config.py
+++ b/pallas/product/llm/webui_config.py
@@ -1023,6 +1023,16 @@ class LlmWebuiConfig(BaseModel):
             "须开启图谱抽取总开关；频繁开启会明显增加模型请求",
         ),
     )
+    llm_memory_graph_extract_daily_budget: int = Field(
+        default=200,
+        ge=0,
+        le=100000,
+        description=field_help(
+            "图谱抽取每日调用上限",
+            "按天计数，含写入后自动抽取与手动抽取；0=不限制（默认 200）",
+            "超限后当天跳过抽取，次日自动恢复",
+        ),
+    )
     llm_memory_hiergraph_max_layers: int = Field(
         default=3,
         ge=1,
@@ -1274,6 +1284,7 @@ def get_llm_webui_config() -> LlmWebuiConfig:
         llm_memory_auto_ip_cooldown_sec=cfg.llm_memory_auto_ip_cooldown_sec,
         llm_memory_graph_extract_enabled=cfg.llm_memory_graph_extract_enabled,
         llm_memory_graph_extract_on_write=cfg.llm_memory_graph_extract_on_write,
+        llm_memory_graph_extract_daily_budget=cfg.llm_memory_graph_extract_daily_budget,
         llm_memory_hiergraph_max_layers=cfg.llm_memory_hiergraph_max_layers,
         llm_memory_decay_half_life_days=cfg.llm_memory_decay_half_life_days,
         llm_memory_decay_min_importance=cfg.llm_memory_decay_min_importance,

--- a/tests/common/test_group_online_cache.py
+++ b/tests/common/test_group_online_cache.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from pallas.core.platform.multi_bot import group_online_cache as mod
@@ -70,3 +72,17 @@ async def test_forget_group_bot_removes_only_target_from_all_group_caches() -> N
     assert mod.recent_local_group_bot_ids(group_id) == [222]
     assert mod.get_cached_group_bot_ids(group_id, namespace=mod.NS_FLEET) == [222]
     assert mod.get_cached_group_bot_ids(group_id, namespace=mod.NS_LOCAL_CONNECTED) == [222]
+
+
+@pytest.mark.asyncio
+async def test_local_connected_bots_stops_when_probe_budget_is_exhausted(monkeypatch) -> None:
+    mod.clear_group_online_cache()
+    monkeypatch.setattr(mod, "_GROUP_MEMBER_PROBE_TIMEOUT_SEC", 0.01)
+
+    class HangingBot:
+        async def get_group_member_info(self, *, group_id: int, user_id: int):
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(mod, "get_bots", lambda: {"111": HangingBot(), "222": HangingBot()})
+
+    assert await mod.resolve_local_connected_bots_in_group(626266906, force_probe=True) == []

--- a/tests/common/test_shard_presence_fanout.py
+++ b/tests/common/test_shard_presence_fanout.py
@@ -152,7 +152,9 @@ def test_list_fanout_bot_ids_filters_offline(monkeypatch):
     asyncio.run(run())
 
 
-def test_list_fanout_bot_ids_uses_short_ttl_cache(monkeypatch):
+def test_list_fanout_bot_ids_uses_group_online_ttl_cache(monkeypatch):
+    from pallas.api.platform import GROUP_ONLINE_TTL_SEC
+
     fanout_mod._FANOUT_BOT_IDS_CACHE.clear()
     calls = 0
     now = 100.0
@@ -182,6 +184,7 @@ def test_list_fanout_bot_ids_uses_short_ttl_cache(monkeypatch):
 
     asyncio.run(run())
     assert calls == 1
+    assert fanout_mod._FANOUT_BOT_IDS_CACHE_TTL == GROUP_ONLINE_TTL_SEC
 
 
 def test_resolve_fanout_gate_uses_single_bot_list_lookup(monkeypatch):
@@ -189,6 +192,8 @@ def test_resolve_fanout_gate_uses_single_bot_list_lookup(monkeypatch):
     calls: list[int] = []
 
     monkeypatch.setattr(fanout_mod, "repeater_fanout_enabled", lambda: True)
+    monkeypatch.setattr(fanout_mod, "get_repeater_config", lambda: SimpleNamespace(fanout_max_bots=2))
+    monkeypatch.setattr(fanout_mod, "select_fanout_bot_ids", lambda bot_ids, *, max_bots: sorted(bot_ids))
 
     async def fake_list(group_id: int) -> list[int]:
         calls.append(group_id)

--- a/tests/platform/ingress/test_dispatch_metrics.py
+++ b/tests/platform/ingress/test_dispatch_metrics.py
@@ -27,6 +27,23 @@ def test_record_group_message_and_p95() -> None:
     assert snap["route_index_fallback_ratio"] == 0.02
 
 
+def test_record_group_message_skips_p95_when_dropped() -> None:
+    dispatch_metrics.clear_dispatch_metrics_for_tests()
+    dispatch_metrics.record_group_message_ingress(
+        duration_ms=78_000.0,
+        full_duration_ms=78_000.0,
+        command_traffic=False,
+        matchers_considered=0,
+        matchers_selected=0,
+        matchers_run=0,
+        record_p95=False,
+    )
+    snap = dispatch_metrics.dispatch_metrics_snapshot()
+    assert snap["group_messages"] == 1
+    assert snap["ingress_duration_ms_p95"] is None
+    assert snap["ingress_full_ms_p95"] is None
+
+
 def test_lane_wait_and_alerts() -> None:
     dispatch_metrics.clear_dispatch_metrics_for_tests()
     dispatch_metrics.record_lane_wait(120.0)

--- a/tests/platform/ingress/test_matcher_dispatch.py
+++ b/tests/platform/ingress/test_matcher_dispatch.py
@@ -467,6 +467,10 @@ async def test_patched_handle_event_drops_chat_when_overloaded(monkeypatch: pyte
     pre_mock = AsyncMock(return_value=True)
     post_mock = AsyncMock()
     run_matcher = AsyncMock()
+    metrics: list[dict[str, object]] = []
+
+    def _record_metrics(**kwargs: object) -> None:
+        metrics.append(kwargs)
 
     monkeypatch.setattr(dispatch, "GroupMessageEvent", FakeGroupMessageEvent)
     monkeypatch.setattr(dispatch.nb_message, "_apply_event_preprocessors", pre_mock)
@@ -479,7 +483,7 @@ async def test_patched_handle_event_drops_chat_when_overloaded(monkeypatch: pyte
     monkeypatch.setattr(dispatch, "chat_drop_on_overload_enabled", lambda: True)
     monkeypatch.setattr(dispatch, "is_overloaded", lambda: True)
     monkeypatch.setattr(dispatch, "record_chatter_overload_dropped", lambda: None)
-    monkeypatch.setattr(dispatch, "record_group_message_ingress", lambda **_kwargs: None)
+    monkeypatch.setattr(dispatch, "record_group_message_ingress", _record_metrics)
     monkeypatch.setattr(dispatch, "matchers", {1: [PassiveMatcher]})
 
     await dispatch.patched_handle_event(bot, event)
@@ -487,6 +491,8 @@ async def test_patched_handle_event_drops_chat_when_overloaded(monkeypatch: pyte
     pre_mock.assert_awaited_once()
     post_mock.assert_awaited_once()
     run_matcher.assert_not_awaited()
+    assert len(metrics) == 1
+    assert metrics[0]["record_p95"] is False
 
 
 @pytest.mark.asyncio
@@ -1058,6 +1064,10 @@ async def test_patched_handle_event_drops_stale_chat_message(monkeypatch: pytest
     post_mock = AsyncMock()
     run_matcher = AsyncMock()
     dropped = {"n": 0}
+    metrics: list[dict[str, object]] = []
+
+    def _record_metrics(**kwargs: object) -> None:
+        metrics.append(kwargs)
 
     def _bump_dropped() -> None:
         dropped["n"] += 1
@@ -1073,7 +1083,7 @@ async def test_patched_handle_event_drops_stale_chat_message(monkeypatch: pytest
     monkeypatch.setattr(dispatch, "is_overloaded", lambda: False)
     monkeypatch.setattr(dispatch, "stale_message_drop_needed", lambda _event: True)
     monkeypatch.setattr(dispatch, "record_stale_message_dropped", _bump_dropped)
-    monkeypatch.setattr(dispatch, "record_group_message_ingress", lambda **_kwargs: None)
+    monkeypatch.setattr(dispatch, "record_group_message_ingress", _record_metrics)
     monkeypatch.setattr(dispatch, "matchers", {1: [PassiveMatcher]})
 
     await dispatch.patched_handle_event(bot, event)
@@ -1082,3 +1092,5 @@ async def test_patched_handle_event_drops_stale_chat_message(monkeypatch: pytest
     pre_mock.assert_awaited_once()
     post_mock.assert_awaited_once()
     run_matcher.assert_not_awaited()
+    assert len(metrics) == 1
+    assert metrics[0]["record_p95"] is False

--- a/tests/platform/ingress/test_matcher_dispatch.py
+++ b/tests/platform/ingress/test_matcher_dispatch.py
@@ -444,6 +444,47 @@ async def test_patched_handle_event_logs_group_message_at_info(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
+async def test_patched_handle_event_escapes_non_group_event_log_for_colors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeNoticeEvent:
+        def get_log_string(self) -> str:
+            return "notice <le> payload"
+
+        def get_type(self) -> str:
+            return "notice"
+
+    class FakeLog:
+        def __init__(self) -> None:
+            self.messages: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def opt(self, **_kwargs):
+            return self
+
+        def debug(self, *args, **kwargs) -> None:
+            from loguru._colorizer import Colorizer
+
+            if args:
+                Colorizer.prepare_simple_message(str(args[0]))
+            self.messages.append((args, kwargs))
+
+        def success(self, *args, **kwargs) -> None:
+            from loguru._colorizer import Colorizer
+
+            if args:
+                Colorizer.prepare_simple_message(str(args[0]))
+            self.messages.append((args, kwargs))
+
+    log = FakeLog()
+    monkeypatch.setattr(dispatch, "GroupMessageEvent", type("OtherGroupEvent", (), {}))
+    monkeypatch.setattr(dispatch.nb_message, "logger", log)
+    monkeypatch.setattr(dispatch, "mark_activity", lambda: None)
+    monkeypatch.setattr(dispatch.nb_message, "_apply_event_preprocessors", AsyncMock(return_value=False))
+
+    await dispatch.patched_handle_event_now(MagicMock(type="Bot", self_id="1"), FakeNoticeEvent())
+
+    assert log.messages
+
+
+@pytest.mark.asyncio
 async def test_patched_handle_event_drops_chat_when_overloaded(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeGroupMessageEvent:
         group_id = 100

--- a/tests/platform/ingress/test_passive_pool.py
+++ b/tests/platform/ingress/test_passive_pool.py
@@ -60,3 +60,31 @@ async def test_pool_drops_work_when_queue_full_and_droppable() -> None:
     await first
     await pool.stop()
     assert pool.snapshot()["dropped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_pool_reports_running_work_duration_and_oldest_age() -> None:
+    pool = PassiveWorkPool("repeater", max_concurrency=1, queue_max=1, droppable=False)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work() -> None:
+        started.set()
+        await release.wait()
+
+    submit = asyncio.create_task(pool.submit(work))
+    await started.wait()
+    await asyncio.sleep(0.01)
+
+    snapshot = pool.snapshot()
+
+    assert snapshot["active"] == 1
+    assert snapshot["active_oldest_ms"] >= 10
+    assert snapshot["run_ms_p95"] is None
+
+    release.set()
+    await submit
+    await asyncio.sleep(0)
+    snapshot = pool.snapshot()
+    assert snapshot["run_ms_p95"] >= 10
+    await pool.stop()

--- a/tests/plugins/repeater/test_message_runtime_handler.py
+++ b/tests/plugins/repeater/test_message_runtime_handler.py
@@ -137,6 +137,7 @@ async def test_repeater_native_handler_handles_local_reply_without_llm(monkeypat
     )()
     refresh_cooldown = AsyncMock()
     learn = AsyncMock()
+    stage_durations: list[tuple[str, float]] = []
 
     async def build_context(_bot_id, _event):
         return type("Context", (), {"plain_body": "闲聊", "norm_raw": "闲聊", "sharding_active": False})()
@@ -154,6 +155,10 @@ async def test_repeater_native_handler_handles_local_reply_without_llm(monkeypat
         lambda *_args: type("Config", (), {"refresh_cooldown": refresh_cooldown})(),
     )
     monkeypatch.setattr("pallas.core.platform.ingress.hotpath_metrics.record_reply_local_dispatched", lambda: None)
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hotpath_metrics.record_stage_duration",
+        lambda name, duration_ms: stage_durations.append((name, duration_ms)),
+    )
 
     outcome = await handler.build_fanout_plan(_context(), bot=type("Bot", (), {"self_id": 10})(), event=event)
 
@@ -165,6 +170,14 @@ async def test_repeater_native_handler_handles_local_reply_without_llm(monkeypat
     chat.answer_from_bundle.assert_awaited_once_with(bundle)
     learn.assert_not_awaited()
     refresh_cooldown.assert_awaited_once_with("repeat")
+    assert [name for name, _duration_ms in stage_durations] == [
+        "repeater_event_gate",
+        "repeater_scrub",
+        "repeater_prepare",
+        "repeater_answer",
+        "repeater_cooldown",
+    ]
+    assert all(duration_ms >= 0 for _name, duration_ms in stage_durations)
 
     await outcome.deferred_actions[0].run()
     learn.assert_awaited_once_with(chat, event)

--- a/tests/plugins/repeater/test_message_runtime_handler.py
+++ b/tests/plugins/repeater/test_message_runtime_handler.py
@@ -183,6 +183,38 @@ async def test_repeater_native_handler_handles_local_reply_without_llm(monkeypat
     learn.assert_awaited_once_with(chat, event)
 
 
+@pytest.mark.asyncio
+async def test_repeater_native_handler_records_stage_when_prepare_raises(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from packages.repeater.message_runtime_handler import RepeaterDirectHandler
+
+    stage_durations: list[str] = []
+
+    async def build_context(_bot_id, _event):
+        return type("Context", (), {"plain_body": "闲聊", "norm_raw": "闲聊", "sharding_active": False})()
+
+    monkeypatch.setattr("packages.repeater.event_gate.build_repeater_event_context", build_context)
+    monkeypatch.setattr("pallas.product.message_scrub.is_message_scrub_blocked_async", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        "packages.repeater.reply_preparation.prepare_repeater_reply",
+        AsyncMock(side_effect=RuntimeError("prepare failed")),
+    )
+    monkeypatch.setattr(
+        "pallas.core.platform.ingress.hotpath_metrics.record_stage_duration",
+        lambda name, _duration_ms: stage_durations.append(name),
+    )
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        await RepeaterDirectHandler().build_fanout_plan(
+            _context(),
+            bot=type("Bot", (), {"self_id": 10})(),
+            event=type("Event", (), {})(),
+        )
+
+    assert stage_durations == ["repeater_event_gate", "repeater_scrub", "repeater_prepare"]
+
+
 @pytest.mark.parametrize(
     ("is_to_me", "has_bundle", "fallback_reason"),
     [

--- a/tests/product/llm/test_memory_graph_extract_budget.py
+++ b/tests/product/llm/test_memory_graph_extract_budget.py
@@ -27,7 +27,7 @@ async def test_extract_from_text_short_circuits_when_budget_exhausted(
         calls.append("called")
         raise AssertionError("LLM should not be called")
 
-    monkeypatch.setattr(extract, "_graph_extract_budget_ok", lambda: False)
+    monkeypatch.setattr(extract, "_reserve_graph_extract_budget", lambda: False)
     monkeypatch.setattr(extract, "_call_extract_llm", fail_call)
 
     result = await extract.extract_from_text(bot_id=1, group_id=2, text="随便聊点")
@@ -55,11 +55,9 @@ async def test_on_write_hook_short_circuits_when_budget_exhausted(
 
 
 @pytest.mark.asyncio
-async def test_extract_from_text_bumps_budget_after_success(
+async def test_extract_from_text_reserves_budget_before_llm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    extract.clear_extract_state_for_tests()
-
     async def ok_llm(_text, **_k):
         return '{"entities": [], "edges": []}'
 
@@ -70,9 +68,8 @@ async def test_extract_from_text_bumps_budget_after_success(
         return {"edge_id": 1}
 
     monkeypatch.setattr(extract, "is_memory_graph_store_available", lambda: True)
-    monkeypatch.setattr(extract, "_graph_extract_budget_ok", lambda: True)
-    bumps: list[int] = []
-    monkeypatch.setattr(extract, "_bump_graph_extract_budget", lambda: bumps.append(1))
+    reservations: list[int] = []
+    monkeypatch.setattr(extract, "_reserve_graph_extract_budget", lambda count=1: reservations.append(count) or True)
     monkeypatch.setattr(extract, "_call_extract_llm", ok_llm)
     monkeypatch.setattr(extract, "upsert_entity", ok_upsert_entity)
     monkeypatch.setattr(extract, "upsert_edge", ok_upsert_edge)
@@ -81,4 +78,56 @@ async def test_extract_from_text_bumps_budget_after_success(
 
     assert result["entities_upserted"] == 0
     assert result["edges_upserted"] == 0
-    assert bumps == [1]
+    assert reservations == [1]
+
+
+@pytest.mark.asyncio
+async def test_extract_from_text_keeps_reserved_budget_when_apply_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reservations: list[int] = []
+
+    async def fail_apply(**_kwargs):
+        raise RuntimeError("graph store failed")
+
+    monkeypatch.setattr(extract, "is_memory_graph_store_available", lambda: True)
+    monkeypatch.setattr(extract, "_reserve_graph_extract_budget", lambda count=1: reservations.append(count) or True)
+
+    async def ok_llm(*_args, **_kwargs):
+        return _ok_extract_result()
+
+    monkeypatch.setattr(extract, "_call_extract_llm", ok_llm)
+    monkeypatch.setattr(extract, "_apply_extraction_payload", fail_apply)
+
+    with pytest.raises(RuntimeError, match="graph store failed"):
+        await extract.extract_from_text(bot_id=1, group_id=2, text="小明约大家周六打球")
+
+    assert reservations == [1]
+
+
+def _ok_extract_result() -> str:
+    return '{"entities": [], "edges": []}'
+
+
+def test_graph_extract_budget_reserves_concurrent_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    extract.clear_extract_state_for_tests()
+    monkeypatch.setattr(
+        extract,
+        "get_llm_config",
+        lambda: type("Config", (), {"llm_memory_graph_extract_daily_budget": 1})(),
+    )
+
+    assert extract._reserve_graph_extract_budget() is True
+    assert extract._reserve_graph_extract_budget() is False
+
+
+def test_graph_extract_budget_reserves_a_batch_atomically(monkeypatch: pytest.MonkeyPatch) -> None:
+    extract.clear_extract_state_for_tests()
+    monkeypatch.setattr(
+        extract,
+        "get_llm_config",
+        lambda: type("Config", (), {"llm_memory_graph_extract_daily_budget": 2})(),
+    )
+
+    assert extract._reserve_graph_extract_budget(2) is True
+    assert extract._reserve_graph_extract_budget() is False

--- a/tests/product/llm/test_memory_graph_extract_budget.py
+++ b/tests/product/llm/test_memory_graph_extract_budget.py
@@ -1,0 +1,84 @@
+"""记忆图谱抽取的每日预算闸与降级行为。"""
+
+from __future__ import annotations
+
+import pytest
+
+from pallas.product.llm.config import LlmConfig
+from pallas.product.llm.memory.graph import extract
+
+
+def test_extract_cooldown_not_below_five_minutes() -> None:
+    assert int(extract._EXTRACT_COOLDOWN_SEC) >= 300
+
+
+def test_config_has_graph_extract_daily_budget() -> None:
+    field = LlmConfig.model_fields["llm_memory_graph_extract_daily_budget"]
+    assert field.default == 200
+
+
+@pytest.mark.asyncio
+async def test_extract_from_text_short_circuits_when_budget_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fail_call(*_a, **_k):
+        calls.append("called")
+        raise AssertionError("LLM should not be called")
+
+    monkeypatch.setattr(extract, "_graph_extract_budget_ok", lambda: False)
+    monkeypatch.setattr(extract, "_call_extract_llm", fail_call)
+
+    result = await extract.extract_from_text(bot_id=1, group_id=2, text="随便聊点")
+
+    assert result["error"] == "daily budget exhausted"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_write_hook_short_circuits_when_budget_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def fail_extract(**_kwargs):
+        calls.append("called")
+        return {"entities_upserted": 1, "edges_upserted": 0}
+
+    monkeypatch.setattr(extract, "_graph_extract_budget_ok", lambda: False)
+    monkeypatch.setattr(extract, "extract_from_text", fail_extract)
+
+    await extract.maybe_extract_after_episode_write(bot_id=1, group_id=2, text="今天一起喝了奶茶")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_extract_from_text_bumps_budget_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    extract.clear_extract_state_for_tests()
+
+    async def ok_llm(_text, **_k):
+        return '{"entities": [], "edges": []}'
+
+    async def ok_upsert_entity(**_kwargs):
+        return {"entity_id": 1}
+
+    async def ok_upsert_edge(**_kwargs):
+        return {"edge_id": 1}
+
+    monkeypatch.setattr(extract, "is_memory_graph_store_available", lambda: True)
+    monkeypatch.setattr(extract, "_graph_extract_budget_ok", lambda: True)
+    bumps: list[int] = []
+    monkeypatch.setattr(extract, "_bump_graph_extract_budget", lambda: bumps.append(1))
+    monkeypatch.setattr(extract, "_call_extract_llm", ok_llm)
+    monkeypatch.setattr(extract, "upsert_entity", ok_upsert_entity)
+    monkeypatch.setattr(extract, "upsert_edge", ok_upsert_edge)
+
+    result = await extract.extract_from_text(bot_id=1, group_id=2, text="小明约大家周六打球")
+
+    assert result["entities_upserted"] == 0
+    assert result["edges_upserted"] == 0
+    assert bumps == [1]


### PR DESCRIPTION
本 PR 将 dev 当前全部 6 个提交合入 main。

- 修正入站 P95 丢弃样本统计语义
- 增加入站调度、passive repeater 及 repeater 阶段耗时观测
- 为群在线 Bot 探测增加总预算并统一缓存 TTL
- 暴露入站诊断指标所需的控制台 OpenAPI 字段
- 为记忆图谱抽取增加每日预算闸并调整冷却策略

WebUI 所需的最低 Bot commit 已在本分支历史中。

## Sourcery 摘要

改进入口分发的可观测性和资源控制，同时新增带预算的记忆图谱提取功能，并增强 Bot 在线状态探测的容错能力。

新功能：
- 通过控制台 OpenAPI 模型公开入口分发热路径和会话调度器遥测数据。
- 为记忆图谱提取添加可配置的每日预算，并在 WebUI 配置中提供该设置。
- 为群组在线 Bot 发现添加有界且一致的缓存和超时行为。

Bug 修复：
- 将分发前被丢弃的消息排除在入口 P95 延迟采样之外。
- 防止不安全的事件日志格式化内容被解析为控制台颜色标记。

增强功能：
- 添加重复器和被动池的执行耗时、活跃时长以及调度器状态指标。
- 延长自动记忆图谱提取的冷却时间，以降低后台请求频率。

测试：
- 增加对入口 P95 排除逻辑、被动池遥测数据、群组在线探测预算、重复器阶段指标以及记忆图谱提取预算的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

增强入站调度的可观测性与资源约束，并为记忆图谱抽取和群组 Bot 探测引入可控预算机制。

新功能：
- 为入站调度诊断开放热路径、会话调度器及被动任务池遥测字段。
- 为记忆图谱抽取增加可配置的每日调用预算，并纳入 WebUI 配置。
- 为群组在线 Bot 探测增加统一缓存 TTL、总超时预算和受控的缓存时效配置。

错误修复：
- 修正入站 P95 延迟统计，排除分发前已丢弃的消息。
- 避免事件日志内容被误解析为控制台颜色标记。

改进：
- 补充复读器各阶段耗时、被动任务池运行耗时与活跃任务年龄等调度观测指标。
- 延长自动记忆图谱抽取冷却时间，并在批量结果不可靠时停止无界回退调用。

测试：
- 增加入站延迟采样、在线 Bot 探测预算、被动任务池和复读阶段遥测、记忆图谱预算及日志安全处理的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

增强入站调度的可观测性与资源约束，并为记忆图谱抽取和群组 Bot 探测引入可控预算机制。

New Features:
- 为入站调度诊断开放热路径、会话调度器及被动任务池遥测字段。
- 为记忆图谱抽取增加可配置的每日调用预算，并纳入 WebUI 配置。
- 为群组在线 Bot 探测增加统一缓存 TTL、总超时预算和受控的缓存时效配置。

Bug Fixes:
- 修正入站 P95 延迟统计，排除分发前已丢弃的消息。
- 避免事件日志内容被误解析为控制台颜色标记。

Enhancements:
- 补充复读器各阶段耗时、被动任务池运行耗时与活跃任务年龄等调度观测指标。
- 延长自动记忆图谱抽取冷却时间，并在批量结果不可靠时停止无界回退调用。

Tests:
- 增加入站延迟采样、在线 Bot 探测预算、被动任务池和复读阶段遥测、记忆图谱预算及日志安全处理的测试覆盖。

</details>

</details>