### PR TITLE
fix(webui): 号主编辑同步失败显式报错

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * fix(blacklist): 命令拉黑同步 ACL 规则
 * fix(webui): 号主编辑同步 admin_members
+* fix(webui): 号主编辑同步失败显式报错，避免配置与 ACL 静默不一致
 * fix(acl): 启动迁移改用 repo 查询
 * fix(llm): 离线评测 judge 改用独立更大输出预算
 

--- a/docs/skills/pallas-release/SKILL.md
+++ b/docs/skills/pallas-release/SKILL.md
@@ -44,7 +44,7 @@ description: >
 `dev`→`main` 多为**不含** `chore(release)` 的普通功能 PR（把一批功能推进 `main`）。此类 PR 的 CHANGELOG 素材应**随批记录**，供后续发版引用：
 
 - 每个普通 dev→main PR，在它那批功能提交里写好 `## [Unreleased]`（只写 `### Added` / `### Fixed` / `### Changed` 明细，**不写** `### 更新公告`，也不改版本号），随 PR 一起合入 `main`。更新公告留到真正发版时再依据明细整理。
-- 该 `Unreleased` 记录独立提交或并入功能提交均可（维护者常 amend 进最新功能提交）；关键是**每次普通 PR 都带一次**，素材随批落到 `main`。
+- 该 `Unreleased` 记录**必须 amend 进该批最新一个功能提交**，不独立提交；关键是**每次普通 PR 都带一次**，素材随批落到 `main`。
 - 发版时把 `main` 上累积的 `Unreleased` 段标题转正式段 `## [X.Y.Z]`，补充 `### 更新公告`，版本号在 `chore(release)` 里改。
 
 这样发版面对的是一份已分好类的素材，无需再从几十条 commit 重新归纳。

--- a/pallas/core/foundation/config/__init__.py
+++ b/pallas/core/foundation/config/__init__.py
@@ -314,29 +314,17 @@ async def sync_bot_admins_to_admin_members(bot_id: int, admins: list[int]) -> No
 
     admin_members 是 ACL 引擎 admin_bypass 的数据真相；WebUI 直接改 BotConfig.admins
     时若不镜像，ACL 层不认新增号主。diff 出新增/删除后逐条 upsert/remove。
+    查询或写入失败时抛错，让调用方感知同步未完成，避免配置与 ACL 静默不一致。
     """
     from pallas.core.foundation.db import make_admin_repository
 
     desired = {int(u) for u in admins if int(u) != int(bot_id)}
     admin_repo = make_admin_repository()
-    try:
-        current = {int(m.user_id) for m in await admin_repo.list_members(scope="bot", bot_id=int(bot_id))}
-    except Exception:
-        current = set()
+    current = {int(m.user_id) for m in await admin_repo.list_members(scope="bot", bot_id=int(bot_id))}
     for uid in desired - current:
-        try:
-            await admin_repo.upsert_member(user_id=uid, scope="bot", bot_id=int(bot_id))
-        except Exception as exc:
-            log_rate_limited(
-                logger, "warning", "config.sync_admins_upsert", "sync admin_members upsert failed: {}", exc
-            )
+        await admin_repo.upsert_member(user_id=uid, scope="bot", bot_id=int(bot_id))
     for uid in current - desired:
-        try:
-            await admin_repo.remove_member(user_id=uid, scope="bot", bot_id=int(bot_id))
-        except Exception as exc:
-            log_rate_limited(
-                logger, "warning", "config.sync_admins_remove", "sync admin_members remove failed: {}", exc
-            )
+        await admin_repo.remove_member(user_id=uid, scope="bot", bot_id=int(bot_id))
     if desired != current:
         from pallas.api.perm import clear_acl_cache
 

--- a/tests/core/perm/test_admin_members_sync.py
+++ b/tests/core/perm/test_admin_members_sync.py
@@ -35,3 +35,19 @@ async def test_sync_bot_admins_skips_bot_self(beanie_fixture):
     admin_repo = make_admin_repository()
     uids = await admin_repo.list_admin_user_ids(bot_id=bot_id)
     assert set(uids) == {880_012}
+
+
+@pytest.mark.asyncio
+async def test_sync_bot_admins_raises_when_query_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """查询 admin_members 失败时抛错，不静默当空集合，避免旧号主残留。"""
+
+    class _FailingRepo:
+        async def list_members(self, **kwargs):
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(
+        "pallas.core.foundation.db.make_admin_repository",
+        lambda: _FailingRepo(),
+    )
+    with pytest.raises(RuntimeError, match="db down"):
+        await sync_bot_admins_to_admin_members(880_021, [880_022])


### PR DESCRIPTION
修复 Sourcery 阻塞评论（PR #330 遗留）：

- fix(webui): 号主编辑同步失败显式报错——sync_bot_admins_to_admin_members 查询 admin_members 失败不再当空集合（避免旧号主残留），upsert/remove 失败不再吞错，抛错让 WebUI 返回 500 感知同步未完成，避免配置与 ACL 静默不一致
- docs(skill): 普通 PR 的 CHANGELOG 并入最新功能提交（发版流程约定更新）

## Sourcery 总结

传播 bot-admin ACL 同步错误，并更新发布变更日志工作流。

错误修复：
- 在 WebUI 中编辑 bot-admin 时，显示管理员成员同步失败，而不是静默忽略错误，从而避免 ACL 条目过时和配置漂移。

文档：
- 要求普通拉取请求将未发布的 CHANGELOG 条目合并到该批次最新的功能提交中。

测试：
- 添加测试覆盖，确认管理员成员查询失败会被正确传播。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate bot-admin ACL synchronization errors and update the release changelog workflow.

Bug Fixes:
- Surface admin-member synchronization failures during WebUI bot-admin edits instead of silently masking them, preventing stale ACL entries and configuration drift.

Documentation:
- Require unreleased CHANGELOG entries for ordinary pull requests to be amended into the batch’s latest feature commit.

Tests:
- Add coverage confirming admin-member query failures are propagated.

</details>