### PR TITLE
feat(webui): 社区插件安装支持子目录插件包结构

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * feat(core): 默认启用 htmlrender playwright 渲染后端
 * feat(webui): 支持解析 NoneBot 官方嵌套插件 Config（env 键 __ 分隔）
+* feat(webui): 社区插件安装支持子目录插件包结构（pyproject 声明子目录）
 
 ### Fixed
 

--- a/docs/developer/plugin-development/publishing.md
+++ b/docs/developer/plugin-development/publishing.md
@@ -34,6 +34,8 @@ Core 不按独立插件发行，随主仓版本。
 
 分发方式：索引收录、Git 直装、或拷入本地插件目录。
 
+Git 直装支持两种仓库结构：根目录即插件包（含 `__init__.py`），或插件包位于子目录（`pyproject.toml` 的 `[tool.nonebot] plugins` 声明，如 PyPI 分发仓库）；后者安装时自动提升到 `local/plugins/<id>/` 根目录。
+
 ## 本地插件
 
 | MUST | MUST NOT |

--- a/pallas/console/webui/community_plugin_install.py
+++ b/pallas/console/webui/community_plugin_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import shutil
 from typing import TYPE_CHECKING
@@ -30,6 +31,9 @@ INSTALL_TIMEOUT_S = 300.0
 UNINSTALL_TIMEOUT_S = 60.0
 PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 ALLOWED_GIT_HOSTS = ("github.com", "gitlab.com", "gitee.com", "codeberg.org")
+# 子目录插件包布局的安装元数据（放仓库壳外，避免被 git clean 误删）
+_INSTALL_META_DIR = ".pallas-install"
+_NON_PLUGIN_SUBDIRS = frozenset({"tests", "test"})
 
 
 def _report(on_progress: ProgressReporter | None, percent: int, message: str) -> None:
@@ -129,6 +133,68 @@ def local_plugin_installed(plugin_id: str) -> bool:
     return path.is_dir() and (path / "__init__.py").is_file()
 
 
