### PR TITLE
fix(blacklist): 命令拉黑同步 ACL 规则

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+* feat(blacklist): 拉黑操作审计记录与展示
+
+### Fixed
+
+* fix(blacklist): 命令拉黑同步 ACL 规则
+* fix(webui): 号主编辑同步 admin_members
+* fix(acl): 启动迁移改用 repo 查询
+* fix(llm): 离线评测 judge 改用独立更大输出预算
+
 ## [4.3.14] - 2026-09-03
 
 ### 更新公告

--- a/packages/blacklist/commands.py
+++ b/packages/blacklist/commands.py
@@ -5,9 +5,8 @@ from nonebot.adapters.onebot.v11 import GroupMessageEvent, PrivateMessageEvent
 from pallas.api.logging import format_plugin_event
 from pallas.api.perm import permission_for_command
 from pallas.core.foundation.config import GroupConfig, UserConfig
-from pallas.product.ban_gate.snapshot import patch_group_banned, patch_group_blocked_users, patch_user_banned
 
-from .ban_gate import invalidate_group_ban_gate_cache, invalidate_user_ban_gate_cache
+from .ban_gate import apply_group_banned_change, apply_group_blocked_users_change, apply_user_banned_change
 from .helpers import (
     build_blacklist_view_message,
     collect_group_ids_from_plain,
@@ -75,8 +74,7 @@ async def handle_blacklist_add(bot: Bot, event: GroupMessageEvent | PrivateMessa
     if isinstance(event, PrivateMessageEvent):
         for uid in targets:
             await UserConfig(uid).ban(operator=f"u:{event.user_id}")
-            await patch_user_banned(uid, True)
-        await invalidate_user_ban_gate_cache(targets)
+            await apply_user_banned_change(uid, True)
         logger.info(
             format_plugin_event(
                 "block_user",
@@ -88,8 +86,7 @@ async def handle_blacklist_add(bot: Bot, event: GroupMessageEvent | PrivateMessa
         )
         return
     await GroupConfig(event.group_id).add_blocked_users(targets)
-    await patch_group_blocked_users(event.group_id, await GroupConfig(event.group_id).blocked_user_ids())
-    await invalidate_group_ban_gate_cache(event.group_id)
+    await apply_group_blocked_users_change(event.group_id, await GroupConfig(event.group_id).blocked_user_ids())
     logger.info(
         format_plugin_event(
             "block_user",
@@ -111,8 +108,7 @@ async def handle_blacklist_remove(bot: Bot, event: GroupMessageEvent | PrivateMe
     if isinstance(event, PrivateMessageEvent):
         for uid in targets:
             await UserConfig(uid).unban(operator=f"u:{event.user_id}")
-            await patch_user_banned(uid, False)
-        await invalidate_user_ban_gate_cache(targets)
+            await apply_user_banned_change(uid, False)
         logger.info(
             format_plugin_event(
                 "unblock_user",
@@ -124,8 +120,7 @@ async def handle_blacklist_remove(bot: Bot, event: GroupMessageEvent | PrivateMe
         )
         return
     await GroupConfig(event.group_id).remove_blocked_users(targets)
-    await patch_group_blocked_users(event.group_id, await GroupConfig(event.group_id).blocked_user_ids())
-    await invalidate_group_ban_gate_cache(event.group_id)
+    await apply_group_blocked_users_change(event.group_id, await GroupConfig(event.group_id).blocked_user_ids())
     logger.info(
         format_plugin_event(
             "unblock_user",
@@ -150,8 +145,7 @@ async def handle_blacklist_add_group(bot: Bot, event: GroupMessageEvent | Privat
             return
     for gid in targets:
         await GroupConfig(gid).ban()
-        await patch_group_banned(gid, True)
-    await invalidate_group_ban_gate_cache(targets)
+        await apply_group_banned_change(gid, True)
     current_group = isinstance(event, GroupMessageEvent) and targets == [event.group_id]
     log_scope = "current group" if current_group else "global"
     display_scope = "本群" if current_group else "全局"
@@ -181,8 +175,7 @@ async def handle_blacklist_remove_group(bot: Bot, event: GroupMessageEvent | Pri
             return
     for gid in targets:
         await GroupConfig(gid).unban()
-        await patch_group_banned(gid, False)
-    await invalidate_group_ban_gate_cache(targets)
+        await apply_group_banned_change(gid, False)
     current_group = isinstance(event, GroupMessageEvent) and targets == [event.group_id]
     log_scope = "current group" if current_group else "global"
     display_scope = "本群" if current_group else "全局"

--- a/packages/blacklist/commands.py
+++ b/packages/blacklist/commands.py
@@ -74,7 +74,7 @@ async def handle_blacklist_add(bot: Bot, event: GroupMessageEvent | PrivateMessa
         return
     if isinstance(event, PrivateMessageEvent):
         for uid in targets:
-            await UserConfig(uid).ban()
+            await UserConfig(uid).ban(operator=f"u:{event.user_id}")
             await patch_user_banned(uid, True)
         await invalidate_user_ban_gate_cache(targets)
         logger.info(
@@ -110,7 +110,7 @@ async def handle_blacklist_remove(bot: Bot, event: GroupMessageEvent | PrivateMe
         return
     if isinstance(event, PrivateMessageEvent):
         for uid in targets:
-            await UserConfig(uid).unban()
+            await UserConfig(uid).unban(operator=f"u:{event.user_id}")
             await patch_user_banned(uid, False)
         await invalidate_user_ban_gate_cache(targets)
         logger.info(

--- a/packages/blacklist/helpers.py
+++ b/packages/blacklist/helpers.py
@@ -1,4 +1,6 @@
 import re
+import time
+from itertools import starmap
 
 from nonebot.adapters import Bot, Event
 from nonebot.adapters.onebot.v11 import (
@@ -52,7 +54,8 @@ def collect_group_ids_from_plain(plain_text: str) -> list[int]:
 _LIST_DISPLAY_LIMIT = 50
 
 
-async def query_global_banned_user_ids() -> list[int]:
+async def query_global_banned_user_ids() -> list[tuple[int, str, int]]:
+    """返回全局拉黑用户列表：[(user_id, banned_by, banned_at)]。"""
     from pallas.core.foundation.db import get_db_backend
 
     backend = get_db_backend()
@@ -60,15 +63,21 @@ async def query_global_banned_user_ids() -> list[int]:
         from pallas.core.foundation.db.modules import UserConfigModule
 
         docs = await UserConfigModule.find(UserConfigModule.banned == True).to_list()  # noqa: E712
-        return sorted(int(d.user_id) for d in docs)
+        return sorted(
+            (int(d.user_id), str(getattr(d, "banned_by", "") or ""), int(getattr(d, "banned_at", 0) or 0)) for d in docs
+        )
     if backend == "postgresql":
         from sqlalchemy import select
 
         from pallas.core.foundation.db.repository_pg import UserConfigRow, get_session
 
         async with get_session(read_only=True) as session:
-            result = await session.execute(select(UserConfigRow.user_id).where(UserConfigRow.banned.is_(True)))
-            return sorted(int(row[0]) for row in result.all())
+            result = await session.execute(
+                select(UserConfigRow.user_id, UserConfigRow.banned_by, UserConfigRow.banned_at).where(
+                    UserConfigRow.banned.is_(True)
+                )
+            )
+            return sorted((int(r[0]), str(r[1] or ""), int(r[2] or 0)) for r in result.all())
     return []
 
 
@@ -102,13 +111,41 @@ def format_id_list(ids: list[int], *, empty_hint: str) -> str:
     return text
 
 
+def _format_ban_operator(operator: str) -> str:
+    """把审计操作者标识转成可读文本。"""
+    if not operator:
+        return "未知"
+    if operator.startswith("u:"):
+        return operator[2:]
+    if operator == "webui":
+        return "WebUI"
+    if operator == "system:kick_me":
+        return "系统(被踢)"
+    return operator
+
+
+def _format_banned_user(uid: int, operator: str, banned_at: int) -> str:
+    if not operator and not banned_at:
+        return str(uid)
+    parts = [str(uid)]
+    if operator:
+        parts.append(f"@{_format_ban_operator(operator)}")
+    if banned_at:
+        parts.append(time.strftime("%m-%d %H:%M", time.localtime(banned_at)))
+    return " ".join(parts)
+
+
 async def build_blacklist_view_message(group_id: int | None) -> str:
     if group_id is None:
         users = await query_global_banned_user_ids()
         groups = await query_global_banned_group_ids()
+        user_text = format_id_list(
+            list(starmap(_format_banned_user, users)),
+            empty_hint="（无）",
+        )
         return "\n".join([
             "博士，米诺斯在册名单如下：",
-            f"全局用户拉黑：{format_id_list(users, empty_hint='（无）')}",
+            f"全局用户拉黑：{user_text}",
             f"全局群拉黑：{format_id_list(groups, empty_hint='（无）')}",
         ])
     blocked = await GroupConfig(group_id).blocked_user_ids()

--- a/packages/greeting/commands.py
+++ b/packages/greeting/commands.py
@@ -19,7 +19,7 @@ from nonebot.adapters.onebot.v11 import (
 from nonebot.rule import Rule, to_me
 from nonebot.typing import T_State
 
-from packages.blacklist import invalidate_group_ban_gate_cache, invalidate_user_ban_gate_cache
+from packages.blacklist import apply_group_banned_change, apply_user_banned_change
 from pallas.api.logging import format_plugin_event
 from pallas.api.perm import (
     group_message_permission_for_command,
@@ -29,7 +29,6 @@ from pallas.core.foundation.config import BotConfig, GroupConfig, UserConfig
 from pallas.core.platform.ingress.matcher_rule_prefilter import mark_exact_plaintext_rule
 from pallas.core.plugin_coord.duel import duel_qte_blocks_greeting_user
 from pallas.core.shared.utils import is_bot_admin
-from pallas.product.ban_gate.snapshot import patch_group_banned, patch_user_banned
 
 from .config import plugin_config
 from .voice import get_random_voice, get_voice_filepath
@@ -403,7 +402,5 @@ async def handle_notice(event: _NoticeEvent):
         if plugin_config.enable_kick_ban:
             await GroupConfig(event.group_id).ban()
             await UserConfig(event.operator_id).ban(operator="system:kick_me")
-            await patch_group_banned(event.group_id, True)
-            await patch_user_banned(event.operator_id, True)
-            await invalidate_group_ban_gate_cache(event.group_id)
-            await invalidate_user_ban_gate_cache(event.operator_id)
+            await apply_group_banned_change(event.group_id, True)
+            await apply_user_banned_change(event.operator_id, True)

--- a/packages/greeting/commands.py
+++ b/packages/greeting/commands.py
@@ -402,7 +402,7 @@ async def handle_notice(event: _NoticeEvent):
     elif event.notice_type == "group_decrease" and event.sub_type == "kick_me":
         if plugin_config.enable_kick_ban:
             await GroupConfig(event.group_id).ban()
-            await UserConfig(event.operator_id).ban()
+            await UserConfig(event.operator_id).ban(operator="system:kick_me")
             await patch_group_banned(event.group_id, True)
             await patch_user_banned(event.operator_id, True)
             await invalidate_group_ban_gate_cache(event.group_id)

--- a/packages/pb_webui/db_api.py
+++ b/packages/pb_webui/db_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -165,6 +166,9 @@ async def _upsert_db_table_row(table: str, row_id: int, data: dict[str, Any]) ->
         await repo.get_or_create(int(row_id), banned=False)
         for k, v in payload.items():
             await repo.upsert_field(int(row_id), k, v)
+        if "banned" in payload:
+            await repo.upsert_field(int(row_id), "banned_by", "webui")
+            await repo.upsert_field(int(row_id), "banned_at", int(time.time()))
         await repo.invalidate_cache()
         if "banned" in payload:
             from packages.blacklist import apply_user_banned_change

--- a/packages/pb_webui/db_api.py
+++ b/packages/pb_webui/db_api.py
@@ -110,9 +110,11 @@ async def _upsert_db_table_row(table: str, row_id: int, data: dict[str, Any]) ->
                 disabled_plugins=list(payload["disabled_plugins"] or []),
             )
         if "admins" in payload:
+            from pallas.core.foundation.config import sync_bot_admins_to_admin_members
             from pallas.core.foundation.config.bot_admins_cache import invalidate_bot_admins_cache
 
             await invalidate_bot_admins_cache(int(row_id))
+            await sync_bot_admins_to_admin_members(int(row_id), payload["admins"])
         got = await _get_db_table_row_public("bot_config", int(row_id))
         if got is None:
             raise ValueError("upsert 后回读失败")

--- a/packages/pb_webui/instances_configs_api.py
+++ b/packages/pb_webui/instances_configs_api.py
@@ -99,9 +99,11 @@ async def _apply_bot_config_patch(account: int, body: _BotConfigPatch) -> dict[s
 
         await apply_disabled_plugin_config_change(bot_id=account, disabled_plugins=fields["disabled_plugins"])
     if "admins" in fields:
+        from pallas.core.foundation.config import sync_bot_admins_to_admin_members
         from pallas.core.foundation.config.bot_admins_cache import invalidate_bot_admins_cache
 
         await invalidate_bot_admins_cache(account)
+        await sync_bot_admins_to_admin_members(account, fields["admins"])
     if "persona" in fields:
         from pallas.product.persona import invalidate_persona_cache
 

--- a/packages/pb_webui/instances_configs_api.py
+++ b/packages/pb_webui/instances_configs_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Header, HTTPException, Query
@@ -166,6 +167,7 @@ async def _apply_user_config_patch(user_id: int, body: _UserConfigPatch) -> dict
     fields = body.model_dump(exclude_none=True)
     await repo.upsert_fields(user_id, fields)
     if "banned" in fields:
+        await repo.upsert_fields(user_id, {"banned_by": "webui", "banned_at": int(time.time())})
         from packages.blacklist import apply_user_banned_change
 
         await apply_user_banned_change(user_id, bool(fields["banned"]))

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -440,11 +440,16 @@ class UserConfig(Config):
 
         self.user_id = user_id
 
-    async def ban(self) -> None:
+    async def ban(self, operator: str | None = None) -> None:
         """
         拉黑这个人
+
+        :param operator: 操作者标识（QQ 号 / webui / system:xxx），用于审计
         """
         await self._update("banned", True)
+        if operator:
+            await self._update("banned_by", str(operator))
+            await self._update("banned_at", int(time.time()))
 
     async def is_banned(self) -> bool:
         """
@@ -453,8 +458,11 @@ class UserConfig(Config):
         banned = await self._find("banned")
         return True if banned else False
 
-    async def unban(self) -> None:
+    async def unban(self, operator: str | None = None) -> None:
         await self._update("banned", False)
+        if operator:
+            await self._update("banned_by", str(operator))
+            await self._update("banned_at", int(time.time()))
 
 
 class TaskManager:

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -309,6 +309,40 @@ async def user_is_bot_admin(bot_id: int, user_id: int) -> bool:
     return False
 
 
+async def sync_bot_admins_to_admin_members(bot_id: int, admins: list[int]) -> None:
+    """把 BotConfig.admins 的最终列表同步到 admin_members（scope="bot"），并失效相关缓存。
+
+    admin_members 是 ACL 引擎 admin_bypass 的数据真相；WebUI 直接改 BotConfig.admins
+    时若不镜像，ACL 层不认新增号主。diff 出新增/删除后逐条 upsert/remove。
+    """
+    from pallas.core.foundation.db import make_admin_repository
+
+    desired = {int(u) for u in admins if int(u) != int(bot_id)}
+    admin_repo = make_admin_repository()
+    try:
+        current = {int(m.user_id) for m in await admin_repo.list_members(scope="bot", bot_id=int(bot_id))}
+    except Exception:
+        current = set()
+    for uid in desired - current:
+        try:
+            await admin_repo.upsert_member(user_id=uid, scope="bot", bot_id=int(bot_id))
+        except Exception as exc:
+            log_rate_limited(
+                logger, "warning", "config.sync_admins_upsert", "sync admin_members upsert failed: {}", exc
+            )
+    for uid in current - desired:
+        try:
+            await admin_repo.remove_member(user_id=uid, scope="bot", bot_id=int(bot_id))
+        except Exception as exc:
+            log_rate_limited(
+                logger, "warning", "config.sync_admins_remove", "sync admin_members remove failed: {}", exc
+            )
+    if desired != current:
+        from pallas.api.perm import clear_acl_cache
+
+        clear_acl_cache()
+
+
 async def user_is_admin_of_any_bot(user_id: int) -> bool:
     """
     判断 user_id 是否在 admin_members（任一 scope）之中。

--- a/pallas/core/foundation/db/modules.py
+++ b/pallas/core/foundation/db/modules.py
@@ -92,6 +92,8 @@ class GroupConfigModule(Document):
 class UserConfigModule(Document):
     user_id: int = Field(...)
     banned: bool = False
+    banned_by: str = ""
+    banned_at: int = 0
     maa_devices: dict = Field(default_factory=dict)
     maa_active_device: str = ""
     maa_stage_plan: list[str] = Field(default_factory=list)

--- a/pallas/core/foundation/db/pallas_console_data.py
+++ b/pallas/core/foundation/db/pallas_console_data.py
@@ -114,6 +114,8 @@ def user_config_to_public(doc_or_row: Any) -> dict[str, Any]:
     return {
         "user_id": int(doc_or_row.user_id),
         "banned": bool(getattr(doc_or_row, "banned", False)),
+        "banned_by": str(getattr(doc_or_row, "banned_by", "") or ""),
+        "banned_at": int(getattr(doc_or_row, "banned_at", 0) or 0),
     }
 
 

--- a/pallas/core/foundation/db/repository_pg.py
+++ b/pallas/core/foundation/db/repository_pg.py
@@ -295,6 +295,8 @@ class UserConfigRow(Base):
 
     user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    banned_by: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    banned_at: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     maa_devices: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=dict)
     maa_active_device: Mapped[str] = mapped_column(Text, nullable=False, default="")
     maa_stage_plan: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
@@ -690,6 +692,18 @@ def _ensure_pg_user_config_maa_devices(connection) -> None:
         connection.execute(text("ALTER TABLE user_config ADD COLUMN plugin_storage JSONB NOT NULL DEFAULT '{}'::jsonb"))
 
 
+def _ensure_pg_user_config_ban_audit(connection) -> None:
+    """旧库 user_config 缺拉黑审计列时补列。"""
+    insp = inspect(connection)
+    if not insp.has_table("user_config"):
+        return
+    names = {c["name"] for c in insp.get_columns("user_config")}
+    if "banned_by" not in names:
+        connection.execute(text("ALTER TABLE user_config ADD COLUMN banned_by TEXT NOT NULL DEFAULT ''"))
+    if "banned_at" not in names:
+        connection.execute(text("ALTER TABLE user_config ADD COLUMN banned_at BIGINT NOT NULL DEFAULT 0"))
+
+
 def _ensure_pg_bot_config_plugin_storage(connection) -> None:
     insp = inspect(connection)
     if not insp.has_table("bot_config"):
@@ -990,6 +1004,7 @@ PG_SCHEMA_ENSURE_STEPS: list[tuple[str, Any]] = [
     ("ddl.bot_config_persona", _ensure_pg_bot_config_persona),
     ("ddl.bot_config_plugin_storage", _ensure_pg_bot_config_plugin_storage),
     ("ddl.user_config_maa_devices", _ensure_pg_user_config_maa_devices),
+    ("ddl.user_config_ban_audit", _ensure_pg_user_config_ban_audit),
     ("ddl.llm_memory_embedding_columns", _ensure_pg_llm_memory_embedding_columns),
     ("ddl.llm_memory_metadata_columns", _ensure_pg_llm_memory_metadata_columns),
     ("ddl.llm_memory_graph_columns", _ensure_pg_llm_memory_graph_columns),

--- a/pallas/core/perm/migration.py
+++ b/pallas/core/perm/migration.py
@@ -11,6 +11,8 @@ from pallas.core.foundation.db import (
     make_acl_repository,
     make_admin_repository,
     make_bot_config_repository,
+    make_group_config_repository,
+    make_user_config_repository,
 )
 from pallas.core.perm.acl import ACL_TARGET_GROUP_BAN, group_block_target
 
@@ -35,10 +37,7 @@ async def migrate_bot_admins_to_admin_members_once() -> dict[str, int]:
     except Exception:
         pass
     try:
-        from pallas.core.foundation.db.modules import BotConfigModule
-
-        cursor = BotConfigModule.find_all()
-        async for doc in cursor:
+        for doc in await bot_config_repo.list_all():
             try:
                 bot_ids.append(int(doc.account))
             except Exception:
@@ -71,9 +70,10 @@ async def derive_acl_from_legacy() -> dict[str, int]:
     counts = {"user_banned": 0, "group_banned": 0, "group_blocked_users": 0}
 
     try:
-        from pallas.core.foundation.db.modules import UserConfigModule
-
-        async for doc in UserConfigModule.find(UserConfigModule.banned == True):  # noqa: E712
+        user_repo = make_user_config_repository()
+        for doc in await user_repo.list_all():
+            if not bool(getattr(doc, "banned", False)):
+                continue
             uid = int(getattr(doc, "user_id", 0))
             if not uid:
                 continue
@@ -92,33 +92,23 @@ async def derive_acl_from_legacy() -> dict[str, int]:
         pass
 
     try:
-        from pallas.core.foundation.db.modules import GroupConfigModule
-
-        async for doc in GroupConfigModule.find(GroupConfigModule.banned == True):  # noqa: E712
+        group_repo = make_group_config_repository()
+        for doc in await group_repo.list_all():
             gid = int(getattr(doc, "group_id", 0))
             if not gid:
                 continue
-            await acl_repo.upsert_rule(
-                role="群",
-                subject=f"g:{gid}",
-                action="event.receive",
-                target_scope="全局",
-                target=ACL_TARGET_GROUP_BAN,
-                effect="deny",
-                priority=2000,
-                source="system",
-            )
-            counts["group_banned"] += 1
-    except Exception:
-        pass
-
-    try:
-        from pallas.core.foundation.db.modules import GroupConfigModule
-
-        async for doc in GroupConfigModule.find_all():
-            gid = int(getattr(doc, "group_id", 0))
-            if not gid:
-                continue
+            if bool(getattr(doc, "banned", False)):
+                await acl_repo.upsert_rule(
+                    role="群",
+                    subject=f"g:{gid}",
+                    action="event.receive",
+                    target_scope="全局",
+                    target=ACL_TARGET_GROUP_BAN,
+                    effect="deny",
+                    priority=2000,
+                    source="system",
+                )
+                counts["group_banned"] += 1
             raw = getattr(doc, "blocked_user_ids", None) or []
             for uid in raw:
                 try:

--- a/pallas/product/llm/offline_quality_eval.py
+++ b/pallas/product/llm/offline_quality_eval.py
@@ -332,12 +332,22 @@ async def run_configured_offline_quality_eval(
         )
         return str(response.get("content") or "")
 
+    async def judge_complete(messages: list[dict[str, str]]) -> str:
+        response = await complete_chat_message(
+            messages,
+            model="",
+            options={"temperature": 0, "max_tokens": 256},
+            tools=None,
+            task="llm_chat",
+        )
+        return str(response.get("content") or "")
+
     return [
         await evaluate_offline_case(
             case,
             base_system_prompt=base_system_prompt,
             complete=complete,
-            judge=complete if judge else None,
+            judge=judge_complete if judge else None,
         )
         for case in cases
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ async def beanie_fixture(monkeypatch: pytest.MonkeyPatch):
     from mongomock_motor import AsyncMongoMockClient
 
     from pallas.core.foundation.db.modules import (
+        AdminMember,
         BlackList,
         BotConfigModule,
         Context,
@@ -50,6 +51,8 @@ async def beanie_fixture(monkeypatch: pytest.MonkeyPatch):
         LlmMemoryEntry,
         LlmRelationshipNote,
         Message,
+        PallasACL,
+        SchemaMigration,
         StickerLabel,
         UserConfigModule,
         UserStickerStat,
@@ -70,17 +73,20 @@ async def beanie_fixture(monkeypatch: pytest.MonkeyPatch):
     await init_beanie(
         database=motor_db,
         document_models=[
-            BotConfigModule,
-            GroupConfigModule,
-            UserConfigModule,
-            Message,
-            Context,
+            AdminMember,
             BlackList,
+            BotConfigModule,
+            Context,
+            GroupConfigModule,
             ImageCache,
             LlmChatMessage,
             LlmMemoryEntry,
             LlmRelationshipNote,
+            Message,
+            PallasACL,
+            SchemaMigration,
             StickerLabel,
+            UserConfigModule,
             UserStickerStat,
         ],
         allow_index_dropping=True,
@@ -100,6 +106,9 @@ async def beanie_fixture(monkeypatch: pytest.MonkeyPatch):
     await motor_db.drop_collection("llm_relationship_note")
     await motor_db.drop_collection("sticker_label")
     await motor_db.drop_collection("user_sticker_stat")
+    await motor_db.drop_collection("acl_rules")
+    await motor_db.drop_collection("admin_members")
+    await motor_db.drop_collection("schema_migrations")
     motor_client.close()
 
 

--- a/tests/core/perm/test_acl_migration.py
+++ b/tests/core/perm/test_acl_migration.py
@@ -1,0 +1,72 @@
+"""ACL 启动迁移测试：从 legacy 列派生 acl_rules / admin_members。"""
+
+import pytest
+
+from pallas.core.foundation.config import GroupConfig, UserConfig
+from pallas.core.foundation.db import make_acl_repository, make_admin_repository
+
+
+@pytest.mark.asyncio
+async def test_derive_acl_from_legacy_mirrors_bans(beanie_fixture):
+    from pallas.core.perm.migration import derive_acl_from_legacy
+
+    uid = 770_001
+    gid = 770_002
+    blocked = 770_003
+    await UserConfig(uid).ban()
+    await GroupConfig(gid).ban()
+    await GroupConfig(gid).add_blocked_users([blocked])
+
+    counts = await derive_acl_from_legacy()
+    assert counts["user_banned"] == 1
+    assert counts["group_banned"] == 1
+    assert counts["group_blocked_users"] == 1
+
+    repo = make_acl_repository()
+    rules = await repo.list_all()
+    by_sig = {(r.role, r.subject, r.action, r.target_scope, r.target): r for r in rules}
+    assert ("用户", f"u:{uid}", "event.receive", "全局", "*") in by_sig
+    assert ("群", f"g:{gid}", "event.receive", "全局", "group") in by_sig
+    assert ("用户", f"u:{blocked}", "event.receive", "全局", f"group:{gid}") in by_sig
+    assert by_sig[("用户", f"u:{uid}", "event.receive", "全局", "*")].effect == "deny"
+    assert by_sig[("用户", f"u:{uid}", "event.receive", "全局", "*")].priority == 2000
+    assert by_sig[("用户", f"u:{blocked}", "event.receive", "全局", f"group:{gid}")].priority == 1000
+
+
+@pytest.mark.asyncio
+async def test_derive_acl_from_legacy_idempotent(beanie_fixture):
+    from pallas.core.perm.migration import derive_acl_from_legacy
+
+    uid = 770_011
+    await UserConfig(uid).ban()
+
+    first = await derive_acl_from_legacy()
+    second = await derive_acl_from_legacy()
+    assert first["user_banned"] == 1
+    assert second == {"already_run": 1}
+
+    repo = make_acl_repository()
+    rules = await repo.list_all()
+    assert len(rules) == 1
+
+
+@pytest.mark.asyncio
+async def test_migrate_bot_admins_to_admin_members_once(beanie_fixture):
+    from pallas.core.foundation.db import make_bot_config_repository
+    from pallas.core.perm.migration import migrate_bot_admins_to_admin_members_once
+
+    bot_id = 770_021
+    admin_uid = 770_022
+    repo = make_bot_config_repository()
+    await repo.get_or_create(bot_id, disabled_plugins=[])
+    await repo.upsert_field(bot_id, "admins", [admin_uid])
+
+    result = await migrate_bot_admins_to_admin_members_once()
+    assert result["migrated"] == 1
+
+    admin_repo = make_admin_repository()
+    uids = await admin_repo.list_admin_user_ids(bot_id=bot_id)
+    assert admin_uid in uids
+
+    again = await migrate_bot_admins_to_admin_members_once()
+    assert again["already_run"] == 1

--- a/tests/core/perm/test_admin_members_sync.py
+++ b/tests/core/perm/test_admin_members_sync.py
@@ -1,0 +1,37 @@
+"""BotConfig.admins 与 admin_members 同步测试。"""
+
+import pytest
+
+from pallas.core.foundation.config import sync_bot_admins_to_admin_members
+from pallas.core.foundation.db import make_admin_repository, make_bot_config_repository
+
+
+@pytest.mark.asyncio
+async def test_sync_bot_admins_to_admin_members_add_and_remove(beanie_fixture):
+    bot_id = 880_001
+    admin_a = 880_002
+    admin_b = 880_003
+
+    repo = make_bot_config_repository()
+    await repo.get_or_create(bot_id, disabled_plugins=[])
+    await repo.upsert_field(bot_id, "admins", [admin_a, admin_b])
+
+    await sync_bot_admins_to_admin_members(bot_id, [admin_a, admin_b])
+    admin_repo = make_admin_repository()
+    uids = await admin_repo.list_admin_user_ids(bot_id=bot_id)
+    assert set(uids) == {admin_a, admin_b}
+
+    # 删除 admin_b
+    await repo.upsert_field(bot_id, "admins", [admin_a])
+    await sync_bot_admins_to_admin_members(bot_id, [admin_a])
+    uids = await admin_repo.list_admin_user_ids(bot_id=bot_id)
+    assert set(uids) == {admin_a}
+
+
+@pytest.mark.asyncio
+async def test_sync_bot_admins_skips_bot_self(beanie_fixture):
+    bot_id = 880_011
+    await sync_bot_admins_to_admin_members(bot_id, [bot_id, 880_012])
+    admin_repo = make_admin_repository()
+    uids = await admin_repo.list_admin_user_ids(bot_id=bot_id)
+    assert set(uids) == {880_012}

--- a/tests/product/llm/test_offline_quality_eval.py
+++ b/tests/product/llm/test_offline_quality_eval.py
@@ -185,3 +185,35 @@ async def test_configured_eval_uses_provider_without_delivery(monkeypatch: pytes
     assert calls[0]["task"] == "llm_chat"
     assert calls[0]["tools"] is None
     assert calls[0]["options"] == {"temperature": 0, "max_tokens": 96}
+
+
+@pytest.mark.asyncio
+async def test_configured_eval_judge_uses_larger_token_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """judge 复用生成预算（96 tokens）会截断 JSON 导致全 3 分，须用独立更大预算。"""
+    calls: list[dict[str, object]] = []
+
+    async def fake_provider(messages: list[dict[str, str]], **kwargs: object) -> dict[str, str]:
+        calls.append({"messages": messages, **kwargs})
+        if "你是严格的群聊回复质量评审" in messages[0]["content"]:
+            return {
+                "content": (
+                    '{"verdict":"ALLOW","scores":{"grounded":5,"naturalness":5,'
+                    '"overexplained":1,"persona_drift":1},"reasons":[]}'
+                )
+            }
+        return {"content": '{"reply":"能。"}'}
+
+    monkeypatch.setattr("pallas.product.llm.provider_client.complete_chat_message", fake_provider)
+
+    results = await run_configured_offline_quality_eval(
+        base_system_prompt="base",
+        cases=[OfflineQualityCase("fact", "这也要再动？", "ACK", "fact")],
+        judge=True,
+    )
+
+    assert results[0].judge is not None
+    assert results[0].judge.verdict == "ALLOW"
+    assert results[0].judge.scores["naturalness"] == 5
+    assert len(calls) == 2
+    judge_call = calls[1]
+    assert judge_call["options"] == {"temperature": 0, "max_tokens": 256}


### PR DESCRIPTION
本批变更：

- feat(blacklist): 拉黑操作审计记录与展示（banned_by / banned_at，命令、WebUI、kick_me 三路径写入，黑名单命令与 WebUI 展示操作者与时间）
- fix(blacklist): 命令拉黑同步 ACL 规则（拉黑/解禁/拉黑群改走 apply_*_change，镜像 acl_rules）
- fix(webui): 号主编辑同步 admin_members（WebUI 改 admins 时镜像 admin_members 并失效 ACL 缓存）
- fix(acl): 启动迁移改用 repo 查询（PG 后端下 beanie 未初始化导致迁移从未完成）
- fix(llm): 离线评测 judge 改用独立更大输出预算（judge JSON 被 96 token 截断导致分数全失真）

## Sourcery 摘要

在配置、ACL 和 WebUI 之间同步黑名单与管理员状态，同时改进封禁审计和离线评估的可靠性。

新功能：
- 添加黑名单审计元数据，并显示用户封禁的操作员和时间戳。

错误修复：
- 将命令触发和踢出触发的黑名单变更与 ACL 规则同步。
- 保持 WebUI 用户封禁和机器人管理员编辑与其基于 ACL 的数据同步。
- 通过仓库查询执行 ACL 启动迁移，使其能够跨数据库后端正常工作。
- 为离线 LLM 评估裁判提供更大的输出预算，以防评分 JSON 被截断。

测试：
- 增加对 ACL 旧版迁移、管理员同步以及扩展后的离线评估裁判预算的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize blacklist and administrator state across configuration, ACLs, and WebUI while improving ban auditing and offline evaluation reliability.

New Features:
- Add blacklist audit metadata and display the operator and timestamp for user bans.

Bug Fixes:
- Synchronize command and kick-triggered blacklist changes with ACL rules.
- Keep WebUI user bans and bot administrator edits synchronized with their ACL-backed data.
- Run ACL startup migrations through repository queries so they work across database backends.
- Give offline LLM evaluation judges a larger output budget to prevent truncated scoring JSON.

Tests:
- Add coverage for ACL legacy migration, administrator synchronization, and the expanded offline evaluation judge budget.

</details>