### PR TITLE
feat(webui): 社区插件依赖自动安装与缺失展示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * feat(core): 默认启用 htmlrender playwright 渲染后端
 * feat(webui): 支持解析 NoneBot 官方嵌套插件 Config（env 键 __ 分隔）
 * feat(webui): 社区插件安装支持子目录插件包结构（pyproject 声明子目录）
+* feat(webui): 社区插件安装/更新自动装 pyproject 依赖，失败回滚并附手动命令
+* feat(webui): 启动时检测 local/plugins 插件依赖缺失并警告
+* feat(webui): 插件目录行暴露社区插件缺失依赖（deps_missing）
 
 ### Fixed
 

--- a/pallas/console/webui/community_plugin_deps.py
+++ b/pallas/console/webui/community_plugin_deps.py
@@ -1,0 +1,42 @@
+"""社区插件 pyproject 依赖安装（解析/比对复用 core 层纯函数）。"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING
+
+from pallas.console.webui.extension_install import run_uv_command, tail_output
+from pallas.core.platform.bot_runtime.plugin_deps import (
+    missing_dependencies,
+    parse_plugin_dependencies,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    ProgressReporter = Callable[[int, str], None]
+
+INSTALL_TIMEOUT_S = 600.0
+
+__all__ = ["parse_plugin_dependencies", "missing_dependencies", "install_missing_dependencies"]
+
+
+async def install_missing_dependencies(
+    dest: Path,
+    *,
+    on_progress: ProgressReporter | None = None,
+) -> tuple[list[str], list[str], str]:
+    """解析并安装缺失依赖。
+
+    返回 (已安装列表, 仍缺失列表, 错误详情)。仍缺失非空时错误详情为失败原因。
+    """
+    requirements = parse_plugin_dependencies(dest)
+    missing = missing_dependencies(requirements)
+    if not missing:
+        return [], [], ""
+    if on_progress is not None:
+        on_progress(88, "执行 uv pip install…")
+    code, out, err = await run_uv_command(INSTALL_TIMEOUT_S, "pip", "install", *missing)
+    if code != 0:
+        return [], missing, tail_output(err or out or "(无输出)")
+    return missing, [], ""

--- a/pallas/console/webui/community_plugin_install.py
+++ b/pallas/console/webui/community_plugin_install.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from nonebot import logger
 
 from pallas.console.cli.bot_process import bot_lifecycle_available
+from pallas.console.webui.community_plugin_deps import install_missing_dependencies
 from pallas.core.foundation.paths import PROJECT_ROOT
 from pallas.core.shared.utils.git_mirror import (
     BUILTIN_MIRRORS,
@@ -261,6 +262,15 @@ async def install_community_plugin(
             shutil.rmtree(dest, ignore_errors=True)
             raise
         _write_install_meta(pid, {"layout": "subdir", "subdir": subdir.name, "plugin_id": pid})
+    _report(on_progress, 85, "安装依赖…")
+    installed_deps, still_missing, deps_error = await install_missing_dependencies(dest, on_progress=on_progress)
+    if still_missing:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise CommunityPluginInstallError(
+            f"依赖安装失败：{deps_error}。请手动执行：uv pip install {' '.join(still_missing)}",
+            status_code=502,
+        )
+    _report(on_progress, 92, "依赖安装完成")
     dirs_ready = extra_plugin_dirs_ready()
     msg = f"已安装到 local/plugins/{pid}/。"
     if not dirs_ready:
@@ -273,6 +283,8 @@ async def install_community_plugin(
         "needs_restart": True,
         "extra_plugin_dirs_ready": dirs_ready,
         "restart_available": bot_lifecycle_available(),
+        "deps_installed": installed_deps,
+        "deps_missing": still_missing,
         "message": msg,
         "stdout_tail": tail_output(out),
     }
@@ -365,6 +377,14 @@ async def update_community_plugin(
             "更新后目录缺少 __init__.py，不是有效 NoneBot 插件包",
             status_code=502,
         )
+    _report(on_progress, 90, "安装依赖…")
+    installed_deps, still_missing, deps_error = await install_missing_dependencies(dest, on_progress=on_progress)
+    if still_missing:
+        raise CommunityPluginInstallError(
+            f"依赖安装失败：{deps_error}。请手动执行：uv pip install {' '.join(still_missing)}",
+            status_code=502,
+        )
+    _report(on_progress, 94, "依赖安装完成")
     dirs_ready = extra_plugin_dirs_ready()
     msg = f"已更新 local/plugins/{pid}/。"
     if not dirs_ready:
@@ -377,6 +397,8 @@ async def update_community_plugin(
         "needs_restart": True,
         "extra_plugin_dirs_ready": dirs_ready,
         "restart_available": bot_lifecycle_available(),
+        "deps_installed": installed_deps,
+        "deps_missing": still_missing,
         "message": msg,
         "stdout_tail": tail_output(out),
     }

--- a/pallas/console/webui/plugin_catalog/catalog.py
+++ b/pallas/console/webui/plugin_catalog/catalog.py
@@ -154,6 +154,14 @@ def build_plugin_catalog_rows(
             module_name=module_name,
             top_level_distributions=top_level_distributions,
         )
+        deps_missing: list[str] = []
+        if plugin_source == "community" and root is not None:
+            from pallas.core.platform.bot_runtime.plugin_deps import (
+                missing_dependencies,
+                parse_plugin_dependencies,
+            )
+
+            deps_missing = missing_dependencies(parse_plugin_dependencies(root))
         rows.append({
             "name": resolved_plugin_id,
             "nb_plugin_name": nb_name,
@@ -177,6 +185,7 @@ def build_plugin_catalog_rows(
             "uninstallable": uninstall_info["uninstallable"],
             "uninstall_kind": uninstall_info["uninstall_kind"],
             "uninstall_target": uninstall_info["uninstall_target"],
+            "deps_missing": deps_missing,
             "avatar": visuals["avatar"],
             "icon": visuals["icon"],
             "cover": visuals["cover"],

--- a/pallas/core/foundation/startup_report.py
+++ b/pallas/core/foundation/startup_report.py
@@ -31,6 +31,7 @@ _FACT_LABELS = {
 _WARNING_LABELS = {
     "llm": "LLM",
     "console": "控制台",
+    "plugin_deps": "插件依赖",
 }
 
 

--- a/pallas/core/platform/bot_runtime/plugin_deps.py
+++ b/pallas/core/platform/bot_runtime/plugin_deps.py
@@ -1,0 +1,45 @@
+"""插件 pyproject 依赖解析与缺失比对（core 层纯函数）。"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import tomllib
+from pathlib import Path  # noqa: TC003
+
+from nonebot import logger
+
+
+def parse_plugin_dependencies(dest: Path) -> list[str]:
+    """解析插件 pyproject.toml 的 [project].dependencies。无 pyproject 或无字段返回空列表。"""
+    toml_path = dest / "pyproject.toml"
+    if not toml_path.is_file():
+        return []
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    deps = data.get("project", {}).get("dependencies")
+    if not isinstance(deps, list):
+        return []
+    return [str(x).strip() for x in deps if str(x).strip()]
+
+
+def missing_dependencies(requirements: list[str]) -> list[str]:
+    """返回未安装或版本不满足的依赖。非法 requirement 跳过并记 warning。"""
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    missing: list[str] = []
+    for raw in requirements:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            logger.warning("插件依赖解析失败，跳过：{}", raw)
+            continue
+        try:
+            installed = importlib.metadata.version(req.name)
+        except importlib.metadata.PackageNotFoundError:
+            missing.append(raw)
+            continue
+        if not req.specifier.contains(installed):
+            missing.append(raw)
+    return missing

