### PR TITLE
fix(test): 隔离 common 测试全局状态

### DIFF
--- a/pallas/core/foundation/config/bot_admins_cache.py
+++ b/pallas/core/foundation/config/bot_admins_cache.py
@@ -27,8 +27,6 @@ _any_bot_admin_fetch_task: asyncio.Task[frozenset[int]] | None = None
 _any_bot_admin_fetch_lock = asyncio.Lock()
 _any_bot_admin_db_fail_until: float = 0.0
 
-_repo = make_bot_config_repository()
-
 
 def mark_bot_admins_db_fail(bot_id: int) -> None:
     _admins_db_fail_until[int(bot_id)] = time.monotonic() + _BOT_ADMINS_DB_FAIL_TTL_SEC
@@ -95,7 +93,7 @@ async def _load_admins_db(bot_id: int) -> list[int]:
     if pg_pool_under_pressure(threshold=0.55):
         return []
     try:
-        doc = await _repo.get(bot_id)
+        doc = await make_bot_config_repository().get(bot_id)
     except Exception as exc:
         if is_pg_pool_timeout_error(exc):
             mark_bot_admins_db_fail(bot_id)

--- a/pallas/core/platform/shard/ingress_metrics.py
+++ b/pallas/core/platform/shard/ingress_metrics.py
@@ -35,6 +35,13 @@ def _rollover_if_needed() -> None:
         _state[k] = 0
 
 
+def clear_ingress_metrics_for_tests() -> None:
+    global _day_key
+    _day_key = ""
+    for key in _COUNTERS:
+        _state[key] = 0
+
+
 def should_record_ingress_metrics(bot_id: int) -> bool:
     """分片 worker 仅代表牛记数；unified 仅最小 QQ 记数，避免多连接重复放大。"""
     from pallas.core.platform.multi_bot.fleet import get_fleet_bot_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+# 目录树无 __init__.py，同名测试文件（test_direct/test_service/test_runtime 等）在 prepend 模式下
+# 模块名冲突导致全量收集报 import file mismatch；importlib 模式按文件路径唯一导入。
+addopts = ["--import-mode=importlib"]

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -20,6 +20,118 @@ PG_TEST_DSN = os.getenv("PG_TEST_DSN")
 _ROOT = Path(__file__).resolve().parents[2]
 
 