+def _install_meta_path(plugin_id: str) -> Path:
+    return community_plugins_root() / _INSTALL_META_DIR / f"{validate_plugin_id(plugin_id)}.json"
+
+
+def _read_install_meta(plugin_id: str) -> dict[str, str] | None:
+    try:
+        data = json.loads(_install_meta_path(plugin_id).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_install_meta(plugin_id: str, meta: dict[str, str]) -> None:
+    path = _install_meta_path(plugin_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _clear_install_meta(plugin_id: str) -> None:
+    try:
+        _install_meta_path(plugin_id).unlink()
+    except OSError:
+        pass
+
+
+def _find_subdir_plugin_package(dest: Path) -> Path | None:
+    """仓库根目录无 __init__.py 时，定位子目录插件包（pyproject 声明优先）。"""
+    from pallas.core.platform.bot_runtime.pyproject_plugins import parse_nonebot_plugin_config
+
+    modules, _dirs = parse_nonebot_plugin_config(dest / "pyproject.toml")
+    for mod in modules:
+        top = mod.split(".", 1)[0]
+        candidate = dest / top
+        if candidate.is_dir() and (candidate / "__init__.py").is_file():
+            return candidate
+    candidates = [
+        entry
+        for entry in dest.iterdir()
+        if entry.is_dir() and entry.name not in _NON_PLUGIN_SUBDIRS and (entry / "__init__.py").is_file()
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _promote_subdir_plugin(dest: Path, subdir: Path) -> None:
+    """把子目录插件包内容提升到仓库根目录，使 local/plugins/<id>/__init__.py 直接存在。"""
+    for item in sorted(subdir.iterdir(), key=lambda p: p.name):
+        target = dest / item.name
+        if target.exists():
+            raise CommunityPluginInstallError(
+                f"插件包子目录 {subdir.name} 与仓库根目录存在同名文件 {item.name}，无法自动适配",
+                status_code=502,
+            )
+        try:
+            shutil.move(str(item), str(target))
+        except OSError as e:
+            raise CommunityPluginInstallError(
+                f"插件包子目录 {subdir.name} 提升失败：{e}",
+                status_code=502,
+            ) from e
+    shutil.rmtree(subdir)
+
+
 async def install_community_plugin(
     plugin_id: str,
     *,
@@ -182,11 +248,19 @@ async def install_community_plugin(
         )
     _report(on_progress, 80, "校验插件包…")
     if not (dest / "__init__.py").is_file():
-        shutil.rmtree(dest, ignore_errors=True)
-        raise CommunityPluginInstallError(
-            "clone 完成但目录缺少 __init__.py，不是有效 NoneBot 插件包",
-            status_code=502,
-        )
+        subdir = _find_subdir_plugin_package(dest)
+        if subdir is None:
+            shutil.rmtree(dest, ignore_errors=True)
+            raise CommunityPluginInstallError(
+                "clone 完成但目录缺少 __init__.py，不是有效 NoneBot 插件包",
+                status_code=502,
+            )
+        try:
+            _promote_subdir_plugin(dest, subdir)
+        except CommunityPluginInstallError:
+            shutil.rmtree(dest, ignore_errors=True)
+            raise
+        _write_install_meta(pid, {"layout": "subdir", "subdir": subdir.name, "plugin_id": pid})
     dirs_ready = extra_plugin_dirs_ready()
     msg = f"已安装到 local/plugins/{pid}/。"
     if not dirs_ready:
@@ -272,6 +346,20 @@ async def update_community_plugin(
             status_code=502,
         )
     _report(on_progress, 85, "校验插件包…")
+    meta = _read_install_meta(pid)
+    if meta and meta.get("layout") == "subdir":
+        subdir_name = str(meta.get("subdir") or "")
+        if subdir_name:
+            code, _out, _err = await run_git_command(
+                INSTALL_TIMEOUT_S,
+                "clean",
+                "-fdx",
+                cwd=str(dest),
+            )
+            if code == 0:
+                subdir = dest / subdir_name
+                if subdir.is_dir() and (subdir / "__init__.py").is_file():
+                    _promote_subdir_plugin(dest, subdir)
     if not (dest / "__init__.py").is_file():
         raise CommunityPluginInstallError(
             "更新后目录缺少 __init__.py，不是有效 NoneBot 插件包",
@@ -317,6 +405,7 @@ async def uninstall_community_plugin(
         shutil.rmtree(dest)
     except OSError as e:
         raise CommunityPluginInstallError(f"删除目录失败：{e}", status_code=502) from e
+    _clear_install_meta(pid)
     _report(on_progress, 95, "删除完成")
     return {
         "plugin_id": pid,

--- a/tests/common/test_community_plugin_subdir_install.py
+++ b/tests/common/test_community_plugin_subdir_install.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _make_subdir_package(dest: Path, module: str = "nonebot_plugin_skland") -> None:
+    """构造「子目录插件包」仓库：根目录无 __init__.py，插件包在子目录。"""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "pyproject.toml").write_text(
+        f'[tool.nonebot]\nplugins = ["{module}"]\n',
+        encoding="utf-8",
+    )
+    sub = dest / module
+    sub.mkdir()
+    (sub / "__init__.py").write_text("", encoding="utf-8")
+
+
+def _make_root_package(dest: Path) -> None:
+    """构造「根目录即插件包」仓库。"""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "__init__.py").write_text("", encoding="utf-8")
+
+
+def _make_no_package(dest: Path) -> None:
+    """构造无插件包的仓库。"""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "README.md").write_text("", encoding="utf-8")
+
+
+def _write_meta(root: Path, plugin_id: str, meta: dict) -> None:
+    meta_dir = root / ".pallas-install"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    (meta_dir / f"{plugin_id}.json").write_text(
+        json.dumps(meta, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_promotes_subdir_package(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as mod
+
+    dest = tmp_path / "skland"
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[0] == "clone":
+            await asyncio.to_thread(_make_subdir_package, Path(args[-1]))
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(mod, "bot_lifecycle_available", lambda: True)
+
+    result = await mod.install_community_plugin(
+        "skland",
+        repository_url="https://github.com/PallasBot/pallas-plugin-skland",
+    )
+
+    assert result["installed"] is True
+    assert (dest / "__init__.py").is_file()
+    assert not (dest / "nonebot_plugin_skland").exists()
+    meta = json.loads((tmp_path / ".pallas-install" / "skland.json").read_text(encoding="utf-8"))
+    assert meta["layout"] == "subdir"
+    assert meta["subdir"] == "nonebot_plugin_skland"
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_root_package_unchanged(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as mod
+
+    dest = tmp_path / "demo"
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[0] == "clone":
+            await asyncio.to_thread(_make_root_package, Path(args[-1]))
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(mod, "bot_lifecycle_available", lambda: True)
+
+    result = await mod.install_community_plugin(
+        "demo",
+        repository_url="https://github.com/example/demo",
+    )
+
+    assert result["installed"] is True
+    assert (dest / "__init__.py").is_file()
+    assert not (tmp_path / ".pallas-install" / "demo.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_no_package_raises(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as mod
+    from pallas.console.webui.community_plugin_install import CommunityPluginInstallError
+
+    dest = tmp_path / "demo"
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[0] == "clone":
+            await asyncio.to_thread(_make_no_package, Path(args[-1]))
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+
+    with pytest.raises(CommunityPluginInstallError, match="不是有效 NoneBot 插件包"):
+        await mod.install_community_plugin(
+            "demo",
+            repository_url="https://github.com/example/demo",
+        )
+    assert not dest.exists()
+
+
+@pytest.mark.asyncio
+async def test_update_community_plugin_repromotes_subdir_package(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as mod
+
+    dest = tmp_path / "skland"
+    # 模拟已安装的提升布局：仓库壳内子目录（reset 后状态）+ 根目录提升残留 + 元数据
+    _make_subdir_package(dest)
+    (dest / "__init__.py").write_text("", encoding="utf-8")
+    _write_meta(tmp_path, "skland", {"layout": "subdir", "subdir": "nonebot_plugin_skland", "plugin_id": "skland"})
+
+    calls: list[list[str]] = []
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        calls.append(list(args))
+        if args[:2] == ("remote", "get-url"):
+            return 0, "https://github.com/PallasBot/pallas-plugin-skland.git", ""
+        if args[:1] == ("fetch",):
+            return 0, "fetched", ""
+        if args[:2] == ("reset", "--hard"):
+            return 0, "", ""
+        if args[:2] == ("clean", "-fdx"):
+            # 模拟 git clean 删除提升残留（未跟踪的根目录 __init__.py）
+            (dest / "__init__.py").unlink(missing_ok=True)
+            return 0, "", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "local_plugin_installed", lambda _pid: True)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(mod, "bot_lifecycle_available", lambda: True)
+
+    result = await mod.update_community_plugin("skland")
+
+    assert result["installed"] is True
+    assert (dest / "__init__.py").is_file()
+    assert not (dest / "nonebot_plugin_skland").exists()
+    assert ["clean", "-fdx"] in calls
+
+
+@pytest.mark.asyncio
+async def test_uninstall_community_plugin_clears_meta(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_install as mod
+
+    dest = tmp_path / "skland"
+    dest.mkdir()
+    (dest / "__init__.py").write_text("", encoding="utf-8")
+    _write_meta(tmp_path, "skland", {"layout": "subdir", "subdir": "nonebot_plugin_skland"})
+
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+
+    result = await mod.uninstall_community_plugin("skland")
+
+    assert result["installed"] is False
+    assert not dest.exists()
+    assert not (tmp_path / ".pallas-install" / "skland.json").exists()


### PR DESCRIPTION
社区插件 git 安装支持「子目录插件包」结构（如 pallas-plugin-skland：根目录无 `__init__.py`，插件包在 `nonebot_plugin_skland/` 子目录）。

- 安装：clone 后解析 pyproject `[tool.nonebot] plugins` 定位模块目录，提升到 `local/plugins/<id>/` 根目录，元数据写入 `local/plugins/.pallas-install/<id>.json`
- 更新/卸载/状态识别同步适配，原有「根目录即插件包」结构行为不变
- 新增 5 个测试覆盖安装/更新/卸载/回归

## Sourcery 摘要

支持安装在声明的子目录中打包的社区插件 Git 仓库，同时保持与根目录级插件包的兼容性。

新功能：
- 支持安装其包在 `pyproject.toml` 子目录中声明的社区插件，并将其提升到标准的本地插件布局中。

Bug 修复：
- 确保提升后的子目录插件包具有正确的更新和卸载行为，同时保留现有的根目录包行为。

文档：
- 记录两种受支持的 Git 插件仓库布局，包括通过 NoneBot 项目元数据声明的子目录包。

测试：
- 增加对子目录安装、根目录包回归、无效仓库、更新以及卸载时元数据清理的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support Git installation of community plugins packaged in declared subdirectories while maintaining compatibility with root-level plugin packages.

New Features:
- Support installing community plugins whose package is declared in a pyproject.toml subdirectory, promoting it into the standard local plugin layout.

Bug Fixes:
- Preserve correct update and uninstall behavior for promoted subdirectory plugin packages while retaining existing root-package behavior.

Documentation:
- Document the two supported Git plugin repository layouts, including subdirectory packages declared through NoneBot project metadata.

Tests:
- Add coverage for subdirectory installation, root-package regression, invalid repositories, updates, and metadata cleanup on uninstall.

</details>