--- a/pallas/core/platform/bot_runtime/plugin_loader.py
+++ b/pallas/core/platform/bot_runtime/plugin_loader.py
@@ -182,6 +182,26 @@ def classify_site_local_plugins(plugin_dirs: list[Path]) -> tuple[int, int]:
     return len(plugin_dirs) - community, community
 
 
+def check_loaded_plugin_dependencies(plugin_dirs: list[Path]) -> None:
+    """对 local/plugins 已加载插件做依赖缺失检测，缺失则警告并登记启动事实。"""
+    from pallas.core.foundation.startup_report import register_startup_warning
+    from pallas.core.platform.bot_runtime.plugin_deps import missing_dependencies, parse_plugin_dependencies
+
+    missing_by_plugin: dict[str, list[str]] = {}
+    for plugin_dir in plugin_dirs:
+        requirements = parse_plugin_dependencies(plugin_dir)
+        if not requirements:
+            continue
+        missing = missing_dependencies(requirements)
+        if missing:
+            missing_by_plugin[plugin_dir.name] = missing
+    if not missing_by_plugin:
+        return
+    detail = "、".join(f"{pid}（{' '.join(deps)}）" for pid, deps in missing_by_plugin.items())
+    logger.warning("启动：社区插件依赖缺失，请用 uv pip install 补装：{}", detail)
+    register_startup_warning("plugin_deps", detail)
+
+
 def _load_slot_key(module_path: str) -> str:
     from pallas.core.platform.bot_runtime.plugin_package_aliases import canonical_plugin_package
 