+@pytest.fixture(autouse=True)
+def _reset_common_runtime_state():
+    """隔离 common 测试使用的进程级缓存和动态导入模块。"""
+    original_env = os.environ.copy()
+    from nonebot import matcher as nb_matcher
+
+    from pallas.core.platform.multi_bot import dedup
+    from pallas.core.platform.shard import ingress_metrics
+    from pallas.core.platform.shard.coord import repeater_buffer, repeater_reply_buffer
+    from pallas.core.platform.shard.registry import config as shard_config
+    from pallas.core.platform.shard.registry import store as shard_store
+
+    original_matchers = {priority: list(items) for priority, items in nb_matcher.matchers.items()}
+    repeater_buffer._seen_event_ids.clear()
+    repeater_buffer._seen_set.clear()
+    repeater_reply_buffer._seen_event_ids.clear()
+    repeater_reply_buffer._seen_set.clear()
+    nb_matcher.matchers.clear()
+    dedup._cross_bot_claim_owners.clear()
+    dedup._shard_ingress_file_locks.clear()
+    dedup._group_message_once_keys.clear()
+    dedup._group_message_once_order.clear()
+    dedup._group_event_sigs.clear()
+    dedup._group_event_sig_set.clear()
+    ingress_metrics.clear_ingress_metrics_for_tests()
+    shard_store.clear_shard_registry_cache()
+    shard_config.get_shard_registry_settings.cache_clear()
+    yield
+    for key in set(os.environ) - set(original_env):
+        del os.environ[key]
+    os.environ.update(original_env)
+    repeater_buffer._seen_event_ids.clear()
+    repeater_buffer._seen_set.clear()
+    repeater_reply_buffer._seen_event_ids.clear()
+    repeater_reply_buffer._seen_set.clear()
+    nb_matcher.matchers.clear()
+    nb_matcher.matchers.update({priority: list(items) for priority, items in original_matchers.items()})
+    dedup._cross_bot_claim_owners.clear()
+    dedup._shard_ingress_file_locks.clear()
+    dedup._group_message_once_keys.clear()
+    dedup._group_message_once_order.clear()
+    dedup._group_event_sigs.clear()
+    dedup._group_event_sig_set.clear()
+    ingress_metrics.clear_ingress_metrics_for_tests()
+    shard_store.clear_shard_registry_cache()
+    shard_config.get_shard_registry_settings.cache_clear()
+
+
+@pytest.fixture
+def isolated_nonebot_plugin_state():
+    """隔离会实际加载 NoneBot 插件的测试，并恢复原模块身份。"""
+    from nonebot import matcher as nb_matcher
+    from nonebot import plugin as nb_plugin
+    from nonebot.plugin import manager as nb_manager
+
+    def is_plugin_module(name: str) -> bool:
+        return name == "packages" or name.startswith(("packages.", "nonebot_plugin_apscheduler", "pallas_plugin_"))
+
+    module_snapshot = {name: module for name, module in sys.modules.items() if is_plugin_module(name)}
+    parent_attrs: dict[tuple[str, str], tuple[bool, object | None]] = {}
+    for name in module_snapshot:
+        parent_name, _, child_name = name.rpartition(".")
+        if not parent_name or parent_name not in module_snapshot:
+            continue
+        parent = module_snapshot[parent_name]
+        if hasattr(parent, child_name):
+            parent_attrs[(parent_name, child_name)] = (True, getattr(parent, child_name))
+        else:
+            parent_attrs[(parent_name, child_name)] = (False, None)
+    saved_plugins = dict(nb_plugin._plugins)
+    saved_managers = list(nb_plugin._managers)
+    saved_matchers = {priority: list(items) for priority, items in nb_matcher.matchers.items()}
+    saved_current_plugin = nb_manager._current_plugin.get()
+
+    def clear_plugin_state() -> None:
+        nb_plugin._plugins.clear()
+        nb_plugin._managers.clear()
+        nb_manager._current_plugin.set(None)
+
+    def remove_plugin_modules() -> None:
+        for name in list(sys.modules):
+            if not is_plugin_module(name):
+                continue
+            module = sys.modules.pop(name)
+            parent_name, _, child_name = name.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None and getattr(parent, child_name, None) is module:
+                delattr(parent, child_name)
+
+    clear_plugin_state()
+    remove_plugin_modules()
+    try:
+        yield
+    finally:
+        clear_plugin_state()
+        remove_plugin_modules()
+        sys.modules.update(module_snapshot)
+        for (parent_name, child_name), (exists, value) in parent_attrs.items():
+            parent = sys.modules.get(parent_name)
+            if parent is None:
+                continue
+            if exists:
+                setattr(parent, child_name, value)
+            elif hasattr(parent, child_name):
+                delattr(parent, child_name)
+        nb_plugin._plugins.update(saved_plugins)
+        nb_plugin._managers.extend(saved_managers)
+        nb_manager._current_plugin.set(saved_current_plugin)
+        nb_matcher.matchers.clear()
+        nb_matcher.matchers.update({priority: list(items) for priority, items in saved_matchers.items()})
+
+
 @pytest.fixture
 async def pg_engine():
     """

--- a/tests/common/multi_bot/test_session_seen.py
+++ b/tests/common/multi_bot/test_session_seen.py
@@ -15,7 +15,7 @@ def test_note_and_load_cluster_seen(tmp_path, monkeypatch):
         "plugin_data_dir",
         lambda name, create=False: shard_dir if name == "pallas_shard" else tmp_path,
     )
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(fleet_mod, "get_enabled_protocol_bot_ids", lambda: frozenset({111, 222}))
 
     mod.note_cluster_session_seen_sync(qq=111)
@@ -31,7 +31,7 @@ def test_note_and_load_cluster_seen(tmp_path, monkeypatch):
 def test_unified_session_seen_from_fleet_memory(monkeypatch):
     from pallas.core.platform.multi_bot import fleet as fleet_mod
 
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: False)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: False)
     monkeypatch.setattr(fleet_mod, "get_enabled_protocol_bot_ids", lambda: frozenset({999}))
     fleet_mod.invalidate_fleet_bot_cache()
     fleet_mod.note_fleet_bot_session_connected(999)
@@ -42,7 +42,7 @@ def test_unified_session_seen_from_fleet_memory(monkeypatch):
 def test_session_seen_intersects_enabled_protocol(monkeypatch):
     from pallas.core.platform.multi_bot import fleet as fleet_mod
 
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: False)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: False)
     monkeypatch.setattr(fleet_mod, "get_enabled_protocol_bot_ids", lambda: frozenset({100}))
     fleet_mod._session_connected.clear()
     fleet_mod.note_fleet_bot_session_connected(100)

--- a/tests/common/shard/coord/test_maa_route_registry.py
+++ b/tests/common/shard/coord/test_maa_route_registry.py
@@ -2,7 +2,7 @@ from pallas.core.platform.shard.coord import maa_route_registry as reg
 
 
 def test_register_and_resolve_user_route(fake_coord_redis, monkeypatch) -> None:
-    monkeypatch.setattr(reg, "is_sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: True)
     monkeypatch.setattr(
         reg,
         "get_shard_registry_settings",
@@ -18,14 +18,20 @@ def test_register_and_resolve_user_route(fake_coord_redis, monkeypatch) -> None:
 
 
 def test_resolve_worker_port_falls_back_to_shard_registry(fake_coord_redis, monkeypatch) -> None:
-    monkeypatch.setattr(reg, "is_sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: True)
 
     class _Reg:
         def shard_for_bot(self, bot_id: str):
             return 1 if bot_id == "123456789" else None
 
-    monkeypatch.setattr(reg, "get_shard_registry", lambda: _Reg())
-    monkeypatch.setattr(reg, "worker_port_for_shard", lambda sid, registry=None: 8091 if sid == 1 else 8090)
+    monkeypatch.setattr(
+        "pallas.extensions.coord.maa.route_registry.get_shard_registry",
+        lambda: _Reg(),
+    )
+    monkeypatch.setattr(
+        "pallas.extensions.coord.maa.route_registry.worker_port_for_shard",
+        lambda sid, registry=None: 8091 if sid == 1 else 8090,
+    )
 
     assert reg.resolve_worker_port_for_maa_user("123456789") == 8091
     assert reg.resolve_worker_port_for_maa_user("999999999") is None

--- a/tests/common/test_bot_version.py
+++ b/tests/common/test_bot_version.py
@@ -64,7 +64,7 @@ def test_build_heartbeat_payload_uses_runtime_version():
             "pallas.product.community_stats.reporter.load_or_create_deployment_id",
             return_value="550e8400-e29b-41d4-a716-446655440000",
         ),
-        patch("pallas.product.community_stats.reporter.is_sharding_active", return_value=False),
+        patch("pallas.core.platform.shard.context.sharding_active", return_value=False),
     ):
         payload = build_heartbeat_payload()
     assert payload["version"] == "v3.1.0"

--- a/tests/common/test_community_stats.py
+++ b/tests/common/test_community_stats.py
@@ -396,6 +396,7 @@ def test_register_apscheduler_startup_hook_idempotent():
     stub = MagicMock()
     with (
         patch.object(mod, "get_driver", return_value=mock_driver),
+        patch.object(mod, "get_plugin", return_value=stub),
         patch.dict(sys.modules, {"nonebot_plugin_apscheduler": stub}),
     ):
         register_apscheduler_startup_hook()

--- a/tests/common/test_ingress_gate_unified.py
+++ b/tests/common/test_ingress_gate_unified.py
@@ -12,7 +12,7 @@ from pallas.core.platform.shard.registry import config as shard_cfg
 
 @pytest.mark.asyncio
 async def test_unified_ingress_once_discards_second_bot(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr(
@@ -49,7 +49,7 @@ async def test_unified_ingress_once_discards_second_bot(monkeypatch: pytest.Monk
 
 @pytest.mark.asyncio
 async def test_unified_ingress_fanout_allows_all_bots(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr(
@@ -82,7 +82,7 @@ async def test_unified_ingress_fanout_allows_all_bots(monkeypatch: pytest.Monkey
 
 @pytest.mark.asyncio
 async def test_group_admin_owner_blocks_before_fanout_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr(
@@ -115,7 +115,7 @@ async def test_group_admin_owner_blocks_before_fanout_bypass(monkeypatch: pytest
 async def test_group_admin_owner_falls_back_to_fanout_when_observation_is_unknown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr(
@@ -171,7 +171,7 @@ async def test_group_admin_notice_ignores_non_local_bot(monkeypatch: pytest.Monk
 
 @pytest.mark.asyncio
 async def test_unified_ingress_fanout_skips_federate_and_once_claim(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     federate = AsyncMock(return_value=True)
@@ -206,7 +206,7 @@ async def test_unified_ingress_fanout_skips_federate_and_once_claim(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_unified_ingress_pallas_status_uses_local_claim_without_federate(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
@@ -252,7 +252,7 @@ async def test_unified_ingress_pallas_status_uses_local_claim_without_federate(m
 
 @pytest.mark.asyncio
 async def test_unified_ingress_bypass_skips_federate_claim(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_fanout_bypasses_claim", lambda _plain: False)
@@ -306,7 +306,7 @@ def test_group_at_qq_ids_falls_back_to_raw_message_when_at_segment_missing() -> 
 
 @pytest.mark.asyncio
 async def test_unified_ingress_discards_federate_peer_bot_before_claims(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda uid: int(uid) == 777)
@@ -344,7 +344,7 @@ async def test_unified_ingress_discards_federate_peer_bot_before_claims(monkeypa
 async def test_unified_ingress_non_owner_deployment_skips_command_once_and_federate_claim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
@@ -388,7 +388,7 @@ async def test_unified_ingress_yields_peer_covered_command_even_if_not_local_com
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """本机未装决斗插件时不认「牛牛决斗」为本地命令，但仍须让给有能力的对端，不得抢 federate claim。"""
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
@@ -432,7 +432,7 @@ async def test_unified_ingress_peer_declared_command_skips_owner_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """本机未装画画、但对端显式宣告了牛牛画画时，本机识别为命令流量并让出，不得抢 federate claim。"""
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
@@ -493,7 +493,7 @@ def test_command_lane_traffic_combines_local_and_peer_declared(monkeypatch: pyte
 async def test_unified_ingress_non_owner_still_claims_chat_traffic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.federate_peer_bot_ids_contains", lambda _uid: False)
@@ -535,7 +535,7 @@ async def test_unified_ingress_non_owner_still_claims_chat_traffic(
 async def test_unified_ingress_reuses_precomputed_plain_for_federate_claim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_fanout_bypasses_claim", lambda _plain: False)
@@ -573,7 +573,7 @@ async def test_unified_ingress_reuses_precomputed_plain_for_federate_claim(
 
 @pytest.mark.asyncio
 async def test_unified_ingress_only_allows_at_target_bot(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.get_fleet_bot_ids", lambda: frozenset({111, 222}))
@@ -611,7 +611,7 @@ async def test_unified_ingress_only_allows_at_target_bot(monkeypatch: pytest.Mon
 
 @pytest.mark.asyncio
 async def test_unified_ingress_at_target_skips_federate_claim(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.get_fleet_bot_ids", lambda: frozenset({111}))
@@ -646,7 +646,7 @@ async def test_unified_ingress_at_target_skips_federate_claim(monkeypatch: pytes
 
 @pytest.mark.asyncio
 async def test_unified_ingress_at_target_command_skips_federate_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.get_fleet_bot_ids", lambda: frozenset({111}))
@@ -690,7 +690,7 @@ async def test_unified_ingress_at_target_command_skips_federate_ownership(monkey
 
 @pytest.mark.asyncio
 async def test_unified_ingress_discards_self_sent_message_before_claims(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     once = AsyncMock(return_value=True)
     federate = AsyncMock(return_value=True)
@@ -722,7 +722,7 @@ async def test_unified_ingress_discards_self_sent_message_before_claims(monkeypa
 
 @pytest.mark.asyncio
 async def test_unified_ingress_marks_winning_alias_for_llm_chat(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(shard_cfg, "is_sharding_active", lambda: False)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: False)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.ingress_gate_active", lambda: True)
     monkeypatch.setattr("pallas.core.platform.ingress.gate.fleet_bot_ids_contains", lambda _uid: False)
     monkeypatch.setattr(

--- a/tests/common/test_llm_session_store_mongo.py
+++ b/tests/common/test_llm_session_store_mongo.py
@@ -46,6 +46,7 @@ async def test_mongo_llm_session_user_window_and_ambient(beanie_fixture, monkeyp
     cfg = LlmConfig(
         llm_session_enabled=True,
         llm_session_user_window=2,
+        llm_session_user_storage_window=2,
         llm_session_group_window=2,
         llm_session_user_ttl_sec=0,
     )

--- a/tests/common/test_plugin_loader_scheduler.py
+++ b/tests/common/test_plugin_loader_scheduler.py
@@ -31,7 +31,7 @@ def test_clear_poisoned_apscheduler_import_removes_unregistered_module():
         sys.modules.pop("nonebot_plugin_apscheduler", None)
 
 
-def test_load_apscheduler_plugin_first_recovers_from_poisoned_preimport():
+def test_load_apscheduler_plugin_first_recovers_from_poisoned_preimport(isolated_nonebot_plugin_state):
     nonebot.init()
     stub = types.ModuleType("nonebot_plugin_apscheduler")
     sys.modules["nonebot_plugin_apscheduler"] = stub

--- a/tests/common/test_plugin_loader_unified.py
+++ b/tests/common/test_plugin_loader_unified.py
@@ -77,7 +77,10 @@ def test_discover_plugin_modules_auto_skips_extra_when_pip_installed(monkeypatch
     assert "duel" not in names
 
 
-def test_unified_role_loads_core_and_skips_shard_only(monkeypatch: pytest.MonkeyPatch):
+def test_unified_role_loads_core_and_skips_shard_only(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_nonebot_plugin_state,
+):
     monkeypatch.delenv("PALLAS_SHARD_ENABLED", raising=False)
     monkeypatch.delenv("PALLAS_BOT_ROLE", raising=False)
     monkeypatch.setenv("PALLAS_LOAD_BUNDLED_EXTRA", "1")
@@ -103,7 +106,7 @@ def test_unified_role_slim_skips_bundled_extra(monkeypatch: pytest.MonkeyPatch):
     assert "draw" not in names
 
 
-def test_worker_role_skips_maa_hub(monkeypatch: pytest.MonkeyPatch):
+def test_worker_role_skips_maa_hub(monkeypatch: pytest.MonkeyPatch, isolated_nonebot_plugin_state):
     if not (_PACKAGES / "maa").is_dir():
         pytest.skip("maa 未捆绑于 4.0 slim packages/")
     monkeypatch.setenv("PALLAS_SHARD_ENABLED", "true")
@@ -119,7 +122,10 @@ def test_worker_role_skips_maa_hub(monkeypatch: pytest.MonkeyPatch):
     assert "maa" in loaded
 
 
-def test_register_kernel_runtime_does_not_preimport_repeater_plugin(monkeypatch: pytest.MonkeyPatch):
+def test_register_kernel_runtime_does_not_preimport_repeater_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_nonebot_plugin_state,
+):
     from pallas.core.platform.ai_callback import http as callback_http
     from pallas.core.platform.bot_runtime import kernel_runtime
 
@@ -139,7 +145,10 @@ def test_register_kernel_runtime_does_not_preimport_repeater_plugin(monkeypatch:
     assert "packages.repeater" not in sys.modules
 
 
-def test_register_kernel_runtime_does_not_preimport_pb_webui_plugin(monkeypatch: pytest.MonkeyPatch):
+def test_register_kernel_runtime_does_not_preimport_pb_webui_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_nonebot_plugin_state,
+):
     from pallas.core.platform.ai_callback import http as callback_http
     from pallas.core.platform.bot_runtime import kernel_runtime
 

--- a/tests/common/test_redis_claim.py
+++ b/tests/common/test_redis_claim.py
@@ -42,7 +42,7 @@ def test_try_claim_message_sharding_does_not_fall_back_to_file(tmp_path, monkeyp
     monkeypatch.setattr(rc, "try_claim_message_redis_sync", lambda *a, **k: None)
     monkeypatch.setattr(claim_mod, "plugin_data_dir", lambda plugin, create=True: tmp_path / plugin)
     monkeypatch.setattr(
-        "pallas.core.platform.shard.registry.config.is_sharding_active",
+        "pallas.core.platform.shard.context.sharding_active",
         lambda: True,
     )
     assert claim_mod.try_claim_message_sync("p", 1, 2, 100) is False
@@ -51,7 +51,7 @@ def test_try_claim_message_sharding_does_not_fall_back_to_file(tmp_path, monkeyp
 
 def test_coord_redis_required_when_sharding(monkeypatch):
     monkeypatch.setattr(
-        "pallas.core.platform.shard.registry.config.is_sharding_active",
+        "pallas.core.platform.shard.context.sharding_active",
         lambda: True,
     )
     monkeypatch.setattr(rs, "coord_redis_enabled", lambda: False)

--- a/tests/common/test_repeater_reply_buffer.py
+++ b/tests/common/test_repeater_reply_buffer.py
@@ -28,7 +28,7 @@ def test_publish_reply_record_skips_coord_when_placeholder():
         "pallas.core.platform.shard.coord.repeater_reply_buffer.schedule_publish_repeater_reply_record",
         MagicMock(),
     ) as mock_schedule:
-        with patch("pallas.core.platform.shard.registry.config.is_sharding_active", return_value=True):
+        with patch("pallas.core.platform.shard.context.sharding_active", return_value=True):
             publish_reply_record(1, 2, {"reply": Chat.REPLY_FLAG, "reply_keywords": Chat.REPLY_FLAG})
     mock_schedule.assert_not_called()
 

--- a/tests/common/test_repository_protocol.py
+++ b/tests/common/test_repository_protocol.py
@@ -38,10 +38,28 @@ class MockContextRepo(ContextRepositoryExistenceMixin):
     async def find_ban_reply_target(self, group_id, reply_message):
         return None
 
+    async def list_answers_for_group_since(self, group_id, cutoff_time):
+        return []
+
 
 class MockMessageRepo:
     async def bulk_insert(self, messages):
         pass
+
+    async def find_recent_in_group(self, group_id, **kwargs):
+        return []
+
+    async def find_by_message_ids(self, group_id, message_ids):
+        return []
+
+    async def list_group_messages_after(self, group_id, **kwargs):
+        return []
+
+    async def list_recent_group_ids_for_bot(self, bot_id, **kwargs):
+        return []
+
+    async def list_recent_bot_ids_for_group(self, group_id, **kwargs):
+        return []
 
 
 class MockBlackListRepo:

--- a/tests/common/test_shard_coord_group_activity.py
+++ b/tests/common/test_shard_coord_group_activity.py
@@ -6,7 +6,7 @@ from pallas.core.platform.shard.coord import group_activity as mod
 
 
 def test_group_activity_lock_exclusive(fake_coord_redis, monkeypatch) -> None:
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(
         mod,
         "get_shard_registry_settings",
@@ -21,7 +21,7 @@ def test_group_activity_lock_exclusive(fake_coord_redis, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_begin_group_activity_reclaims_orphan(fake_coord_redis, monkeypatch) -> None:
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(
         mod,
         "get_shard_registry_settings",

--- a/tests/common/test_shard_ingress_metrics.py
+++ b/tests/common/test_shard_ingress_metrics.py
@@ -35,7 +35,7 @@ def test_ingress_metrics_snapshot_and_merge():
 
 def test_should_record_ingress_metrics_unified(monkeypatch):
     monkeypatch.setattr(
-        "pallas.core.platform.shard.registry.config.is_sharding_active",
+        "pallas.core.platform.shard.context.sharding_active",
         lambda: False,
     )
     monkeypatch.setattr(
@@ -48,7 +48,7 @@ def test_should_record_ingress_metrics_unified(monkeypatch):
 
 def test_should_record_ingress_metrics_unified_empty_fleet(monkeypatch):
     monkeypatch.setattr(
-        "pallas.core.platform.shard.registry.config.is_sharding_active",
+        "pallas.core.platform.shard.context.sharding_active",
         lambda: False,
     )
     monkeypatch.setattr(
@@ -60,7 +60,7 @@ def test_should_record_ingress_metrics_unified_empty_fleet(monkeypatch):
 
 def test_should_record_ingress_metrics_shard_rep(monkeypatch):
     monkeypatch.setattr(
-        "pallas.core.platform.shard.registry.config.is_sharding_active",
+        "pallas.core.platform.shard.context.sharding_active",
         lambda: True,
     )
     monkeypatch.setattr(

--- a/tests/common/test_shard_pg_pool_estimate.py
+++ b/tests/common/test_shard_pg_pool_estimate.py
@@ -11,7 +11,7 @@ def test_pg_pool_estimate_no_warn_at_28_times_9(monkeypatch):
         "pallas.core.foundation.config.repo_settings.repo_env_raw_value",
         fake_env,
     )
-    monkeypatch.setattr("pallas.core.platform.shard.observability.is_sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: True)
     monkeypatch.setattr(
         "pallas.core.platform.shard.observability.get_shard_registry",
         lambda: type("R", (), {"shards": list(range(8))})(),
@@ -29,7 +29,7 @@ def test_pg_pool_estimate_warns_when_oversized(monkeypatch):
         "pallas.core.foundation.config.repo_settings.repo_env_raw_value",
         fake_env,
     )
-    monkeypatch.setattr("pallas.core.platform.shard.observability.is_sharding_active", lambda: True)
+    monkeypatch.setattr("pallas.core.platform.shard.context.sharding_active", lambda: True)
     monkeypatch.setattr(
         "pallas.core.platform.shard.observability.get_shard_registry",
         lambda: type("R", (), {"shards": [1, 2, 3, 4, 5, 6, 7, 8]})(),

--- a/tests/common/test_shard_presence.py
+++ b/tests/common/test_shard_presence.py
@@ -19,7 +19,7 @@ def force_file_presence(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_presence_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     mod.note_worker_bot_connected_sync(qq=111, connection_key="111", adapter="OneBot V11", shard_id=0)
     mod.note_worker_bot_connected_sync(qq=222, connection_key="222", adapter="OneBot V11", shard_id=1)
@@ -38,7 +38,7 @@ def test_presence_roundtrip(tmp_path, monkeypatch):
 
 def test_presence_stale_pruned(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     mod.note_worker_bot_connected_sync(qq=333, connection_key="333", adapter="OneBot V11", shard_id=0)
     path = mod._presence_path()
@@ -88,7 +88,7 @@ def test_presence_redis_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(rp, "get_presence_redis_client", lambda: client)
     monkeypatch.setattr(rp, "presence_uses_redis_only", lambda: True)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(mod, "_read_file_bots", dict)
 
     mod.note_worker_bot_connected_sync(qq=111, connection_key="111", adapter="OneBot V11", shard_id=0)
@@ -100,7 +100,7 @@ def test_presence_redis_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_presence_imports_file_when_redis_empty(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     mod.note_worker_bot_connected_sync(qq=444, connection_key="444", adapter="OneBot V11", shard_id=2)
     file_bots = mod._read_file_bots()
@@ -148,7 +148,7 @@ def test_reconcile_redis_upserts_missing_local_bot(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(rp, "get_presence_redis_client", lambda: client)
     monkeypatch.setattr(rp, "presence_uses_redis_only", lambda: True)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(mod, "_read_file_bots", dict)
 
     rp.note_worker_bot_connected_redis_sync(
@@ -171,7 +171,7 @@ def test_reconcile_redis_upserts_missing_local_bot(monkeypatch: pytest.MonkeyPat
 
 def test_reconcile_file_upserts_missing_local_bot(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     mod.note_worker_bot_connected_sync(qq=222, connection_key="222", adapter="OneBot V11", shard_id=1)
     mod.reconcile_local_worker_presence_sync(shard_id=0, local_qq_ids={111})
@@ -185,7 +185,7 @@ def test_reconcile_file_upserts_missing_local_bot(tmp_path, monkeypatch: pytest.
 
 def test_protocol_offline_clears_presence_and_blocks_reconcile(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     mod.clear_protocol_bot_offline_sync(qq=111)
 
     mod.note_worker_bot_connected_sync(qq=111, connection_key="111", adapter="OneBot V11", shard_id=0)
@@ -206,7 +206,7 @@ def test_protocol_offline_clears_presence_and_blocks_reconcile(tmp_path, monkeyp
 
 def test_touch_missing_presence_does_not_write_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     writes: list[dict[str, object]] = []
     real_write = mod._write_atomic
@@ -225,7 +225,7 @@ def test_touch_missing_presence_does_not_write_file(tmp_path, monkeypatch: pytes
 
 def test_disconnect_missing_presence_does_not_write_file(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "plugin_data_dir", lambda name, create=True: tmp_path / name)
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
 
     writes: list[dict[str, object]] = []
     real_write = mod._write_atomic
@@ -244,7 +244,7 @@ def test_disconnect_missing_presence_does_not_write_file(tmp_path, monkeypatch: 
 
 @pytest.mark.asyncio
 async def test_note_worker_bot_connected_does_not_call_login_info(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(mod, "is_sharding_active", lambda: True)
+    monkeypatch.setattr(mod.shard_ctx, "sharding_active", lambda: True)
     monkeypatch.setattr(mod, "get_shard_registry_settings", lambda: SimpleNamespace(shard_id=7))
 
     captured: dict[str, object] = {}

--- a/tests/common/test_shared_mail.py
+++ b/tests/common/test_shared_mail.py
@@ -8,7 +8,8 @@ from pallas.core.shared.utils import mail as mail_mod
 
 def _isolate_env(monkeypatch, env: dict[str, str]) -> None:
     """让 SmtpConfig 只从给定 env 读取（屏蔽磁盘 .env 合并值）。"""
-    monkeypatch.setattr(repo_settings, "merged_repo_settings_upper", dict)
+    monkeypatch.setattr(repo_settings, "merged_repo_settings_upper", lambda: dict(env))
+    monkeypatch.setattr("pallas.console.webui.plugin_config.repo_env_raw_value", lambda key: env.get(key))
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     mail_mod.clear_smtp_config_cache()

--- a/tests/common/test_sync_docs_to_web_links.py
+++ b/tests/common/test_sync_docs_to_web_links.py
@@ -30,7 +30,7 @@ FILE_MAP = _MOD.FILE_MAP
         ),
         (
             "[docker](../../../DockerDeployment.md)",
-            "[docker](/deploy/docker)",
+            "[docker](/maintainer/deploy/docker)",
         ),
         (
             "[stats](../community_stats.md)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,3 +113,19 @@ def pytest_configure(config):  # noqa: ARG001
     except ValueError:
         # Not initialized, so initialize it
         nonebot.init()
+
+
+@pytest.fixture(autouse=True)
+def _reset_nonebot_plugin_registry():
+    """恢复测试期间变更的 NoneBot 插件注册状态。"""
+    from nonebot import plugin as nb_plugin
+    from nonebot.plugin import manager as nb_manager
+
+    saved_plugins = dict(nb_plugin._plugins)
+    saved_managers = list(nb_plugin._managers)
+    saved_current_plugin = nb_manager._current_plugin.get()
+    yield
+    nb_plugin._plugins.clear()
+    nb_plugin._plugins.update(saved_plugins)
+    nb_plugin._managers[:] = saved_managers
+    nb_manager._current_plugin.set(saved_current_plugin)

--- a/tests/platform/message_runtime/test_runtime.py
+++ b/tests/platform/message_runtime/test_runtime.py
@@ -211,7 +211,7 @@ async def test_native_handler_error_is_classified_without_logging_message_conten
         error_class="RuntimeError",
     )
     logger.warning.assert_called_once_with(
-        "MessageRuntime direct handler failed handler_id={} error_class={}",
+        "MessageRuntime direct handler [{}] failed with error class [{}].",
         "pb_core.raising",
         "RuntimeError",
     )

--- a/tests/plugins/test_webui_env_sections.py
+++ b/tests/plugins/test_webui_env_sections.py
@@ -47,10 +47,6 @@ def test_list_webui_env_sections_is_empty():
     assert "LLM_MEMORY_RAG_TOP_K" in env_keys
     assert "LLM_MEMORY_AUTO_EPISODE_COOLDOWN_SEC" in env_keys
     assert "LLM_SESSION_SUMMARY_ENABLED" in env_keys
-    assert "LLM_EXPRESSION_INJECT_ENABLED" in env_keys
-    assert "LLM_EXPRESSION_LEARN_ENABLED" in env_keys
-    assert "LLM_EXPRESSION_AUTO_PROMOTE_ENABLED" in env_keys
-    assert "LLM_EXPRESSION_RETRIEVE_LIMIT" in env_keys
     assert "LLM_BUBBLE_DELAY_BASE_SEC" in env_keys
     assert "LLM_BUBBLE_DELAY_PER_CHAR" in env_keys
     assert "LLM_BUBBLE_DELAY_JITTER" in env_keys
@@ -60,7 +56,6 @@ def test_list_webui_env_sections_is_empty():
     assert "LLM_API_KEY" not in env_keys
     assert "LLM_MODEL" not in env_keys
     assert "LLM_REPEATER_BIAS_ENABLED" in env_keys
-    assert "LLM_REPEATER_WRITEBACK_ENABLED" in env_keys
     assert "CONVERSATION_FEATURE_LEVEL" in env_keys
     assert "LLM_VECTOR_RETRIEVE" in env_keys
     assert "LLM_EMBEDDING_MODEL" in env_keys


### PR DESCRIPTION
隔离 `tests/common/` 中跨测试文件共享的缓存、去重集合、shard registry、ingress metrics、环境变量和插件加载状态，消除单测单独通过而全量失败的问题。

同时修正后端切换时 Bot 配置仓储复用旧实例、仓储 Protocol mock 与相关测试配置漂移。

验证：`tests/common/` 为 1245 passed、58 skipped；Ruff check、Ruff format check 和 `git diff --check` 均通过。

全仓仍有既有的 LLM 预算契约失败：`tests/features/test_llm_inference_params.py` 期望 `repeater.semantic_style` 为 96，而当前实现为 240；该问题不在本 PR 范围内。

## Sourcery 总结

隔离测试运行时全局状态并修复后端切换时的配置仓储复用问题，提升全量测试的稳定性。

错误修复：
- 防止机器人配置仓储在切换后端时保留过期实例。
- 消除共享缓存、去重状态、分片注册表、入口指标、环境变量和插件注册导致的跨测试污染。

改进：
- 使测试与集中式分片运行时上下文以及当前的仓储协议和配置保持一致。
- 隔离动态加载的插件模块，并在测试之间恢复 NoneBot 运行时状态。

构建：
- 配置 pytest 使用 importlib 模式，以便在不存在模块冲突的情况下收集同名测试。

测试：
- 更新通用测试及相关测试，使其使用隔离的运行时状态，并符合当前的行为预期。

<details>
<summary>Original summary in English</summary>

## Sourcery 汇总

隔离共享的测试运行时状态，并修复后端切换时仓库复用的问题，以提升完整测试套件的稳定性。

错误修复：
- 防止机器人配置仓库在切换后端时保留过期实例。
- 消除共享缓存、去重状态、分片注册表、入口指标、环境变量和插件注册状态导致的跨测试污染。

增强功能：
- 使通用测试与集中式分片运行时上下文以及当前的仓库协议和配置保持一致。
- 在测试之间恢复动态加载的插件模块和 NoneBot 运行时状态。

构建：
- 配置 pytest 使用 importlib 导入模式，以便在不存在模块冲突的情况下收集同名测试。

测试：
- 更新通用测试及相关测试，使其使用隔离的运行时状态和当前预期行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate shared test runtime state and fix backend-switch repository reuse to improve full-suite test stability.

Bug Fixes:
- Prevent bot configuration repositories from retaining stale instances when switching backends.
- Eliminate cross-test contamination from shared caches, deduplication state, shard registries, ingress metrics, environment variables, and plugin registration state.

Enhancements:
- Align common tests with the centralized shard runtime context and current repository protocols and configuration.
- Restore dynamically loaded plugin modules and NoneBot runtime state between tests.

Build:
- Configure pytest to use importlib import mode so same-named tests can be collected without module conflicts.

Tests:
- Update common and related tests to use isolated runtime state and current expected behavior.

</details>

</details>