@@ -483,6 +503,7 @@ def load_extra_plugin_dirs_by_source(
         loaded_plugin_dirs=site_local_plugin_dirs,
     )
     local, community = classify_site_local_plugins(site_local_plugin_dirs)
+    check_loaded_plugin_dependencies(site_local_plugin_dirs)
     extra = _load_toml_extra_plugin_dirs(custom_dirs, role_label=role_label, loaded_short=loaded_short)
     return local, community, extra
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "nonebot-plugin-htmlrender>=0.7,<0.8",
     "githubkit>=0.13,<0.14",
     "mdit-py-emoji>=0.1",
+    "packaging>=24.0",
     # 4.0 默认 PostgreSQL；Mongo 站点仍可用 beanie，多装这两项无害
     "sqlalchemy[asyncio]>=2.0",
     "asyncpg>=0.29",

--- a/tests/common/test_community_plugin_deps.py
+++ b/tests/common/test_community_plugin_deps.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+
+def _write_pyproject(dest: Path, deps: list[str] | None = None) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    lines = ["[project]", 'name = "demo"']
+    if deps is not None:
+        lines.append("dependencies = [")
+        lines.extend(f'    "{d}",' for d in deps)
+        lines.append("]")
+    (dest / "pyproject.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _make_root_package_with_deps(dest: Path, deps: list[str] | None = None) -> None:
+    _write_pyproject(dest, deps)
+    (dest / "__init__.py").write_text("", encoding="utf-8")
+
+
+def _always_missing_version(name: str) -> str:
+    raise importlib.metadata.PackageNotFoundError(name)
+
+
+def test_parse_plugin_dependencies_reads_project_dependencies(tmp_path) -> None:
+    from pallas.console.webui.community_plugin_deps import parse_plugin_dependencies
+
+    _write_pyproject(tmp_path, ["httpx>=0.27.0", "qrcode[pil]>=7.4.2"])
+    assert parse_plugin_dependencies(tmp_path) == ["httpx>=0.27.0", "qrcode[pil]>=7.4.2"]
+
+
+def test_parse_plugin_dependencies_missing_pyproject_returns_empty(tmp_path) -> None:
+    from pallas.console.webui.community_plugin_deps import parse_plugin_dependencies
+
+    assert parse_plugin_dependencies(tmp_path) == []
+
+
+def test_parse_plugin_dependencies_no_dependencies_field_returns_empty(tmp_path) -> None:
+    from pallas.console.webui.community_plugin_deps import parse_plugin_dependencies
+
+    _write_pyproject(tmp_path, None)
+    assert parse_plugin_dependencies(tmp_path) == []
+
+
+def test_missing_dependencies_filters_satisfied_and_invalid(monkeypatch) -> None:
+    from pallas.console.webui.community_plugin_deps import missing_dependencies
+
+    def fake_version(name: str) -> str:
+        versions = {"httpx": "0.28.0", "rich": "13.9.0"}
+        if name not in versions:
+            raise importlib.metadata.PackageNotFoundError(name)
+        return versions[name]
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    missing = missing_dependencies(
+        ["httpx>=0.27.0", "rich>=13.9.4", "qrcode[pil]>=7.4.2", "bad req!!"]
+    )
+    assert missing == ["rich>=13.9.4", "qrcode[pil]>=7.4.2"]
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_installs_missing_deps(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_deps as deps_mod
+    from pallas.console.webui import community_plugin_install as mod
+
+    dest = tmp_path / "skland"
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[0] == "clone":
+            await asyncio.to_thread(_make_root_package_with_deps, Path(args[-1]), ["httpx>=0.27.0"])
+            return 0, "", ""
+        return 0, "", ""
+
+    async def fake_uv(timeout_s: float, *args: str) -> tuple[int, str, str]:
+        return 0, "installed", ""
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(mod, "extra_plugin_dirs_ready", lambda: True)
+    monkeypatch.setattr(mod, "bot_lifecycle_available", lambda: True)
+    monkeypatch.setattr(deps_mod, "run_uv_command", fake_uv)
+    monkeypatch.setattr(importlib.metadata, "version", _always_missing_version)
+
+    result = await mod.install_community_plugin(
+        "skland",
+        repository_url="https://github.com/PallasBot/pallas-plugin-skland",
+    )
+
+    assert result["installed"] is True
+    assert result["deps_installed"] == ["httpx>=0.27.0"]
+    assert result["deps_missing"] == []
+    assert dest.exists()
+
+
+@pytest.mark.asyncio
+async def test_install_community_plugin_deps_failure_rolls_back(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_deps as deps_mod
+    from pallas.console.webui import community_plugin_install as mod
+    from pallas.console.webui.community_plugin_install import CommunityPluginInstallError
+
+    dest = tmp_path / "skland"
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[0] == "clone":
+            await asyncio.to_thread(_make_root_package_with_deps, Path(args[-1]), ["httpx>=0.27.0"])
+            return 0, "", ""
+        return 0, "", ""
+
+    async def fake_uv(timeout_s: float, *args: str) -> tuple[int, str, str]:
+        return 1, "", "network error"
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(deps_mod, "run_uv_command", fake_uv)
+    monkeypatch.setattr(importlib.metadata, "version", _always_missing_version)
+
+    with pytest.raises(CommunityPluginInstallError, match="依赖安装失败"):
+        await mod.install_community_plugin(
+            "skland",
+            repository_url="https://github.com/PallasBot/pallas-plugin-skland",
+        )
+    assert not dest.exists()
+
+
+@pytest.mark.asyncio
+async def test_update_community_plugin_deps_failure_keeps_dir(monkeypatch, tmp_path) -> None:
+    from pallas.console.webui import community_plugin_deps as deps_mod
+    from pallas.console.webui import community_plugin_install as mod
+    from pallas.console.webui.community_plugin_install import CommunityPluginInstallError
+
+    dest = tmp_path / "skland"
+    _make_root_package_with_deps(dest, ["httpx>=0.27.0"])
+
+    async def fake_git(timeout_s: float, *args: str, cwd: str | None = None) -> tuple[int, str, str]:
+        if args[:2] == ("remote", "get-url"):
+            return 0, "https://github.com/PallasBot/pallas-plugin-skland.git", ""
+        if args[:1] == ("fetch",):
+            return 0, "fetched", ""
+        if args[:2] == ("reset", "--hard"):
+            return 0, "", ""
+        return 0, "", ""
+
+    async def fake_uv(timeout_s: float, *args: str) -> tuple[int, str, str]:
+        return 1, "", "network error"
+
+    monkeypatch.setattr(mod, "run_git_command", fake_git)
+    monkeypatch.setattr(mod, "local_plugin_installed", lambda _pid: True)
+    monkeypatch.setattr(mod, "plugin_install_path", lambda _pid: dest)
+    monkeypatch.setattr(mod, "community_plugins_root", lambda: tmp_path)
+    monkeypatch.setattr(deps_mod, "run_uv_command", fake_uv)
+    monkeypatch.setattr(importlib.metadata, "version", _always_missing_version)
+
+    with pytest.raises(CommunityPluginInstallError, match="依赖安装失败"):
+        await mod.update_community_plugin("skland")
+    assert dest.exists()
+
+
+def test_check_loaded_plugin_dependencies_warns_on_missing(monkeypatch, tmp_path) -> None:
+    from pallas.core.platform.bot_runtime import plugin_deps as deps_mod
+    from pallas.core.platform.bot_runtime import plugin_loader as mod
+
+    plugin_dir = tmp_path / "skland"
+    plugin_dir.mkdir()
+
+    monkeypatch.setattr(deps_mod, "parse_plugin_dependencies", lambda _d: ["httpx>=0.27.0"])
+    monkeypatch.setattr(deps_mod, "missing_dependencies", lambda reqs: ["httpx>=0.27.0"])
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pallas.core.foundation.startup_report.register_startup_warning",
+        lambda key, value: warnings.append((key, value)),
+    )
+
+    mod.check_loaded_plugin_dependencies([plugin_dir])
+
+    assert warnings == [("plugin_deps", "skland（httpx>=0.27.0）")]
+
+
+def test_check_loaded_plugin_dependencies_silent_when_ok(monkeypatch, tmp_path) -> None:
+    from pallas.core.platform.bot_runtime import plugin_deps as deps_mod
+    from pallas.core.platform.bot_runtime import plugin_loader as mod
+
+    plugin_dir = tmp_path / "skland"
+    plugin_dir.mkdir()
+
+    monkeypatch.setattr(deps_mod, "parse_plugin_dependencies", lambda _d: ["httpx>=0.27.0"])
+    monkeypatch.setattr(deps_mod, "missing_dependencies", lambda reqs: [])
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pallas.core.foundation.startup_report.register_startup_warning",
+        lambda key, value: warnings.append((key, value)),
+    )
+
+    mod.check_loaded_plugin_dependencies([plugin_dir])
+
+    assert warnings == []
+
+
+def test_check_loaded_plugin_dependencies_skips_without_pyproject(monkeypatch, tmp_path) -> None:
+    from pallas.core.platform.bot_runtime import plugin_loader as mod
+
+    plugin_dir = tmp_path / "demo"
+    plugin_dir.mkdir()
+
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pallas.core.foundation.startup_report.register_startup_warning",
+        lambda key, value: warnings.append((key, value)),
+    )
+
+    mod.check_loaded_plugin_dependencies([plugin_dir])
+
+    assert warnings == []

--- a/tests/common/test_plugin_catalog.py
+++ b/tests/common/test_plugin_catalog.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,34 @@ def test_catalog_plugin_source_marks_registered_local_plugin_as_community(monkey
     assert catalog_plugin_source("demo_local", "local") == "community"
     assert catalog_plugin_source("manual_local", "local") == "local"
     assert catalog_plugin_source("take_name", "bundled") == "bundled"
+
+
+def test_catalog_row_reports_community_deps_missing(tmp_path, monkeypatch) -> None:
+    pkg = tmp_path / "demo"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\ndependencies = ["httpx>=0.27.0"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "pallas.core.foundation.config.repo_settings.resolve_extra_plugin_dirs",
+        lambda: [str(tmp_path)],
+    )
+    monkeypatch.setattr(
+        "pallas.console.webui.plugin_catalog.community_plugin_row_for_plugin",
+        lambda plugin_id: {"plugin_id": plugin_id} if plugin_id == "demo" else None,
+    )
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(importlib.metadata.PackageNotFoundError(name)),
+    )
+
+    rows = build_plugin_catalog_rows()
+    by_name = {r["name"]: r for r in rows}
+    assert by_name["demo"]["plugin_source"] == "community"
+    assert by_name["demo"]["deps_missing"] == ["httpx>=0.27.0"]
 
 
 def test_plugin_version_prefers_distribution_then_local_pyproject(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
社区插件商店安装/更新后自动解析 pyproject 依赖并用 uv pip install 只装缺失项；安装失败回滚目录，更新失败报错并附手动命令。启动时对 local/plugins 插件做依赖缺失检测并警告，插件目录行暴露 deps_missing 供 WebUI 展示。

## Sourcery 摘要

为社区插件添加自动依赖管理和缺失依赖可见性支持。

新功能：
- 在安装和更新期间，自动检测并安装社区插件 `pyproject.toml` 文件中声明的缺失依赖。
- 在插件目录列表中公开缺失的社区插件依赖，以便在 WebUI 中显示。
- 在启动时检查本地插件依赖，并通过启动警告报告缺失的软件包。

错误修复：
- 依赖安装失败时回滚新安装的插件目录；更新失败时保留现有目录，并提供手动安装命令。

增强功能：
- 添加用于解析插件需求和验证版本的共享依赖解析功能。

构建：
- 添加需求解析所需的 packaging 依赖。

测试：
- 添加对依赖解析、缺失软件包检测、安装和更新失败处理、启动警告以及目录报告的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic dependency management and missing-dependency visibility for community plugins.

New Features:
- Automatically detect and install missing dependencies declared in community plugins’ pyproject.toml files during installation and updates.
- Expose missing community-plugin dependencies in plugin catalog rows for WebUI display.
- Check local plugin dependencies at startup and report missing packages through startup warnings.

Bug Fixes:
- Roll back newly installed plugin directories when dependency installation fails, while preserving existing directories on update failures and providing manual installation commands.

Enhancements:
- Add shared dependency parsing and version validation for plugin requirements.

Build:
- Add the packaging dependency required for requirement parsing.

Tests:
- Add coverage for dependency parsing, missing-package detection, installation and update failure handling, startup warnings, and catalog reporting.

</details>