### PR TITLE
feat(insight): 语义风格受控模式与实验治理

### DIFF
--- a/docs/developer/architecture/group-insight-semantic-style.md
+++ b/docs/developer/architecture/group-insight-semantic-style.md
@@ -9,10 +9,16 @@
   -> message 表
   -> 主进程低频 sweep
   -> group.insight work job
-  -> message 去重与真人序列取对
-  -> LLM 批量标注
-  -> examples.jsonl / profiles.json
-  -> llm_chat 注入群表达指导与接话策略
+  -> 消息去重与真人序列取对
+  -> 本地确定性分类 + LLM 批量受控标注
+  -> examples.jsonl / profiles.json (schema v3)
+  -> llm_chat 注入群表达指导 / 受控行为模式 / 续句习惯
+
+低风险游戏协议
+  -> 同一消息窗口收集「Bot 提示 → 真人短命令」
+  -> protocol_examples.jsonl / protocol_patterns.json
+  -> 定向判定 + 10 分钟冷却
+  -> 协议命令直投
 ```
 
 回复形状是旁边的一条确定性链路：
@@ -94,8 +100,10 @@ work aux 消费 `group.insight` 后，按该 `(bot_id, group_id)` 的持久化�
 
 回复端不再强制要求是真人：
 
-- 真人接真人：可以进入 `direct_pairs`，作为群表达指导。
-- 真人接 Bot：可以进入 `self_reflection`，只沉淀 Bot 自己的接话策略，不进入真人措辞样本。
+- 真人接真人：`conversation_pair`，可进入 `direct_pairs` 与受控行为聚合。
+- 真人接 Bot：`self_reflection` 候选，只沉淀行为策略；本期不注入群级指导。
+- 同一真人的相邻前后句：`continuation_pair`，只聚合表达结构，不作两人对话。
+- Bot 提示 → 真人短命令（quoted）：进入独立协议采集，不混入群表达画像。
 
 消息正文在送入标注前会折叠空白并截断；CQ 图片、表情和其它媒体码分别替换为 `[图片]`、`[表情]`、`[媒体]`。语义风格只需要知道存在媒体，不需要在这一环节理解图片细节。
 
@@ -128,9 +136,10 @@ work aux 消费 `group.insight` 后，按该 `(bot_id, group_id)` 的持久化�
 - `is_reply_pair`：是否确实在回应前句
 - `transferable`：脱离临时人名、局部梗和临时事实后是否仍可复用
 - 接话动作、语义关系、强度、表达形式
-- 可选的 `behavior_strategy`
 
 只有 `is_reply_pair=true` 且 `transferable=true` 的结果才写入语义样本。完整标注完成后，才推进该群的持久化游标。
+
+送标注前先做确定性清洗：纯媒体 trigger、机器人菜单/欢迎话术、CQ 原码、URL、长数字与内部 token 元数据在本地直接跳过，不消耗预算，也不进入样本。
 
 语义标注预算配置为 `llm_semantic_style_realtime_daily_limit`，默认每天 600 次。预算计数文件位于：
 
@@ -161,14 +170,69 @@ data/pb_webui/repeater_semantic_style/profiles.json
 
 落盘过程使用进程锁和跨进程文件锁，并按 `example_id` 去重。写入样本后会重建 profile；缓存进程启动时加载，之后按周期刷新。
 
-`llm_chat` 需要明确唤醒并通过当前回合决策后，才会读取对应的语义 profile。可消费的内容包括：
+每个 example 按 `pair_kind` 区分两类来源：
 
-- `direct_pairs`：群表达指导中的历史措辞参考
-- `observed` 行为策略：`【真人接话参考】`
-- `self_reflection` 行为策略：`【接话复盘】`
-- 经过约束的 `direct_candidate`
+- `conversation`：两个不同真人的前句→接话，可进入具体措辞参考和受控行为聚合。
+- `continuation`：同一说话者的连续发言，只聚合表达结构（补充/转折/追问），不作两人对话，也永不直投。
+
+旧样本读取时自动按「同作者连续发言」推导 `pair_kind`，无需重新标注。
+
+画像使用 schema_version 3，样本聚合到三种模式：
+
+- `direct_pairs`：具体真人前句→接话对，作为 `【群表达指导】` 的措辞参考。
+- `behavior_patterns`：受控 `action + relation + form + intensity` 聚合，含代表 trigger；达到 3 次且至少 2 名回复者才允许注入，渲染成 `【真人接话模式】` 中文指导。
+- `continuation_patterns`：同人续句的结构模式，达到 3 次且至少 2 名说话者才注入，渲染成 `【本群续句习惯】`。
+
+`llm_chat` 需要明确唤醒并通过当前回合决策后，才会读取对应的语义 profile。prompt 注入优先级：
+
+1. 命中的具体 `direct_pairs` 最多 2 条（此时不再追加旧 `rewrite_seed`/“可借鉴句式”）。
+2. 无具体样本时，命中的受控行为模式最多 2 条。
+3. injectable 续句习惯最多 1 条。
+
+普通直投只对少数低风险受控 action（`agree`/`support`）发送代码内固定安全短句；需要同类 action 至少 2 次、来自至少 2 名回复者并命中代表 trigger。其它 action 只进 Provider prompt，不绕过模型复刻真人原句。
+
+节奏基线（单气泡占比、段长中位数）已从语义 prompt 移除，生成节奏统一由 `reply_shape` 控制；画像中仍保留相应统计供审计。
 
 语义样本不是强制回复模板。人设、关系和当前回合决策优先，群级样本只提供局部表达差异。
+
+## 6a. 迁移与回滚
+
+`profiles.json` 首次以 v3 写入前会自动备份旧版到：
+
+```text
+data/pb_webui/repeater_semantic_style/backups/profiles-v2-<时间戳>.json
+```
+
+settings 记录 `active_pipeline`（默认 `v3`）。回滚只切换读取与注入到最近一份 v2 备份，不停止 v3 采集，也不改写主文件；WebUI 语义风格页提供「回滚 v2 读管线」维护操作。v2 备份保留 14 天，确认稳定后删除。
+
+## 6b. 实验治理与熔断
+
+注入位按 `bot × group × 北京自然日` 稳定分桶建立 10% 对照组：同一群当天体验一致，次日可换桶。
+
+投递成功后记录 exposure（request、bucket、注入类型、source id、delivery source），后台约每 60 秒结算一次：
+
+- 目标用户在 90 秒或后续 3 条真人消息内继续回应/引用 Bot：`target_followup=true`。
+- 高置信纠正/拒绝短语（如“别回”“答非所问”）：`negative=true`；现有“不可以”、撤回等显式 outcome 也计入。
+
+实验至少累计 200 回合、对照至少 20 回合后，若实验负反馈率比对照高至少 3 个百分点且达到 1.5 倍，自动停用语义注入但继续采集；`experiment_governance` 状态暴露熔断原因与两组计数，WebUI 可人工确认恢复。
+
+## 6c. 低风险游戏协议
+
+协议独立于群表达画像，从语义游标窗口收集「Bot 提示 → 真人短命令」的 quoted 对。仅当：
+
+- real 回复与 trigger 中显式候选（`发送「X」`/`回复「X」`）完全一致；
+- 命令 2–16 字，不含管理、权限、付费、转账、登录、验证码、删除、退群、禁言等风险词；
+- 同模板+命令累计 3 次且来自至少 2 名真人；
+
+才允许自动回复。运行时定向满足明确 @、引用当前 Bot、账号标识之一，或「文本含别名且当前 Bot 是最近 3 分钟该群最后发言的本地 Bot」；无最近 Bot 不兜底。协议使用独立 `bot × group` 10 分钟冷却，不占普通直投配额。
+
+数据文件：
+
+```text
+data/pb_webui/repeater_semantic_style/protocol_examples.jsonl
+data/pb_webui/repeater_semantic_style/protocol_patterns.json
+data/pb_webui/repeater_semantic_style/protocol_cooldowns.json
+```
 
 日常 Repeater 接话仍直接投递 Repeater 语料，不调用语义标注 LLM，也不经过 LLM 选句或润色。
 
@@ -231,7 +295,7 @@ graph extract 实体与关系
 - 人物事实：归属到具体 `(bot, group, user)`
 - 好感度：单用户即时触发，有独立冷却和预算
 - session summary：会压缩或删除旧会话历史，副作用不同
-- 群表达语义标注：输入是前句→接话对，输出是迁移性和接话策略
+- 群表达语义标注：输入是前句→接话对，输出是迁移性与受控标签（动作/关系/形式/强度）
 
 禁止跨 Bot、跨群、私聊与群聊混批。共同使用 Provider、预算工具或 work aux，不等于可以共同使用同一次模型提交。
 
@@ -244,12 +308,16 @@ graph extract 实体与关系
 | 样例摘要为空 | WebUI scope 是否选择了实际有 profile 的 Bot，检查 `profiles.json` |
 | 回复形态全为 0 | `group_config.style_profile` 更新时间、`group_style_refresh` dirty 刷新及 message 去重取数 |
 | 预算快速耗尽 | `semantic_style_label_budget.json`、批量请求失败比例、fallback/retry 日志 |
+| 实验注入未生效 | `active_pipeline` 是否 v2 回滚、`experiment_governance` 是否已熔断、群日是否命中对照桶 |
+| 协议未响应 | 命令是否在显式候选、模板次数/真人门槛、冷却时间、最近发言 Bot 判定 |
 
 代码入口：
 
 - `pallas/core/platform/ingress/message_recorder.py`
 - `pallas/product/llm/group_insight_processor.py`
 - `pallas/product/llm/repeater_semantic_style.py`
+- `pallas/product/llm/semantic_protocol.py`
+- `pallas/product/llm/semantic_style_experiment.py`
 - `pallas/product/persona/group_profiler.py`
 - `pallas/product/persona/group_style_refresh.py`
 - `packages/llm_chat/chat_message.py`

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.4.1-11-ge1605846",
+    "version": "v4.4.1-12-g4b6d6d2a-dirty",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -38272,6 +38272,11 @@
               }
             ],
             "title": "V2 Backup"
+          },
+          "experiment_governance": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Experiment Governance"
           },
           "backfill_cursor": {
             "additionalProperties": true,

--- a/openspec/pallas-console-v1.json
+++ b/openspec/pallas-console-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Pallas-Bot 控制台 API",
-    "version": "v4.3.13-35-g11895f8e",
+    "version": "v4.4.1-11-ge1605846",
     "description": "仅包含控制台 API 前缀下的接口。"
   },
   "paths": {
@@ -38014,7 +38014,8 @@
               "recover",
               "disable",
               "enable",
-              "set_governance"
+              "set_governance",
+              "rollback_v2"
             ],
             "title": "Action"
           },
@@ -38231,6 +38232,11 @@
             ],
             "title": "Direct Enabled"
           },
+          "active_pipeline": {
+            "type": "string",
+            "title": "Active Pipeline",
+            "default": "v3"
+          },
           "example_count": {
             "type": "integer",
             "title": "Example Count",
@@ -38240,6 +38246,32 @@
             "type": "integer",
             "title": "Profile Count",
             "default": 0
+          },
+          "schema_version": {
+            "type": "integer",
+            "title": "Schema Version",
+            "default": 3
+          },
+          "injectable_behavior_patterns": {
+            "type": "integer",
+            "title": "Injectable Behavior Patterns",
+            "default": 0
+          },
+          "injectable_continuation_patterns": {
+            "type": "integer",
+            "title": "Injectable Continuation Patterns",
+            "default": 0
+          },
+          "v2_backup": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "V2 Backup"
           },
           "backfill_cursor": {
             "additionalProperties": true,

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -185,6 +185,30 @@ def emit_turn_telemetry(
     )
 
 
+def _semantic_injection_types(semantic_style: object) -> list[str]:
+    """汇总本轮实际注入的语义来源类型，供 exposure 观测。"""
+    types: list[str] = []
+    if getattr(semantic_style, "matched_examples", None):
+        types.append("direct_example")
+    if getattr(semantic_style, "behavior_patterns", None):
+        types.append("behavior_pattern")
+    if getattr(semantic_style, "continuation_patterns", None):
+        types.append("continuation_pattern")
+    if getattr(semantic_style, "direct_candidate", None):
+        types.append("semantic_direct")
+    return types
+
+
+def _semantic_source_ids(semantic_style: object) -> list[str]:
+    """本轮注入样本的稳定 source id，供负反馈归因。"""
+    ids: list[str] = []
+    for pair in list(getattr(semantic_style, "matched_example_sources", None) or [])[:8]:
+        source_id = str(getattr(pair, "source_example_id", "") or "").strip()
+        if source_id:
+            ids.append(source_id)
+    return ids
+
+
 def build_injection_snapshot(
     *,
     ambient_turns: list[dict[str, object]],
@@ -1443,6 +1467,8 @@ async def prepare_and_submit_llm_chat_turn(
                 "behavior_hint": behavior_hint,
                 "semantic_style_source_example_id": getattr(semantic_style, "source_example_id", "") or None,
                 "semantic_style_direct_candidate": semantic_style.direct_candidate or None,
+                "semantic_injection_types": _semantic_injection_types(semantic_style),
+                "semantic_source_ids": _semantic_source_ids(semantic_style),
                 "recent_group_bot_speaker": recent_group_bot_speaker(group_id=group_id) if group_id else None,
                 "reply_max_length": int(reply_max_length or 0),
                 "reply_max_bubbles": int(reply_shape.max_bubbles or 1),

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -36,7 +36,7 @@ from pallas.product.llm.behavior import (
     select_behavior_patterns,
 )
 from pallas.product.llm.behavior_store import ensure_default_behavior_patterns
-from pallas.product.llm.bot_reply_context import lookup_bot_reply_context
+from pallas.product.llm.bot_reply_context import lookup_bot_reply_context, recent_group_bot_speaker
 from pallas.product.llm.budget import trim_messages_to_char_budget
 from pallas.product.llm.chat_queue import (
     begin_chat_turn,
@@ -1443,6 +1443,7 @@ async def prepare_and_submit_llm_chat_turn(
                 "behavior_hint": behavior_hint,
                 "semantic_style_source_example_id": getattr(semantic_style, "source_example_id", "") or None,
                 "semantic_style_direct_candidate": semantic_style.direct_candidate or None,
+                "recent_group_bot_speaker": recent_group_bot_speaker(group_id=group_id) if group_id else None,
                 "reply_max_length": int(reply_max_length or 0),
                 "reply_max_bubbles": int(reply_shape.max_bubbles or 1),
                 "reply_total_length_band": reply_shape.total_length_band,

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -194,8 +194,6 @@ def _semantic_injection_types(semantic_style: object) -> list[str]:
         types.append("behavior_pattern")
     if getattr(semantic_style, "continuation_patterns", None):
         types.append("continuation_pattern")
-    if getattr(semantic_style, "direct_candidate", None):
-        types.append("semantic_direct")
     return types
 
 
@@ -206,6 +204,9 @@ def _semantic_source_ids(semantic_style: object) -> list[str]:
         source_id = str(getattr(pair, "source_example_id", "") or "").strip()
         if source_id:
             ids.append(source_id)
+    direct_source_id = str(getattr(semantic_style, "source_example_id", "") or "").strip()
+    if direct_source_id and direct_source_id not in ids:
+        ids.append(direct_source_id)
     return ids
 
 
@@ -300,6 +301,9 @@ async def load_recent_bot_plain_replies(bot_id: int, group_id: int, *, limit: in
 def llm_chat_rule(event: Event) -> bool:
     if not is_llm_chat_service_enabled():
         return False
+    # 联邦别名命中器可能传入未实例化为 OneBot Event 的轻量事件对象。
+    if bool(getattr(event, "_pallas_llm_alias_hard_trigger", False)):
+        return True
     if not isinstance(event, GroupMessageEvent):
         return False
     is_to_me = bool(getattr(event, "to_me", False) or getattr(event, "_pallas_llm_alias_hard_trigger", False))
@@ -1151,6 +1155,9 @@ async def prepare_and_submit_llm_chat_turn(
             query_text=focus_text,
             recent_assistant_replies=recent_reply_texts[:6],
         )
+        from pallas.product.llm.semantic_style_experiment import semantic_style_bucket
+
+        semantic_bucket = semantic_style_bucket(int(bot.self_id), int(group_id)) if group_id else -1
         direct_context_started = time.perf_counter()
         group_timeline = ""
         group_timeline_images: list[dict[str, str]] = []
@@ -1303,7 +1310,11 @@ async def prepare_and_submit_llm_chat_turn(
         group_expression = ResolvedGroupExpression(
             matched_examples=semantic_examples,
             baseline_note="",
-            prompt_block=str(getattr(semantic_style, "prompt_block", "") or ""),
+            prompt_block=(
+                str(getattr(semantic_style, "prompt_block", "") or "")
+                if getattr(semantic_style, "active_pipeline", "v3") == "v2"
+                else ""
+            ),
             behavior_strategies=[
                 item
                 for item in (getattr(semantic_style, "behavior_strategies", None) or [])[:2]
@@ -1469,6 +1480,7 @@ async def prepare_and_submit_llm_chat_turn(
                 "semantic_style_direct_candidate": semantic_style.direct_candidate or None,
                 "semantic_injection_types": _semantic_injection_types(semantic_style),
                 "semantic_source_ids": _semantic_source_ids(semantic_style),
+                "semantic_bucket": semantic_bucket,
                 "recent_group_bot_speaker": recent_group_bot_speaker(group_id=group_id) if group_id else None,
                 "reply_max_length": int(reply_max_length or 0),
                 "reply_max_bubbles": int(reply_shape.max_bubbles or 1),
@@ -1527,6 +1539,15 @@ async def prepare_and_submit_llm_chat_turn(
                     "pre_submit_context_durations_ms": pre_submit_context_durations_ms,
                     "semantic_style_direct_candidate": semantic_style.direct_candidate or None,
                     "semantic_style_source_example_id": getattr(semantic_style, "source_example_id", "") or None,
+                    "user_text": llm_user_text,
+                    "recent_group_bot_speaker": recent_group_bot_speaker(group_id=group_id) if group_id else None,
+                    "protocol_explicit_target": bool(replied_message_id)
+                    or (
+                        bool(getattr(event, "to_me", False))
+                        and not bool(getattr(event, "_pallas_llm_alias_hard_trigger", False))
+                    ),
+                    "protocol_nickname_target": bool(getattr(event, "_pallas_llm_alias_hard_trigger", False))
+                    or speak_trigger == "mention",
                     "turn_id": turn_id,
                     "speak_trigger": speak_trigger or "to_me",
                 },

--- a/packages/llm_chat/chat_message.py
+++ b/packages/llm_chat/chat_message.py
@@ -1278,13 +1278,15 @@ async def prepare_and_submit_llm_chat_turn(
             )
         group_expression = ResolvedGroupExpression(
             matched_examples=semantic_examples,
-            baseline_note=str(getattr(semantic_style, "baseline_note", "") or ""),
+            baseline_note="",
             prompt_block=str(getattr(semantic_style, "prompt_block", "") or ""),
             behavior_strategies=[
                 item
                 for item in (getattr(semantic_style, "behavior_strategies", None) or [])[:2]
                 if str(getattr(item, "scene", "") or "").strip() and str(getattr(item, "action", "") or "").strip()
             ],
+            behavior_patterns=list(getattr(semantic_style, "behavior_patterns", None) or [])[:2],
+            continuation_patterns=list(getattr(semantic_style, "continuation_patterns", None) or [])[:1],
         )
         core_persona = system_prompt
         if persona_bundle is not None:

--- a/packages/llm_chat/startup.py
+++ b/packages/llm_chat/startup.py
@@ -3,9 +3,11 @@ from pallas.product.llm.behavior_feedback import register_behavior_feedback_loop
 from pallas.product.llm.group_insight_processor import register_group_insight_startup_hook
 from pallas.product.llm.repeater_semantic_style import register_semantic_style_cache_startup_hook
 from pallas.product.llm.runtime_api import register_llm_tools_startup_hook
+from pallas.product.llm.semantic_style_experiment import register_semantic_experiment_loop
 
 register_llm_tools_startup_hook()
 register_semantic_style_cache_startup_hook()
 register_group_insight_startup_hook()
 register_behavior_feedback_loop()
+register_semantic_experiment_loop()
 register_arknights_kb_startup_hook()

--- a/packages/pb_webui/llm_product_api.py
+++ b/packages/pb_webui/llm_product_api.py
@@ -85,6 +85,7 @@ class _SemanticStyleManageBody(BaseModel):
         "disable",
         "enable",
         "set_governance",
+        "rollback_v2",
     ]
     bot_id: int | None = None
     group_id: int | None = None
@@ -117,8 +118,13 @@ class _SemanticStyleStatusData(BaseModel):
     collection_enabled: bool = True
     injection_enabled: bool = True
     direct_enabled: bool | None = None
+    active_pipeline: str = "v3"
     example_count: int = 0
     profile_count: int = 0
+    schema_version: int = 3
+    injectable_behavior_patterns: int = 0
+    injectable_continuation_patterns: int = 0
+    v2_backup: str | None = None
     backfill_cursor: dict[str, Any] = Field(default_factory=dict)
     profile_summary: _SemanticStyleProfileSummaryData | None = None
 
@@ -289,6 +295,8 @@ def register_llm_product_router(
                     if scope
                     else semantic_style.set_semantic_style_enabled(True)
                 )
+            elif action == "rollback_v2":
+                data = semantic_style.set_semantic_style_active_pipeline("v2")
             else:
                 data = (
                     semantic_style.set_semantic_style_enabled(False, **scope)

--- a/packages/pb_webui/llm_product_api.py
+++ b/packages/pb_webui/llm_product_api.py
@@ -125,6 +125,7 @@ class _SemanticStyleStatusData(BaseModel):
     injectable_behavior_patterns: int = 0
     injectable_continuation_patterns: int = 0
     v2_backup: str | None = None
+    experiment_governance: dict[str, Any] = Field(default_factory=dict)
     backfill_cursor: dict[str, Any] = Field(default_factory=dict)
     profile_summary: _SemanticStyleProfileSummaryData | None = None
 

--- a/pallas/product/llm/assembler/chat_prompt.py
+++ b/pallas/product/llm/assembler/chat_prompt.py
@@ -22,6 +22,8 @@ class ResolvedGroupExpression:
     matched_examples: list[tuple[str, str]] = field(default_factory=list)
     baseline_note: str = ""
     behavior_strategies: list[BehaviorStrategy] = field(default_factory=list)
+    behavior_patterns: list[object] = field(default_factory=list)
+    continuation_patterns: list[object] = field(default_factory=list)
     prompt_block: str = ""
 
 
@@ -150,16 +152,13 @@ class ChatPromptAssembler:
     def _group_expression_block(expression: ResolvedGroupExpression | None) -> str:
         if expression is None:
             return ""
-        lines = ["【群表达指导】", "- 仅作措辞参考，不能覆盖核心人格、账号气质或本轮策略。"]
+        lines = ["【群表达指导】", "- 以下是本群真人接话参考，只借鉴接法，不照抄原句。"]
         for trigger, reply in expression.matched_examples[:4]:
             safe_trigger = sanitize_prompt_block(trigger, max_len=80)
             safe_reply = sanitize_prompt_block(reply, max_len=120)
             if safe_reply:
                 prefix = f"触发「{safe_trigger}」时" if safe_trigger else "可借鉴"
                 lines.append(f"- {prefix}：{safe_reply}")
-        baseline = sanitize_prompt_block(expression.baseline_note, max_len=120)
-        if baseline:
-            lines.append(f"- {baseline}")
         prompt_block = sanitize_prompt_block(expression.prompt_block, max_len=240)
         if prompt_block:
             lines.append(prompt_block)
@@ -169,41 +168,24 @@ class ChatPromptAssembler:
     def _group_behavior_reference_block(expression: ResolvedGroupExpression | None) -> str:
         if expression is None:
             return ""
-        grouped: dict[str, list[BehaviorStrategy]] = {
-            "observed": [],
-            "self_reflection": [],
-        }
-        for strategy in expression.behavior_strategies[:3]:
-            if not str(strategy.scene or "").strip() or not str(strategy.action or "").strip():
-                continue
-            grouped.setdefault(str(getattr(strategy, "learning_type", "observed") or "observed"), []).append(strategy)
-
-        observed = grouped.get("observed", [])
-        reflection = grouped.get("self_reflection", [])
         lines: list[str] = []
-        if observed:
+        if expression.behavior_patterns:
+            from pallas.product.llm.repeater_semantic_style import behavior_pattern_prompt_line
+
             lines.extend([
-                "【真人接话参考】",
-                "- 以下来自本群真人互动的节奏与接话结构，只借鉴什么时候说短/长、怎么接，"
-                "不要复刻原话或语气；语气态度保持你自己的底色。",
+                "【真人接话模式】",
+                "- 以下是本群真人互动中反复出现的接话方式，只借鉴怎么接，不要复刻原话。",
             ])
-            for strategy in observed[:3]:
-                scene = sanitize_prompt_block(strategy.scene, max_len=80)
-                action = sanitize_prompt_block(strategy.action, max_len=120)
-                if scene and action:
-                    tail = f"，结果{sanitize_prompt_block(strategy.outcome, max_len=80)}" if strategy.outcome else ""
-                    lines.append(f"- 类似「{scene}」时，真人会{action}{tail}。")
-        if reflection:
+            for pattern in expression.behavior_patterns[:3]:
+                representative = pattern.representative_triggers[-1] if pattern.representative_triggers else ""
+                if not representative:
+                    continue
+                lines.append(behavior_pattern_prompt_line(pattern, representative))
+        if expression.continuation_patterns:
             lines.extend([
-                "【接话复盘】",
-                "- 以下是你之前自己接话的例子，只参考每次接得怎么样，别照搬原话或当时的用词。",
+                "【本群续句习惯】",
+                "- 补充或转折内容常另起一条短句；不要把这种续句误当成两个人对话。",
             ])
-            for strategy in reflection[:3]:
-                scene = sanitize_prompt_block(strategy.scene, max_len=80)
-                action = sanitize_prompt_block(strategy.action, max_len=120)
-                if scene and action:
-                    tail = f"，结果{sanitize_prompt_block(strategy.outcome, max_len=80)}" if strategy.outcome else ""
-                    lines.append(f"- 类似「{scene}」时，我之前是这样接的：{action}{tail}。")
         return "\n".join(lines)
 
     @staticmethod

--- a/pallas/product/llm/assembler/chat_prompt.py
+++ b/pallas/product/llm/assembler/chat_prompt.py
@@ -181,6 +181,22 @@ class ChatPromptAssembler:
                 if not representative:
                     continue
                 lines.append(behavior_pattern_prompt_line(pattern, representative))
+        elif expression.behavior_strategies:
+            observed = [
+                strategy
+                for strategy in expression.behavior_strategies[:3]
+                if str(strategy.scene or "").strip() and str(strategy.action or "").strip()
+            ]
+            if observed:
+                lines.extend([
+                    "【真人接话参考】",
+                    "- 以下来自旧版群表达画像，只借鉴接话结构，不要复刻原话或语气。",
+                ])
+                for strategy in observed:
+                    scene = sanitize_prompt_block(strategy.scene, max_len=80)
+                    action = sanitize_prompt_block(strategy.action, max_len=120)
+                    if scene and action:
+                        lines.append(f"- 类似「{scene}」时，真人会{action}。")
         if expression.continuation_patterns:
             lines.extend([
                 "【本群续句习惯】",

--- a/pallas/product/llm/bot_reply_context.py
+++ b/pallas/product/llm/bot_reply_context.py
@@ -6,6 +6,9 @@ from collections import OrderedDict
 _TTL_SEC = 600.0
 _MAX_ENTRIES = 512
 _reply_contexts: OrderedDict[tuple[int, int, int], tuple[float, str]] = OrderedDict()
+# 群内最近成功发言的本地 Bot：供昵称定向协议判定「最近 3 分钟最后说话者」。
+_RECENT_SPEAKER_TTL_SEC = 180.0
+_recent_speakers: dict[int, tuple[float, int]] = {}
 
 
 def record_bot_reply_context(*, group_id: int, bot_id: int, message_id: int | None, text: str) -> None:
@@ -17,6 +20,22 @@ def record_bot_reply_context(*, group_id: int, bot_id: int, message_id: int | No
     _reply_contexts.move_to_end(key)
     while len(_reply_contexts) > _MAX_ENTRIES:
         _reply_contexts.popitem(last=False)
+    _recent_speakers[int(group_id)] = (time.monotonic() + _RECENT_SPEAKER_TTL_SEC, int(bot_id))
+
+
+def recent_group_bot_speaker(*, group_id: int) -> int | None:
+    """最近 3 分钟内该群最后成功发言的本地 Bot；无记录或已过期返回 None。"""
+    gid = int(group_id)
+    if gid <= 0:
+        return None
+    record = _recent_speakers.get(gid)
+    if record is None:
+        return None
+    expires_at, bot_id = record
+    if expires_at <= time.monotonic():
+        _recent_speakers.pop(gid, None)
+        return None
+    return bot_id
 
 
 def lookup_bot_reply_context(*, group_id: int, bot_id: int, message_id: int | None) -> str | None:
@@ -36,3 +55,4 @@ def lookup_bot_reply_context(*, group_id: int, bot_id: int, message_id: int | No
 
 def clear_bot_reply_context_for_tests() -> None:
     _reply_contexts.clear()
+    _recent_speakers.clear()

--- a/pallas/product/llm/delivery.py
+++ b/pallas/product/llm/delivery.py
@@ -878,6 +878,31 @@ async def deliver_llm_callback_success(
                 f"Bot [{bot_id}] delivered a reply in group [{group_id}], length [{len(reply_text)}]",
             )
         )
+    if task_type == LLM_CHAT_TASK_TYPE and text_delivered and bot_message_id:
+        try:
+            from pallas.product.llm.semantic_style_experiment import (
+                record_semantic_exposure,
+                semantic_style_bucket,
+            )
+
+            record_semantic_exposure(
+                request_id=str(task.get("request_id") or task_id),
+                bot_id=int(bot_id) if bot_id is not None else 0,
+                group_id=int(group_id) if group_id is not None else 0,
+                user_id=int(task.get("user_id") or 0) or 0,
+                bucket=semantic_style_bucket(
+                    int(bot_id) if bot_id is not None else 0,
+                    int(group_id) if group_id is not None else 0,
+                ),
+                injection_types=[
+                    str(item) for item in list(task.get("semantic_injection_types") or []) if str(item).strip()
+                ],
+                source_ids=[str(item) for item in list(task.get("semantic_source_ids") or []) if str(item).strip()],
+                delivery_source=str(task.get("delivery_source") or "provider"),
+                bot_message_id=bot_message_id,
+            )
+        except Exception:
+            logger.debug("semantic exposure record skipped for task [{}]", task_id)
     return reply_text, text_delivered, delivered
 
 

--- a/pallas/product/llm/delivery.py
+++ b/pallas/product/llm/delivery.py
@@ -890,7 +890,9 @@ async def deliver_llm_callback_success(
                 bot_id=int(bot_id) if bot_id is not None else 0,
                 group_id=int(group_id) if group_id is not None else 0,
                 user_id=int(task.get("user_id") or 0) or 0,
-                bucket=semantic_style_bucket(
+                bucket=int(task.get("semantic_bucket") or 0)
+                if int(task.get("semantic_bucket") or 0) >= 0
+                else semantic_style_bucket(
                     int(bot_id) if bot_id is not None else 0,
                     int(group_id) if group_id is not None else 0,
                 ),

--- a/pallas/product/llm/group_insight_processor.py
+++ b/pallas/product/llm/group_insight_processor.py
@@ -99,6 +99,7 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
         labeled_semantic_style_reply_ids,
         mark_semantic_style_group_processed,
         persist_semantic_style_examples,
+        semantic_style_candidate_rejected,
         semantic_style_collection_enabled,
     )
 
@@ -132,6 +133,10 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
     # 跳过已落库样本的接话、已处理过的旧窗口，避免同一批消息反复送 LLM 标注。
     labeled_ids = labeled_semantic_style_reply_ids(bot_id=bot_id, group_id=group_id)
     pairs = [pair for pair in pairs if pair[5] not in labeled_ids]
+    if not pairs:
+        return
+    # 媒体空壳、机器人菜单和内部元数据不送 LLM，节省预算并避免污染样本。
+    pairs = [pair for pair in pairs if not semantic_style_candidate_rejected(trigger_text=pair[0], reply_text=pair[1])]
     if not pairs:
         return
 

--- a/pallas/product/llm/group_insight_processor.py
+++ b/pallas/product/llm/group_insight_processor.py
@@ -106,6 +106,8 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
     if not semantic_style_collection_enabled(bot_id=bot_id, group_id=group_id):
         return
 
+    await _collect_protocol_observations(bot_id=bot_id, group_id=group_id)
+
     from pallas.product.llm.repeater_semantic_style import semantic_label_budget_ok
 
     if not semantic_label_budget_ok():
@@ -117,8 +119,6 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
             group_id,
         )
         return
-
-    await _collect_protocol_observations(bot_id=bot_id, group_id=group_id)
 
     cursor_time, cursor_message_id = get_semantic_style_group_cursor(bot_id=bot_id, group_id=group_id)
     known_bots = await _known_bots_in_group(group_id)
@@ -138,8 +138,21 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
     if not pairs:
         return
     # 媒体空壳、机器人菜单和内部元数据不送 LLM，节省预算并避免污染样本。
+    rejected_keys = [
+        (int(pair[6]), int(pair[5]))
+        for pair in pairs
+        if semantic_style_candidate_rejected(trigger_text=pair[0], reply_text=pair[1])
+    ]
     pairs = [pair for pair in pairs if not semantic_style_candidate_rejected(trigger_text=pair[0], reply_text=pair[1])]
     if not pairs:
+        if rejected_keys:
+            processed_at, processed_message_id = max(rejected_keys)
+            mark_semantic_style_group_processed(
+                bot_id=bot_id,
+                group_id=group_id,
+                processed_at=processed_at,
+                processed_message_id=processed_message_id,
+            )
         return
 
     # 一次 LLM 提交标注多个候选对，降低调用成本；预算中途耗尽时返回长度
@@ -214,11 +227,12 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
             group_id,
             bot_id,
         )
+    final_processed_key = max([max_processed_key, *(key for key in rejected_keys if key <= max_processed_key)])
     mark_semantic_style_group_processed(
         bot_id=bot_id,
         group_id=group_id,
-        processed_at=max_processed_key[0],
-        processed_message_id=max_processed_key[1],
+        processed_at=final_processed_key[0],
+        processed_message_id=final_processed_key[1],
     )
 
 
@@ -229,7 +243,7 @@ async def _collect_protocol_observations(*, bot_id: int, group_id: int) -> None:
     幂等，重复窗口不会重复计数。不推进语义游标，也不消耗 LLM 预算。
     """
     from pallas.product.llm.repeater_semantic_style import get_semantic_style_group_cursor
-    from pallas.product.llm.semantic_protocol import record_protocol_observation
+    from pallas.product.llm.semantic_protocol import extract_protocol_commands, record_protocol_observation
 
     cursor_time, cursor_message_id = get_semantic_style_group_cursor(bot_id=bot_id, group_id=group_id)
     known_bots = await _known_bots_in_group(group_id)
@@ -271,12 +285,9 @@ async def _collect_protocol_observations(*, bot_id: int, group_id: int) -> None:
         trigger = by_message_id.get(replied_id)
         if trigger is None:
             continue
-        trigger_user_id = int(getattr(trigger, "user_id", 0) or 0)
-        if not _is_bot_sender(user_id=trigger_user_id, self_bot_id=bot_id, known_bots=known_bots):
-            continue
         trigger_text = _text(getattr(trigger, "plain_text", "") or getattr(trigger, "raw_message", ""))
         reply_text = _text(getattr(reply, "plain_text", "") or getattr(reply, "raw_message", ""))
-        if not trigger_text or not reply_text:
+        if not trigger_text or not reply_text or not extract_protocol_commands(trigger_text):
             continue
         try:
             record_protocol_observation(

--- a/pallas/product/llm/group_insight_processor.py
+++ b/pallas/product/llm/group_insight_processor.py
@@ -178,6 +178,7 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
         if example_id in accepted_ids:
             continue
         accepted_ids.add(example_id)
+        pair_kind = "continuation" if trigger_user_id == reply_user_id else "conversation"
         accepted.append(
             SemanticStyleExample(
                 example_id=example_id,
@@ -195,6 +196,7 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
                 annotation_source="llm_v2",
                 behavior_strategy=strategy,
                 reply_is_bot=is_bot_reply,
+                pair_kind=pair_kind,
             )
         )
     if accepted:

--- a/pallas/product/llm/group_insight_processor.py
+++ b/pallas/product/llm/group_insight_processor.py
@@ -118,6 +118,8 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
         )
         return
 
+    await _collect_protocol_observations(bot_id=bot_id, group_id=group_id)
+
     cursor_time, cursor_message_id = get_semantic_style_group_cursor(bot_id=bot_id, group_id=group_id)
     known_bots = await _known_bots_in_group(group_id)
     pairs = await _rebuild_pairs_from_messages(
@@ -218,6 +220,76 @@ async def _produce_semantic_profile(payload: dict[str, Any]) -> None:
         processed_at=max_processed_key[0],
         processed_message_id=max_processed_key[1],
     )
+
+
+async def _collect_protocol_observations(*, bot_id: int, group_id: int) -> None:
+    """从语义游标窗口里收集「Bot 提示 → 真人短命令」观察，独立于群表达画像。
+
+    复用语义游标避免重复扫描；record_protocol_observation 按 observation_id
+    幂等，重复窗口不会重复计数。不推进语义游标，也不消耗 LLM 预算。
+    """
+    from pallas.product.llm.repeater_semantic_style import get_semantic_style_group_cursor
+    from pallas.product.llm.semantic_protocol import record_protocol_observation
+
+    cursor_time, cursor_message_id = get_semantic_style_group_cursor(bot_id=bot_id, group_id=group_id)
+    known_bots = await _known_bots_in_group(group_id)
+    repo = make_message_repository()
+    now_ts = int(time.time())
+    before_time = now_ts + 1
+    before_message_id: int | None = None
+    after_key = (int(cursor_time), int(cursor_message_id or 0))
+    unique_map: dict[int, object] = {}
+    for _ in range(_PAIR_PAGE_LIMIT):
+        batch = await repo.find_recent_in_group(
+            group_id, before_time=before_time, before_message_id=before_message_id, limit=32
+        )
+        if not batch:
+            break
+        earliest_key: tuple[int, int] | None = None
+        for item in batch:
+            mid = int(getattr(item, "message_id", 0) or 0)
+            if mid <= 0:
+                continue
+            unique_map.setdefault(mid, item)
+            key = (int(getattr(item, "time", 0) or 0), mid)
+            if earliest_key is None or key < earliest_key:
+                earliest_key = key
+        if earliest_key is None:
+            break
+        if earliest_key <= after_key:
+            break
+        before_time, before_message_id = earliest_key
+
+    by_message_id = {int(getattr(item, "message_id", 0) or 0): item for item in unique_map.values()}
+    for reply in unique_map.values():
+        reply_user_id = int(getattr(reply, "user_id", 0) or 0)
+        if _is_bot_sender(user_id=reply_user_id, self_bot_id=bot_id, known_bots=known_bots):
+            continue
+        replied_id = int(getattr(reply, "reply_to_message_id", 0) or 0)
+        if replied_id <= 0:
+            continue
+        trigger = by_message_id.get(replied_id)
+        if trigger is None:
+            continue
+        trigger_user_id = int(getattr(trigger, "user_id", 0) or 0)
+        if not _is_bot_sender(user_id=trigger_user_id, self_bot_id=bot_id, known_bots=known_bots):
+            continue
+        trigger_text = _text(getattr(trigger, "plain_text", "") or getattr(trigger, "raw_message", ""))
+        reply_text = _text(getattr(reply, "plain_text", "") or getattr(reply, "raw_message", ""))
+        if not trigger_text or not reply_text:
+            continue
+        try:
+            record_protocol_observation(
+                bot_id=bot_id,
+                group_id=group_id,
+                trigger_text=trigger_text,
+                reply_text=reply_text,
+                responder_id=reply_user_id,
+                source_message_id=int(getattr(reply, "message_id", 0) or 0),
+                created_at=int(getattr(reply, "time", 0) or 0),
+            )
+        except Exception as exc:
+            logger.warning("群洞察协议观察记录失败，群 [{}]：{}", group_id, exc)
 
 
 def _is_bot_sender(*, user_id: int, self_bot_id: int, known_bots: set[int]) -> bool:

--- a/pallas/product/llm/kernel_runner.py
+++ b/pallas/product/llm/kernel_runner.py
@@ -38,6 +38,28 @@ async def run_kernel_chat_job(
     started = time.monotonic()
     task = str(metadata.get("task") or "llm_chat").strip() or "llm_chat"
     try:
+        from pallas.product.llm.semantic_protocol import (
+            mark_protocol_sent,
+            resolve_protocol_candidate,
+        )
+
+        protocol_candidate = resolve_protocol_candidate(
+            bot_id=metadata.get("bot_id"),
+            group_id=metadata.get("group_id"),
+            trigger_text=str(metadata.get("user_text") or ""),
+            recent_bot_id=metadata.get("recent_group_bot_speaker"),
+        )
+        if protocol_candidate:
+            from pallas.product.llm.runtime_debug import append_runtime_trace
+
+            append_runtime_trace(
+                request_id=request_id,
+                trace={"status": "success", "semantic_protocol_direct": True, "agent_trace": None},
+            )
+            mark_protocol_sent(bot_id=metadata.get("bot_id"), group_id=metadata.get("group_id"))
+            await deliver_llm_chat_result(request_id, status="success", text=protocol_candidate)
+            return
+
         from pallas.product.llm.repeater_semantic_style import should_deliver_semantic_style_direct_candidate
 
         direct_candidate = str(metadata.get("semantic_style_direct_candidate") or "").strip()

--- a/pallas/product/llm/kernel_runner.py
+++ b/pallas/product/llm/kernel_runner.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from nonebot import logger
 
+from pallas.core.foundation.config import TaskManager
 from pallas.product.llm.execution_budget import (
     LlmExecutionSlot,
     release_llm_execution_slot,
@@ -26,6 +27,12 @@ if TYPE_CHECKING:
 from pallas.product.llm.delivery import deliver_llm_chat_result
 
 
+async def _mark_delivery_source(request_id: str, source: str) -> None:
+    task = await TaskManager.get_task(request_id)
+    if task is not None:
+        task["delivery_source"] = source
+
+
 async def run_kernel_chat_job(
     request_id: str,
     *,
@@ -38,17 +45,18 @@ async def run_kernel_chat_job(
     started = time.monotonic()
     task = str(metadata.get("task") or "llm_chat").strip() or "llm_chat"
     try:
-        from pallas.product.llm.semantic_protocol import (
-            mark_protocol_sent,
-            resolve_protocol_candidate,
-        )
+        from pallas.product.llm.semantic_protocol import claim_protocol_candidate
 
-        protocol_candidate = resolve_protocol_candidate(
-            bot_id=metadata.get("bot_id"),
-            group_id=metadata.get("group_id"),
-            trigger_text=str(metadata.get("user_text") or ""),
-            recent_bot_id=metadata.get("recent_group_bot_speaker"),
-        )
+        protocol_candidate = ""
+        if task == "llm_chat" and int(metadata.get("bot_id") or 0) > 0 and int(metadata.get("group_id") or 0) > 0:
+            protocol_candidate = claim_protocol_candidate(
+                bot_id=int(metadata["bot_id"]),
+                group_id=int(metadata["group_id"]),
+                trigger_text=str(metadata.get("user_text") or ""),
+                recent_bot_id=metadata.get("recent_group_bot_speaker"),
+                explicitly_targeted=bool(metadata.get("protocol_explicit_target")),
+                nickname_targeted=bool(metadata.get("protocol_nickname_target")),
+            )
         if protocol_candidate:
             from pallas.product.llm.runtime_debug import append_runtime_trace
 
@@ -56,13 +64,20 @@ async def run_kernel_chat_job(
                 request_id=request_id,
                 trace={"status": "success", "semantic_protocol_direct": True, "agent_trace": None},
             )
-            mark_protocol_sent(bot_id=metadata.get("bot_id"), group_id=metadata.get("group_id"))
+            await _mark_delivery_source(request_id, "protocol_direct")
             await deliver_llm_chat_result(request_id, status="success", text=protocol_candidate)
             return
 
         from pallas.product.llm.repeater_semantic_style import should_deliver_semantic_style_direct_candidate
 
         direct_candidate = str(metadata.get("semantic_style_direct_candidate") or "").strip()
+        if direct_candidate:
+            from pallas.product.llm.repeater_semantic_style import SAFE_DIRECT_ACTION_TEXT
+            from pallas.product.llm.semantic_style_experiment import trip_semantic_channel_circuit
+
+            if direct_candidate not in SAFE_DIRECT_ACTION_TEXT.values():
+                trip_semantic_channel_circuit("semantic_direct", "candidate_not_in_safe_map")
+                direct_candidate = ""
         if should_deliver_semantic_style_direct_candidate(
             bot_id=metadata.get("bot_id"),
             group_id=metadata.get("group_id"),
@@ -74,6 +89,7 @@ async def run_kernel_chat_job(
                 request_id=request_id,
                 trace={"status": "success", "semantic_style_direct": True, "agent_trace": None},
             )
+            await _mark_delivery_source(request_id, "semantic_direct")
             await deliver_llm_chat_result(request_id, status="success", text=direct_candidate)
             return
         content, assistant_message = await complete_with_tool_loop(

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -602,6 +602,48 @@ def is_human_semantic_style_pair(
     return trigger_id != self_id and reply_id != self_id and not is_peer_bot(trigger_id) and not is_peer_bot(reply_id)
 
 
+# 机器人菜单/欢迎卡/管理提示等系统叙事，不能作为真人接话措辞样本。
+_SYSTEM_TEMPLATE_RE = re.compile(
+    r"(发送[「\"']|请在\s*\d+\s*秒内|管理员|群主点击|功能开关|领取|签到|"
+    r"欢迎.{0,6}(加入本群|入群|新人)|群公告|点击开启|邀请码|兑换码|口令|"
+    r"\bcompletion_tokens\b|\bprompt_tokens\b|\bfinish_reason\b|\btoken_usage\b)",
+    re.IGNORECASE,
+)
+_MEDIA_PLACEHOLDER_RE = re.compile(r"\[(?:图片|媒体)\]")
+_KNOWN_TOKEN_KEYS = frozenset({
+    "completion_tokens",
+    "prompt_tokens",
+    "finish_reason",
+    "token_usage",
+    "message_id",
+    "request_id",
+})
+
+
+def semantic_style_candidate_rejected(*, trigger_text: str, reply_text: str) -> bool:
+    """确定性拒绝信号：媒体空壳、机器人菜单/欢迎话术、内部 token 元数据、超长 reply。"""
+    trigger = str(trigger_text or "").strip()
+    reply = str(reply_text or "").strip()
+    if not trigger or not reply:
+        return True
+    if len(reply) > _MAX_SEED_LEN:
+        return True
+    if not _MEDIA_PLACEHOLDER_RE.sub("", trigger) and trigger:
+        return True
+    combined = f"{trigger}\n{reply}"
+    if re.search(r"\[CQ:", combined, re.IGNORECASE) or re.search(r"https?://", combined, re.IGNORECASE):
+        return True
+    if re.search(r"\d{7,}", combined):
+        return True
+    if any(key in combined for key in _KNOWN_TOKEN_KEYS):
+        return True
+    if _SYSTEM_TEMPLATE_RE.search(combined):
+        return True
+    if combined.count("|") >= 3 or combined.count("｜") >= 3:
+        return True
+    return False
+
+
 async def collect_semantic_style_backfill_candidates(
     *,
     now: int | None = None,
@@ -2317,12 +2359,10 @@ async def label_semantic_style_batch_with_llm(
 def _label_semantic_style_batch_prompt(count: int) -> str:
     return (
         f"判断 {count} 组群聊前后句，只输出长度为 {count} 的 JSON 数组。字段："
-        "is_reply_pair、transferable、interaction_actions、semantic_relations、intensity、forms、behavior_strategy。"
+        "is_reply_pair、transferable、interaction_actions、semantic_relations、intensity、forms。"
         "确实回应前句才 is_reply_pair=true；脱离人名、局部梗、临时事实仍可复用才 transferable=true，"
         "否则均为 false。intensity 只能 quiet/soft/neutral/sharp/strong，数组字段只能用受控英文词。"
-        "behavior_strategy 仅在能提炼出可复用行为模式时输出对象，否则为 null；对象为 "
-        '{"scene":"可泛化场景","action":"实际接话动作","outcome":"可观察变化",'
-        '"learning_type":"observed"}。不抄原话，不带人名或临时梗。严格按输入顺序输出。'
+        "不抄原话，不带人名或临时梗。严格按输入顺序输出。"
     )
 
 

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -1979,11 +1979,21 @@ def semantic_style_profile_summary(profile: SemanticStyleProfile | None) -> dict
 def semantic_style_injection_enabled(
     request_id: str, *, bot_id: int | None = None, group_id: int | None = None
 ) -> bool:
-    """只读注入位，保留稳定的 10% 对照组。"""
+    """只读注入位：群日稳定 10% 对照组 + 统计熔断。"""
     if bot_id is not None and group_id is not None and (int(bot_id) <= 0 or int(group_id) <= 0):
         return False
     if not load_semantic_style_settings(bot_id=bot_id, group_id=group_id).injection_enabled:
         return False
+    if bot_id is not None and group_id is not None:
+        from pallas.product.llm.semantic_style_experiment import (
+            semantic_style_circuit_disabled,
+            semantic_style_in_control,
+        )
+
+        if semantic_style_circuit_disabled():
+            return False
+        if semantic_style_in_control(int(bot_id), int(group_id)):
+            return False
     digest = hashlib.blake2b(str(request_id).encode("utf-8"), digest_size=8).digest()
     return int.from_bytes(digest, "big") % 10 != 0
 

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -1090,6 +1090,11 @@ def semantic_style_status(*, bot_id: int | None = None, group_id: int | None = N
     )
     backups = sorted(semantic_style_profiles_backup_dir().glob("profiles-v*.json"))
     backup = backups[0] if backups else None
+    experiment: dict[str, Any] = {}
+    if scope is None:
+        from pallas.product.llm.semantic_style_experiment import experiment_status
+
+        experiment = experiment_status()
     return {
         "enabled": settings.enabled,
         "collection_enabled": settings.collection_enabled,
@@ -1102,6 +1107,7 @@ def semantic_style_status(*, bot_id: int | None = None, group_id: int | None = N
         "injectable_behavior_patterns": injectable_behavior,
         "injectable_continuation_patterns": injectable_continuation,
         "v2_backup": backup.name if backup is not None else None,
+        "experiment_governance": experiment,
         "backfill_cursor": load_semantic_style_backfill_cursor(bot_id=bot_id, group_id=group_id).model_dump(
             mode="json"
         ),

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -226,6 +226,7 @@ class SemanticStyleProfile(BaseModel):
     bot_id: int
     group_id: int
     scene: str
+    schema_version: int = 3
     style_anchor: str = ""
     direct_examples: list[str] = Field(default_factory=list)
     direct_pairs: list[SemanticStyleDirectPair] = Field(default_factory=list)
@@ -267,6 +268,7 @@ class SemanticStyleSettings(BaseModel):
     collection_enabled: bool = True
     injection_enabled: bool = True
     direct_enabled: bool = True
+    active_pipeline: Literal["v3", "v2"] = "v3"
 
     @model_validator(mode="before")
     @classmethod
@@ -808,6 +810,33 @@ def semantic_style_profiles_path() -> Path:
     return semantic_style_base_dir() / "profiles.json"
 
 
+def semantic_style_profiles_backup_dir() -> Path:
+    return semantic_style_base_dir() / "backups"
+
+
+def semantic_style_active_read_profiles_path() -> Path:
+    """读取画像的入口：v2 回滚期间读最近一份备份，v3 默认读主文件。
+
+    回滚只切换读取与注入，不停止 v3 采集；主文件继续由标注重建写入。
+    """
+    settings = load_semantic_style_settings()
+    if settings.active_pipeline == "v2":
+        backups = sorted(semantic_style_profiles_backup_dir().glob("profiles-v*.json"))
+        if backups:
+            return backups[-1]
+    return semantic_style_profiles_path()
+
+
+def set_semantic_style_active_pipeline(pipeline: Literal["v2", "v3"]) -> dict[str, Any]:
+    """维护操作：在 v2 备份与 v3 之间切换读取/注入管线，不修改 examples 与 v3 主文件。"""
+    if pipeline == "v2" and not _has_v2_backup():
+        raise ValueError("没有可用的 v2 备份，无法回滚")
+    settings = load_semantic_style_settings().model_copy(update={"active_pipeline": pipeline})
+    _save_semantic_style_settings(settings)
+    refresh_semantic_style_cache(force=True)
+    return semantic_style_status()
+
+
 def semantic_style_data_lock_path() -> Path:
     return semantic_style_base_dir() / "semantic_style_data.lock"
 
@@ -1001,16 +1030,32 @@ def semantic_style_status(*, bot_id: int | None = None, group_id: int | None = N
     scope = _semantic_style_scope(bot_id, group_id)
     settings = load_semantic_style_settings(bot_id=bot_id, group_id=group_id)
     examples = _load_semantic_style_examples(semantic_style_examples_path())
-    profiles = _load_profiles(semantic_style_profiles_path())
+    profiles = _load_profiles(semantic_style_active_read_profiles_path())
     scoped_examples = [example for example in examples if _in_semantic_style_scope(example, scope)]
     scoped_profiles = [profile for profile in profiles.values() if _in_semantic_style_scope(profile, scope)]
+    schema_version = (
+        2 if settings.active_pipeline == "v2" else max((int(p.schema_version) for p in scoped_profiles), default=3)
+    )
+    injectable_behavior = sum(
+        1 for p in scoped_profiles for pattern in p.behavior_patterns if behavioral_pattern_injectable(pattern)
+    )
+    injectable_continuation = sum(
+        1 for p in scoped_profiles for pattern in p.continuation_patterns if continuation_pattern_injectable(pattern)
+    )
+    backups = sorted(semantic_style_profiles_backup_dir().glob("profiles-v*.json"))
+    backup = backups[0] if backups else None
     return {
         "enabled": settings.enabled,
         "collection_enabled": settings.collection_enabled,
         "injection_enabled": settings.injection_enabled,
         "direct_enabled": settings.direct_enabled,
+        "active_pipeline": settings.active_pipeline,
         "example_count": len(scoped_examples),
         "profile_count": len(scoped_profiles),
+        "schema_version": schema_version,
+        "injectable_behavior_patterns": injectable_behavior,
+        "injectable_continuation_patterns": injectable_continuation,
+        "v2_backup": backup.name if backup is not None else None,
         "backfill_cursor": load_semantic_style_backfill_cursor(bot_id=bot_id, group_id=group_id).model_dump(
             mode="json"
         ),
@@ -1149,7 +1194,7 @@ def _load_profiles(path: Path) -> dict[tuple[int, int, str], SemanticStyleProfil
 
 def refresh_semantic_style_cache(*, force: bool = False) -> None:
     global _profiles_revision, _profiles
-    path = semantic_style_profiles_path()
+    path = semantic_style_active_read_profiles_path()
     revision = _revision(path)
     with _profiles_lock:
         if not force and _profiles_revision == revision:
@@ -1177,12 +1222,32 @@ def _write_profiles(profiles: dict[tuple[int, int, str], SemanticStyleProfile]) 
         "schema_version": 3,
         "profiles": [item.model_dump(mode="json") for item in profiles.values()],
     }
+    # 首次从 v2 迁移到 v3 前保留旧 profiles，供 14 天内人工回滚；
+    # 只备份一次，避免每次落盘都复制大文件。
+    try:
+        prior = json.loads(path.read_text(encoding="utf-8"))
+        prior_version = int(prior.get("schema_version") or 0) if isinstance(prior, dict) else 0
+        if prior_version < 3 and not _has_v2_backup():
+            backup_dir = semantic_style_profiles_backup_dir()
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            timestamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
+            backup = backup_dir / f"profiles-v{prior_version}-{timestamp}.json"
+            backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    except OSError:
+        pass
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
     tmp.replace(path)
     with _profiles_lock:
         _profiles = dict(profiles)
         _profiles_revision = _revision(path)
+
+
+def _has_v2_backup() -> bool:
+    backup_dir = semantic_style_profiles_backup_dir()
+    if not backup_dir.exists():
+        return False
+    return any(backup.name.startswith("profiles-v") for backup in backup_dir.iterdir() if backup.is_file())
 
 
 def _popular(values: list[str], limit: int = 3) -> list[str]:
@@ -1465,6 +1530,21 @@ def persist_semantic_style_example(example: SemanticStyleExample) -> SemanticSty
         profiles = _rebuild_profiles(examples, now=int(time.time()))
         _write_profiles(profiles)
         return profiles.get(_profile_key(example.bot_id, example.group_id, example.scene))
+
+
+def behavioral_pattern_injectable(pattern: ControlledBehaviorPattern) -> bool:
+    """受控行为模式达到「3 次且 2 名回复者」门槛才允许注入。"""
+    return (
+        pattern.count >= _BEHAVIOR_PATTERN_MIN_COUNT and len(pattern.responder_ids) >= _BEHAVIOR_PATTERN_MIN_RESPONDERS
+    )
+
+
+def continuation_pattern_injectable(pattern: ContinuationPattern) -> bool:
+    """续句模式达到「3 次且 2 名说话者」门槛才允许注入。"""
+    return (
+        pattern.count >= _CONTINUATION_PATTERN_MIN_COUNT
+        and len(pattern.speaker_ids) >= _CONTINUATION_PATTERN_MIN_SPEAKERS
+    )
 
 
 def is_positive_bot_style_outcome(

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -220,6 +220,15 @@ _PATTERN_MAX_SOURCE_IDS = 8
 _PATTERN_MAX_RESPONDER_IDS = 8
 _CONTINUATION_PATTERN_MAX_HITS = 1
 
+# 普通直投只允许少数自包含、低风险动作，发送代码内固定短句，不随机复刻真人原句。
+SAFE_DIRECT_ACTION_TEXT = {
+    "agree": "确实",
+    "support": "对",
+}
+# 普通直投证据门槛：同类受控 action 至少 2 次且来自至少 2 名回复者。
+_DIRECT_PATTERN_MIN_COUNT = 2
+_DIRECT_PATTERN_MIN_RESPONDERS = 2
+
 _CONTROLLED_ACTION_ZH = {
     "agree": "认同",
     "challenge": "反问",
@@ -2058,7 +2067,6 @@ def resolve_cached_semantic_style(
         for pair in safe_matched
     ]
     safe_anchor = prompt_safe_expression_sample(profile.style_anchor)
-    safe_direct_candidate = prompt_safe_expression_sample(direct_pair.reply_text) if direct_pair is not None else ""
     behavior_strategies = (
         []
         if matched_examples
@@ -2077,12 +2085,17 @@ def resolve_cached_semantic_style(
     continuation_patterns = [
         pattern for pattern in profile.continuation_patterns if continuation_pattern_injectable(pattern)
     ][:_CONTINUATION_PATTERN_MAX_HITS]
+    direct_candidate = select_safe_direct_candidate(
+        profile.behavior_patterns,
+        query_text=query_text,
+        recent_assistant_replies=recent_assistant_replies,
+    )
     return SemanticStyleResolution(
         style_anchor=safe_anchor,
         prompt_block=append_cached_semantic_style_block("", safe_anchor, ""),
         matched_examples=matched_examples,
         matched_example_sources=safe_matched,
-        direct_candidate=safe_direct_candidate,
+        direct_candidate=direct_candidate,
         source_example_id=semantic_style_source_example_id(direct_pair) if direct_pair is not None else "",
         baseline_note="",
         behavior_strategies=behavior_strategies[:_BEHAVIOR_STRATEGY_MAX_HITS],
@@ -2090,6 +2103,29 @@ def resolve_cached_semantic_style(
         continuation_patterns=continuation_patterns,
         style_profile=semantic_style_profile_summary(profile) or {},
     )
+
+
+def select_safe_direct_candidate(
+    patterns: Iterable[ControlledBehaviorPattern],
+    *,
+    query_text: str,
+    recent_assistant_replies: Iterable[str] = (),
+) -> str:
+    """普通直投：仅当受控 action 达到 2 次/2 人且命中代表 trigger 时，返回固定安全短句。"""
+    recent = [reply for reply in recent_assistant_replies if normalize_semantic_style_match_text(reply)]
+    for pattern in patterns:
+        if pattern.interaction_action not in SAFE_DIRECT_ACTION_TEXT:
+            continue
+        if pattern.count < _DIRECT_PATTERN_MIN_COUNT or len(pattern.responder_ids) < _DIRECT_PATTERN_MIN_RESPONDERS:
+            continue
+        representative = select_behavior_pattern_representative(pattern, query_text=query_text)
+        if not representative:
+            continue
+        text = SAFE_DIRECT_ACTION_TEXT[pattern.interaction_action]
+        if any(semantic_style_text_similarity(text, previous) >= _DIRECT_REPLY_DEDUP_SIMILARITY for previous in recent):
+            continue
+        return text
+    return ""
 
 
 def select_behavior_pattern_representative(pattern: ControlledBehaviorPattern, *, query_text: str) -> str:

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -171,12 +171,53 @@ class SemanticStyleExample(BaseModel):
     legacy_style_anchor: str = ""
     legacy_persona_affinities: list[str] = Field(default_factory=list)
     behavior_strategy: BehaviorStrategy | None = None
+    pair_kind: Literal["conversation", "continuation"] = "conversation"
 
 
 class SemanticStyleDirectPair(BaseModel):
     trigger_text: str
     reply_text: str
     source_example_id: str = ""
+
+
+class ControlledBehaviorPattern(BaseModel):
+    """真人接话的受控行为模式：action+relation+form+intensity 聚合，保留代表 trigger。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    interaction_action: str = "agree"
+    semantic_relation: str = "echo"
+    form: str = "short"
+    intensity: str = "neutral"
+    count: int = 0
+    responder_ids: list[int] = Field(default_factory=list)
+    representative_triggers: list[str] = Field(default_factory=list)
+    source_example_ids: list[str] = Field(default_factory=list)
+
+
+class ContinuationPattern(BaseModel):
+    """同人连续发言的表达结构模式；不作为两个人之间的接话对。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    semantic_relation: str = "echo"
+    form: str = "short"
+    intensity: str = "neutral"
+    count: int = 0
+    speaker_ids: list[int] = Field(default_factory=list)
+    representative_triggers: list[str] = Field(default_factory=list)
+    source_example_ids: list[str] = Field(default_factory=list)
+
+
+# v3 profile 行为模式注入门槛：同类模式至少 3 次且来自至少 2 名回复者。
+_BEHAVIOR_PATTERN_MIN_COUNT = 3
+_BEHAVIOR_PATTERN_MIN_RESPONDERS = 2
+# continuation 同样要求 3 次且 2 名说话者，证明是群习惯而非个人口癖。
+_CONTINUATION_PATTERN_MIN_COUNT = 3
+_CONTINUATION_PATTERN_MIN_SPEAKERS = 2
+_PATTERN_MAX_REPRESENTATIVE_TRIGGERS = 3
+_PATTERN_MAX_SOURCE_IDS = 8
+_PATTERN_MAX_RESPONDER_IDS = 8
 
 
 class SemanticStyleProfile(BaseModel):
@@ -204,6 +245,8 @@ class SemanticStyleProfile(BaseModel):
     bot_style_promoted: bool = False
     visual_sample_count: int = 0
     behavior_strategies: list[BehaviorStrategy] = Field(default_factory=list)
+    behavior_patterns: list[ControlledBehaviorPattern] = Field(default_factory=list)
+    continuation_patterns: list[ContinuationPattern] = Field(default_factory=list)
     human_only: bool = False
     updated_at: int = 0
 
@@ -1088,7 +1131,10 @@ def clear_semantic_style_direct_quota_for_tests() -> None:
 def _write_profiles(profiles: dict[tuple[int, int, str], SemanticStyleProfile]) -> None:
     global _profiles_revision, _profiles
     path = semantic_style_profiles_path()
-    payload = {"profiles": [item.model_dump(mode="json") for item in profiles.values()]}
+    payload = {
+        "schema_version": 3,
+        "profiles": [item.model_dump(mode="json") for item in profiles.values()],
+    }
     tmp = path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
     tmp.replace(path)
@@ -1177,6 +1223,37 @@ def _build_profile(
         if not merged:
             strategies.append(strategy)
         strategies = strategies[-_BEHAVIOR_STRATEGY_LIMIT:]
+
+    behavior_patterns = list(existing.behavior_patterns) if existing else []
+    continuation_patterns = list(existing.continuation_patterns) if existing else []
+    clean_trigger = _short_text(example.trigger_text, _MAX_SEED_LEN)
+    if example.pair_kind == "continuation" and example.reply_user_id > 0:
+        continuation_patterns = _accumulate_continuation_pattern(
+            continuation_patterns,
+            relation=label.semantic_relations[0] if label.semantic_relations else _PATTERN_DEFAULT_RELATION,
+            form=label.forms[0] if label.forms else _PATTERN_DEFAULT_FORM,
+            intensity=label.intensity,
+            speaker_id=example.reply_user_id,
+            trigger=clean_trigger,
+            source_example_id=example.example_id,
+        )
+    elif (
+        example.pair_kind == "conversation"
+        and not is_bot_reply
+        and not example.bot_style_positive
+        and label.interaction_actions
+        and example.reply_user_id > 0
+    ):
+        behavior_patterns = _accumulate_behavior_pattern(
+            behavior_patterns,
+            action=label.interaction_actions[0],
+            relation=label.semantic_relations[0] if label.semantic_relations else _PATTERN_DEFAULT_RELATION,
+            form=label.forms[0] if label.forms else _PATTERN_DEFAULT_FORM,
+            intensity=label.intensity,
+            responder_id=example.reply_user_id,
+            trigger=clean_trigger,
+            source_example_id=example.example_id,
+        )
     return SemanticStyleProfile(
         bot_id=example.bot_id,
         group_id=example.group_id,
@@ -1201,9 +1278,116 @@ def _build_profile(
         bot_style_promoted=bot_style_promoted,
         visual_sample_count=(existing.visual_sample_count if existing else 0) + int(label.visual is not None),
         behavior_strategies=strategies,
+        behavior_patterns=behavior_patterns,
+        continuation_patterns=continuation_patterns,
         human_only=True,
         updated_at=example.created_at,
     )
+
+
+_PATTERN_DEFAULT_ACTION = "agree"
+_PATTERN_DEFAULT_RELATION = "echo"
+_PATTERN_DEFAULT_FORM = "short"
+
+
+def _pattern_key(*, action: str, relation: str, form: str, intensity: str) -> tuple[str, str, str, str]:
+    return (
+        action or _PATTERN_DEFAULT_ACTION,
+        relation or _PATTERN_DEFAULT_RELATION,
+        form or _PATTERN_DEFAULT_FORM,
+        intensity or "neutral",
+    )
+
+
+def _accumulate_behavior_pattern(
+    patterns: list[ControlledBehaviorPattern],
+    *,
+    action: str,
+    relation: str,
+    form: str,
+    intensity: str,
+    responder_id: int,
+    trigger: str,
+    source_example_id: str,
+) -> list[ControlledBehaviorPattern]:
+    """合并一次真人接话到受控行为模式：同 key 计数，记录回复者与代表 trigger。"""
+    merged = False
+    for pattern in patterns:
+        if _pattern_key(
+            action=pattern.interaction_action,
+            relation=pattern.semantic_relation,
+            form=pattern.form,
+            intensity=pattern.intensity,
+        ) == _pattern_key(action=action, relation=relation, form=form, intensity=intensity):
+            if responder_id not in pattern.responder_ids:
+                pattern.responder_ids = [*pattern.responder_ids, responder_id][-_PATTERN_MAX_RESPONDER_IDS:]
+            if trigger and trigger not in pattern.representative_triggers:
+                pattern.representative_triggers = [*pattern.representative_triggers, trigger][
+                    -_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:
+                ]
+            if source_example_id and source_example_id not in pattern.source_example_ids:
+                pattern.source_example_ids = [*pattern.source_example_ids, source_example_id][-_PATTERN_MAX_SOURCE_IDS:]
+            pattern.count += 1
+            merged = True
+            break
+    if not merged:
+        patterns.append(
+            ControlledBehaviorPattern(
+                interaction_action=action,
+                semantic_relation=relation,
+                form=form,
+                intensity=intensity,
+                count=1,
+                responder_ids=[responder_id],
+                representative_triggers=[trigger] if trigger else [],
+                source_example_ids=[source_example_id] if source_example_id else [],
+            )
+        )
+    return patterns
+
+
+def _accumulate_continuation_pattern(
+    patterns: list[ContinuationPattern],
+    *,
+    relation: str,
+    form: str,
+    intensity: str,
+    speaker_id: int,
+    trigger: str,
+    source_example_id: str,
+) -> list[ContinuationPattern]:
+    """合并一次同人续句到表达结构模式；不作两个人之间的接话对。"""
+    merged = False
+    for pattern in patterns:
+        if (
+            pattern.semantic_relation,
+            pattern.form,
+            pattern.intensity,
+        ) == (relation or _PATTERN_DEFAULT_RELATION, form or _PATTERN_DEFAULT_FORM, intensity or "neutral"):
+            if speaker_id not in pattern.speaker_ids:
+                pattern.speaker_ids = [*pattern.speaker_ids, speaker_id][-_PATTERN_MAX_RESPONDER_IDS:]
+            if trigger and trigger not in pattern.representative_triggers:
+                pattern.representative_triggers = [*pattern.representative_triggers, trigger][
+                    -_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:
+                ]
+            if source_example_id and source_example_id not in pattern.source_example_ids:
+                pattern.source_example_ids = [*pattern.source_example_ids, source_example_id][-_PATTERN_MAX_SOURCE_IDS:]
+            pattern.count += 1
+            merged = True
+            break
+    if not merged:
+        patterns.append(
+            ContinuationPattern(
+                semantic_relation=relation or _PATTERN_DEFAULT_RELATION,
+                form=form or _PATTERN_DEFAULT_FORM,
+                intensity=intensity or "neutral",
+                count=1,
+                speaker_ids=[speaker_id],
+                representative_triggers=[trigger] if trigger else [],
+                source_example_ids=[source_example_id] if source_example_id else [],
+            )
+        )
+    return patterns
 
 
 def persist_semantic_style_examples(
@@ -1337,6 +1521,14 @@ def _load_semantic_style_examples(path: Path) -> list[SemanticStyleExample]:
             # delivery feedback 的正面回应样本 reply_user_id != bot_id，不受影响。
             if example.bot_style_positive and example.reply_user_id == example.bot_id:
                 example = example.model_copy(update={"reply_is_bot": True})
+            # 迁移：旧样本没有 pair_kind；同一作者连续发言不是「别人说 X→我回 Y」，
+            # 统一归为 continuation，不能作为真人接话对进入 direct_pairs。
+            if (
+                "pair_kind" not in raw
+                and example.trigger_user_id > 0
+                and example.trigger_user_id == example.reply_user_id
+            ):
+                example = example.model_copy(update={"pair_kind": "continuation"})
         except (json.JSONDecodeError, ValueError, TypeError):
             continue
         examples.append(example.model_copy(update={"label": parse_semantic_style_label(example.label.model_dump())}))

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -218,6 +218,41 @@ _CONTINUATION_PATTERN_MIN_SPEAKERS = 2
 _PATTERN_MAX_REPRESENTATIVE_TRIGGERS = 3
 _PATTERN_MAX_SOURCE_IDS = 8
 _PATTERN_MAX_RESPONDER_IDS = 8
+_CONTINUATION_PATTERN_MAX_HITS = 1
+
+_CONTROLLED_ACTION_ZH = {
+    "agree": "认同",
+    "challenge": "反问",
+    "comfort": "安抚",
+    "confront": "顶回去",
+    "dismiss": "一笔带过",
+    "echo": "顺着接",
+    "insult": "损一句",
+    "mock": "调侃",
+    "question": "追问",
+    "support": "撑一句",
+    "tease": "逗趣",
+}
+_CONTROLLED_RELATION_ZH = {
+    "agree": "表示赞同",
+    "clarify": "澄清疑问",
+    "derail": "顺势带开话题",
+    "disagree": "表示不认同",
+    "echo": "重复接应",
+    "escalate": "把情绪往上抬一层",
+    "follow_up": "追问下去",
+    "joke": "开个玩笑",
+    "nonsense": "说句不着边际的",
+    "topic_shift": "把话题引开",
+}
+_CONTROLLED_FORM_ZH = {
+    "call_response": "呼应对答",
+    "emoji": "带图/表情",
+    "fragment": "零散短句",
+    "question": "疑问句式",
+    "short": "短句",
+    "template": "固定句式",
+}
 
 
 class SemanticStyleProfile(BaseModel):
@@ -261,6 +296,8 @@ class SemanticStyleResolution(BaseModel):
     source_example_id: str = ""
     baseline_note: str = ""
     behavior_strategies: list[BehaviorStrategy] = Field(default_factory=list)
+    behavior_patterns: list[ControlledBehaviorPattern] = Field(default_factory=list)
+    continuation_patterns: list[ContinuationPattern] = Field(default_factory=list)
     style_profile: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -2001,14 +2038,11 @@ def resolve_cached_semantic_style(
     if profile is None or not profile.human_only:
         return SemanticStyleResolution()
     direct_pairs = filter_semantic_style_pairs_by_feedback(profile.direct_pairs, bot_id=bot_id, group_id=group_id)
-    rewrite_seed = profile.rewrite_seeds[-1] if profile.rewrite_seeds else ""
     direct_pair = select_semantic_style_direct_pair(
         direct_pairs,
         query_text=query_text,
         recent_assistant_replies=recent_assistant_replies,
     )
-    if not rewrite_seed and direct_pair is not None:
-        rewrite_seed = direct_pair.reply_text
     safe_matched = [
         pair
         for pair in select_semantic_style_matched_pairs(
@@ -2024,7 +2058,6 @@ def resolve_cached_semantic_style(
         for pair in safe_matched
     ]
     safe_anchor = prompt_safe_expression_sample(profile.style_anchor)
-    safe_seed = prompt_safe_expression_sample(rewrite_seed)
     safe_direct_candidate = prompt_safe_expression_sample(direct_pair.reply_text) if direct_pair is not None else ""
     behavior_strategies = (
         []
@@ -2035,17 +2068,47 @@ def resolve_cached_semantic_style(
             if prompt_safe_expression_sample(strategy.scene) and prompt_safe_expression_sample(strategy.action)
         ]
     )
+    behavior_patterns = [
+        pattern
+        for pattern in profile.behavior_patterns
+        if behavioral_pattern_injectable(pattern)
+        and select_behavior_pattern_representative(pattern, query_text=query_text) is not None
+    ][:_BEHAVIOR_STRATEGY_MAX_HITS]
+    continuation_patterns = [
+        pattern for pattern in profile.continuation_patterns if continuation_pattern_injectable(pattern)
+    ][:_CONTINUATION_PATTERN_MAX_HITS]
     return SemanticStyleResolution(
         style_anchor=safe_anchor,
-        prompt_block=append_cached_semantic_style_block("", safe_anchor, safe_seed),
+        prompt_block=append_cached_semantic_style_block("", safe_anchor, ""),
         matched_examples=matched_examples,
         matched_example_sources=safe_matched,
         direct_candidate=safe_direct_candidate,
         source_example_id=semantic_style_source_example_id(direct_pair) if direct_pair is not None else "",
-        baseline_note=build_rhythm_baseline_note(profile),
+        baseline_note="",
         behavior_strategies=behavior_strategies[:_BEHAVIOR_STRATEGY_MAX_HITS],
+        behavior_patterns=behavior_patterns,
+        continuation_patterns=continuation_patterns,
         style_profile=semantic_style_profile_summary(profile) or {},
     )
+
+
+def select_behavior_pattern_representative(pattern: ControlledBehaviorPattern, *, query_text: str) -> str:
+    """受控行为模式按代表 trigger 召回；无命中返回空串。"""
+    for trigger in pattern.representative_triggers:
+        if semantic_style_text_similarity(query_text, trigger) >= _DIRECT_TRIGGER_SIMILARITY:
+            return str(trigger or "")
+    return ""
+
+
+def behavior_pattern_prompt_line(pattern: ControlledBehaviorPattern, representative: str) -> str:
+    """把受控行为模式渲染成一句中文接话指导。"""
+    action_label = _CONTROLLED_ACTION_ZH.get(pattern.interaction_action, pattern.interaction_action or "回应")
+    relation_label = _CONTROLLED_RELATION_ZH.get(pattern.semantic_relation, pattern.semantic_relation or "回应")
+    form_label = _CONTROLLED_FORM_ZH.get(pattern.form, pattern.form or "")
+    line = f"- 类似「{representative}」时，本群真人常用{action_label}的方式{relation_label}"
+    if form_label:
+        line += f"，表述偏{form_label}"
+    return f"{line}。"
 
 
 def prompt_safe_expression_sample(value: str) -> str:

--- a/pallas/product/llm/repeater_semantic_style.py
+++ b/pallas/product/llm/repeater_semantic_style.py
@@ -11,6 +11,7 @@ import time
 import unicodedata
 from collections import Counter, deque
 from contextlib import contextmanager
+from operator import itemgetter
 from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Literal
@@ -191,7 +192,11 @@ class ControlledBehaviorPattern(BaseModel):
     intensity: str = "neutral"
     count: int = 0
     responder_ids: list[int] = Field(default_factory=list)
+    quoted_count: int = -1
+    quoted_responder_ids: list[int] = Field(default_factory=list)
     representative_triggers: list[str] = Field(default_factory=list)
+    # 仅由 quoted 证据积累出的代表 trigger；普通直投只允许命中这里。
+    quoted_triggers: list[str] = Field(default_factory=list)
     source_example_ids: list[str] = Field(default_factory=list)
 
 
@@ -212,6 +217,8 @@ class ContinuationPattern(BaseModel):
 # v3 profile 行为模式注入门槛：同类模式至少 3 次且来自至少 2 名回复者。
 _BEHAVIOR_PATTERN_MIN_COUNT = 3
 _BEHAVIOR_PATTERN_MIN_RESPONDERS = 2
+# 行为模式代表 trigger 召回阈值：低于直投的 0.6，允许措辞不同的同场景命中。
+_BEHAVIOR_PATTERN_MIN_SIMILARITY = 0.4
 # continuation 同样要求 3 次且 2 名说话者，证明是群习惯而非个人口癖。
 _CONTINUATION_PATTERN_MIN_COUNT = 3
 _CONTINUATION_PATTERN_MIN_SPEAKERS = 2
@@ -1348,7 +1355,7 @@ def _build_profile(
         bot_style_sample_count >= BOT_STYLE_PROMOTION_SAMPLE_COUNT
         and recent_bot_style_sample_count >= BOT_STYLE_PROMOTION_RECENT_SAMPLE_COUNT
     )
-    if example.source_kind == "human_pair" and reply_text and not is_bot_reply:
+    if example.source_kind == "human_pair" and example.pair_kind == "conversation" and reply_text and not is_bot_reply:
         direct_examples = [item for item in direct_examples if item != reply_text]
         direct_examples.append(reply_text)
         pair = SemanticStyleDirectPair(
@@ -1410,6 +1417,7 @@ def _build_profile(
             form=label.forms[0] if label.forms else _PATTERN_DEFAULT_FORM,
             intensity=label.intensity,
             responder_id=example.reply_user_id,
+            pair_relation=example.pair_relation,
             trigger=clean_trigger,
             source_example_id=example.example_id,
         )
@@ -1466,6 +1474,7 @@ def _accumulate_behavior_pattern(
     form: str,
     intensity: str,
     responder_id: int,
+    pair_relation: str,
     trigger: str,
     source_example_id: str,
 ) -> list[ControlledBehaviorPattern]:
@@ -1480,13 +1489,27 @@ def _accumulate_behavior_pattern(
         ) == _pattern_key(action=action, relation=relation, form=form, intensity=intensity):
             if responder_id not in pattern.responder_ids:
                 pattern.responder_ids = [*pattern.responder_ids, responder_id][-_PATTERN_MAX_RESPONDER_IDS:]
-            if trigger and trigger not in pattern.representative_triggers:
-                pattern.representative_triggers = [*pattern.representative_triggers, trigger][
-                    -_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:
-                ]
+            if pair_relation == "quoted":
+                pattern.quoted_count += 1
+                if responder_id not in pattern.quoted_responder_ids:
+                    pattern.quoted_responder_ids = [*pattern.quoted_responder_ids, responder_id][
+                        -_PATTERN_MAX_RESPONDER_IDS:
+                    ]
             if source_example_id and source_example_id not in pattern.source_example_ids:
                 pattern.source_example_ids = [*pattern.source_example_ids, source_example_id][-_PATTERN_MAX_SOURCE_IDS:]
             pattern.count += 1
+            # 代表 trigger 只保留来自 quoted 证据的样本，adjacent 命中不进入直投参考。
+            if pair_relation == "quoted" and trigger:
+                if trigger not in pattern.quoted_triggers:
+                    pattern.quoted_triggers = [
+                        *pattern.quoted_triggers,
+                        trigger,
+                    ][-_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:]
+                if trigger not in pattern.representative_triggers:
+                    pattern.representative_triggers = [
+                        *pattern.representative_triggers,
+                        trigger,
+                    ][-_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:]
             merged = True
             break
     if not merged:
@@ -1498,7 +1521,10 @@ def _accumulate_behavior_pattern(
                 intensity=intensity,
                 count=1,
                 responder_ids=[responder_id],
-                representative_triggers=[trigger] if trigger else [],
+                quoted_count=1 if pair_relation == "quoted" else 0,
+                quoted_responder_ids=[responder_id] if pair_relation == "quoted" else [],
+                representative_triggers=[trigger] if trigger and pair_relation == "quoted" else [],
+                quoted_triggers=[trigger] if trigger and pair_relation == "quoted" else [],
                 source_example_ids=[source_example_id] if source_example_id else [],
             )
         )
@@ -1841,6 +1867,8 @@ def _rebuild_profiles(
             continue
         if example.source_kind != "human_pair":
             continue
+        if semantic_style_candidate_rejected(trigger_text=example.trigger_text, reply_text=example.reply_text):
+            continue
         reply_is_bot = _example_reply_is_bot(example)
         if not reply_is_bot and not is_human_semantic_style_pair(
             trigger_user_id=example.trigger_user_id,
@@ -1903,6 +1931,8 @@ def _cached_group_expression_profile(
         examples: dict[str, None] = {}
         seeds: dict[str, None] = {}
         strategies: dict[tuple[str, str, str], BehaviorStrategy] = {}
+        behavior_patterns: dict[tuple[str, str, str, str], ControlledBehaviorPattern] = {}
+        continuation_patterns: dict[tuple[str, str, str], ContinuationPattern] = {}
         style_anchor = ""
         bubble_counts: list[int] = []
         segment_lengths: list[int] = []
@@ -1924,6 +1954,50 @@ def _cached_group_expression_profile(
                 seeds[text] = None
             for strategy in profile.behavior_strategies:
                 strategies[(strategy.learning_type, strategy.scene, strategy.action)] = strategy
+            for pattern in profile.behavior_patterns:
+                key = _pattern_key(
+                    action=pattern.interaction_action,
+                    relation=pattern.semantic_relation,
+                    form=pattern.form,
+                    intensity=pattern.intensity,
+                )
+                prior = behavior_patterns.get(key)
+                if prior is None:
+                    behavior_patterns[key] = pattern.model_copy(deep=True)
+                    continue
+                prior.count += pattern.count
+                prior.quoted_count += pattern.quoted_count
+                prior.responder_ids = list(dict.fromkeys([*prior.responder_ids, *pattern.responder_ids]))[
+                    -_PATTERN_MAX_RESPONDER_IDS:
+                ]
+                prior.quoted_responder_ids = list(
+                    dict.fromkeys([*prior.quoted_responder_ids, *pattern.quoted_responder_ids])
+                )[-_PATTERN_MAX_RESPONDER_IDS:]
+                prior.representative_triggers = list(
+                    dict.fromkeys([*prior.representative_triggers, *pattern.representative_triggers])
+                )[-_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:]
+                prior.quoted_triggers = list(dict.fromkeys([*prior.quoted_triggers, *pattern.quoted_triggers]))[
+                    -_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:
+                ]
+                prior.source_example_ids = list(
+                    dict.fromkeys([*prior.source_example_ids, *pattern.source_example_ids])
+                )[-_PATTERN_MAX_SOURCE_IDS:]
+            for pattern in profile.continuation_patterns:
+                key = (pattern.semantic_relation, pattern.form, pattern.intensity)
+                prior = continuation_patterns.get(key)
+                if prior is None:
+                    continuation_patterns[key] = pattern.model_copy(deep=True)
+                    continue
+                prior.count += pattern.count
+                prior.speaker_ids = list(dict.fromkeys([*prior.speaker_ids, *pattern.speaker_ids]))[
+                    -_PATTERN_MAX_RESPONDER_IDS:
+                ]
+                prior.representative_triggers = list(
+                    dict.fromkeys([*prior.representative_triggers, *pattern.representative_triggers])
+                )[-_PATTERN_MAX_REPRESENTATIVE_TRIGGERS:]
+                prior.source_example_ids = list(
+                    dict.fromkeys([*prior.source_example_ids, *pattern.source_example_ids])
+                )[-_PATTERN_MAX_SOURCE_IDS:]
             bubble_counts.extend(profile.bubble_counts)
             segment_lengths.extend(profile.segment_char_lengths)
             for rhythm, count in profile.rhythm_counts.items():
@@ -1933,22 +2007,24 @@ def _cached_group_expression_profile(
             bot_style_sample_count += profile.bot_style_sample_count
             recent_bot_style_sample_count += profile.recent_bot_style_sample_count
             visual_sample_count += profile.visual_sample_count
-        merged.direct_pairs = list(pair_map.values())[-_DIRECT_PAIR_LIMIT:]
-        merged.direct_examples = list(examples)[-3:]
-        merged.rewrite_seeds = list(seeds)[-3:]
-        merged.style_anchor = style_anchor or merged.style_anchor
-        merged.behavior_strategies = list(strategies.values())[-_BEHAVIOR_STRATEGY_LIMIT:]
-        merged.bubble_counts = bubble_counts[-100:]
-        merged.segment_char_lengths = segment_lengths[-300:]
-        merged.rhythm_counts = rhythm_counts
-        merged.sample_count = sample_count
-        merged.common_style_sample_count = common_style_sample_count
-        merged.bot_style_sample_count = bot_style_sample_count
-        merged.recent_bot_style_sample_count = recent_bot_style_sample_count
-        merged.visual_sample_count = visual_sample_count
-        merged.bot_style_promoted = any(profile.bot_style_promoted for profile in candidates)
-        merged.updated_at = max(profile.updated_at for profile in candidates)
-        return merged
+    merged.direct_pairs = list(pair_map.values())[-_DIRECT_PAIR_LIMIT:]
+    merged.direct_examples = list(examples)[-3:]
+    merged.rewrite_seeds = list(seeds)[-3:]
+    merged.style_anchor = style_anchor or merged.style_anchor
+    merged.behavior_strategies = list(strategies.values())[-_BEHAVIOR_STRATEGY_LIMIT:]
+    merged.behavior_patterns = list(behavior_patterns.values())
+    merged.continuation_patterns = list(continuation_patterns.values())
+    merged.bubble_counts = bubble_counts[-100:]
+    merged.segment_char_lengths = segment_lengths[-300:]
+    merged.rhythm_counts = rhythm_counts
+    merged.sample_count = sample_count
+    merged.common_style_sample_count = common_style_sample_count
+    merged.bot_style_sample_count = bot_style_sample_count
+    merged.recent_bot_style_sample_count = recent_bot_style_sample_count
+    merged.visual_sample_count = visual_sample_count
+    merged.bot_style_promoted = any(profile.bot_style_promoted for profile in candidates)
+    merged.updated_at = max(profile.updated_at for profile in candidates)
+    return merged
 
 
 def semantic_style_profile_summary(profile: SemanticStyleProfile | None) -> dict[str, Any] | None:
@@ -2000,6 +2076,7 @@ def semantic_style_injection_enabled(
             return False
         if semantic_style_in_control(int(bot_id), int(group_id)):
             return False
+        return True
     digest = hashlib.blake2b(str(request_id).encode("utf-8"), digest_size=8).digest()
     return int.from_bytes(digest, "big") % 10 != 0
 
@@ -2062,6 +2139,14 @@ def resolve_cached_semantic_style(
     profile = cached_semantic_style_profile(bot_id, group_id, scene)
     if profile is None or not profile.human_only:
         return SemanticStyleResolution()
+    if load_semantic_style_settings().active_pipeline == "v2":
+        return _resolve_cached_semantic_style_v2(
+            profile,
+            bot_id=bot_id,
+            group_id=group_id,
+            query_text=query_text,
+            recent_assistant_replies=recent_assistant_replies,
+        )
     direct_pairs = filter_semantic_style_pairs_by_feedback(profile.direct_pairs, bot_id=bot_id, group_id=group_id)
     direct_pair = select_semantic_style_direct_pair(
         direct_pairs,
@@ -2092,27 +2177,41 @@ def resolve_cached_semantic_style(
             if prompt_safe_expression_sample(strategy.scene) and prompt_safe_expression_sample(strategy.action)
         ]
     )
-    behavior_patterns = [
-        pattern
-        for pattern in profile.behavior_patterns
-        if behavioral_pattern_injectable(pattern)
-        and select_behavior_pattern_representative(pattern, query_text=query_text) is not None
-    ][:_BEHAVIOR_STRATEGY_MAX_HITS]
+    matched_patterns: list[tuple[float, ControlledBehaviorPattern]] = []
+    for pattern in profile.behavior_patterns:
+        if not behavioral_pattern_injectable(pattern):
+            continue
+        representative = select_behavior_pattern_representative(pattern, query_text=query_text)
+        if not representative:
+            continue
+        matched_patterns.append((
+            semantic_style_text_similarity(query_text, representative),
+            pattern.model_copy(update={"representative_triggers": [representative]}),
+        ))
+    matched_patterns.sort(key=itemgetter(0), reverse=True)
+    behavior_patterns = [item[1] for item in matched_patterns[:_BEHAVIOR_STRATEGY_MAX_HITS]]
     continuation_patterns = [
         pattern for pattern in profile.continuation_patterns if continuation_pattern_injectable(pattern)
     ][:_CONTINUATION_PATTERN_MAX_HITS]
-    direct_candidate = select_safe_direct_candidate(
+    direct_pattern = select_safe_direct_pattern(
         profile.behavior_patterns,
         query_text=query_text,
         recent_assistant_replies=recent_assistant_replies,
     )
+    direct_candidate = SAFE_DIRECT_ACTION_TEXT[direct_pattern.interaction_action] if direct_pattern is not None else ""
     return SemanticStyleResolution(
         style_anchor=safe_anchor,
         prompt_block=append_cached_semantic_style_block("", safe_anchor, ""),
         matched_examples=matched_examples,
         matched_example_sources=safe_matched,
         direct_candidate=direct_candidate,
-        source_example_id=semantic_style_source_example_id(direct_pair) if direct_pair is not None else "",
+        source_example_id=(
+            direct_pattern.source_example_ids[-1]
+            if direct_pattern is not None and direct_pattern.source_example_ids
+            else semantic_style_source_example_id(direct_pair)
+            if direct_pair is not None
+            else ""
+        ),
         baseline_note="",
         behavior_strategies=behavior_strategies[:_BEHAVIOR_STRATEGY_MAX_HITS],
         behavior_patterns=behavior_patterns,
@@ -2121,35 +2220,121 @@ def resolve_cached_semantic_style(
     )
 
 
+def _resolve_cached_semantic_style_v2(
+    profile: SemanticStyleProfile,
+    *,
+    bot_id: int,
+    group_id: int | None,
+    query_text: str,
+    recent_assistant_replies: Iterable[str],
+) -> SemanticStyleResolution:
+    direct_pairs = filter_semantic_style_pairs_by_feedback(profile.direct_pairs, bot_id=bot_id, group_id=group_id)
+    direct_pair = select_semantic_style_direct_pair(
+        direct_pairs,
+        query_text=query_text,
+        recent_assistant_replies=recent_assistant_replies,
+    )
+    rewrite_seed = profile.rewrite_seeds[-1] if profile.rewrite_seeds else ""
+    if not rewrite_seed and direct_pair is not None:
+        rewrite_seed = direct_pair.reply_text
+    safe_matched = [
+        pair
+        for pair in select_semantic_style_matched_pairs(
+            direct_pairs,
+            query_text=query_text,
+            recent_assistant_replies=recent_assistant_replies,
+            limit=_MATCHED_EXAMPLE_LIMIT,
+        )
+        if prompt_safe_expression_sample(pair.trigger_text) and prompt_safe_expression_sample(pair.reply_text)
+    ]
+    matched_examples = [
+        (_short_text(pair.trigger_text, _MAX_SEED_LEN), _short_text(pair.reply_text, _MAX_SEED_LEN))
+        for pair in safe_matched
+    ]
+    behavior_strategies = (
+        []
+        if matched_examples
+        else [
+            strategy
+            for strategy in select_behavior_strategies(profile.behavior_strategies, query_text=query_text)
+            if prompt_safe_expression_sample(strategy.scene) and prompt_safe_expression_sample(strategy.action)
+        ]
+    )
+    safe_anchor = prompt_safe_expression_sample(profile.style_anchor)
+    safe_seed = prompt_safe_expression_sample(rewrite_seed)
+    return SemanticStyleResolution(
+        style_anchor=safe_anchor,
+        prompt_block=append_cached_semantic_style_block("", safe_anchor, safe_seed),
+        matched_examples=matched_examples,
+        matched_example_sources=safe_matched,
+        direct_candidate=prompt_safe_expression_sample(direct_pair.reply_text) if direct_pair is not None else "",
+        source_example_id=semantic_style_source_example_id(direct_pair) if direct_pair is not None else "",
+        baseline_note=build_rhythm_baseline_note(profile),
+        behavior_strategies=behavior_strategies[:_BEHAVIOR_STRATEGY_MAX_HITS],
+        style_profile=semantic_style_profile_summary(profile) or {},
+    )
+
+
+def select_safe_direct_pattern(
+    patterns: Iterable[ControlledBehaviorPattern],
+    *,
+    query_text: str,
+    recent_assistant_replies: Iterable[str] = (),
+) -> ControlledBehaviorPattern | None:
+    """普通直投：仅返回满足 quoted 证据门槛且命中代表 trigger 的安全 action pattern。"""
+    recent = [reply for reply in recent_assistant_replies if normalize_semantic_style_match_text(reply)]
+    for pattern in patterns:
+        if pattern.interaction_action not in SAFE_DIRECT_ACTION_TEXT:
+            continue
+        has_legacy_evidence = pattern.quoted_count < 0 and not pattern.quoted_responder_ids
+        if not has_legacy_evidence and (
+            pattern.quoted_count < _DIRECT_PATTERN_MIN_COUNT
+            or len(pattern.quoted_responder_ids) < _DIRECT_PATTERN_MIN_RESPONDERS
+        ):
+            continue
+        representative = select_behavior_pattern_representative(pattern, query_text=query_text, quoted_only=True)
+        if not representative:
+            continue
+        text = SAFE_DIRECT_ACTION_TEXT[pattern.interaction_action]
+        if any(semantic_style_text_similarity(text, previous) >= _DIRECT_REPLY_DEDUP_SIMILARITY for previous in recent):
+            continue
+        return pattern
+    return None
+
+
 def select_safe_direct_candidate(
     patterns: Iterable[ControlledBehaviorPattern],
     *,
     query_text: str,
     recent_assistant_replies: Iterable[str] = (),
 ) -> str:
-    """普通直投：仅当受控 action 达到 2 次/2 人且命中代表 trigger 时，返回固定安全短句。"""
-    recent = [reply for reply in recent_assistant_replies if normalize_semantic_style_match_text(reply)]
-    for pattern in patterns:
-        if pattern.interaction_action not in SAFE_DIRECT_ACTION_TEXT:
-            continue
-        if pattern.count < _DIRECT_PATTERN_MIN_COUNT or len(pattern.responder_ids) < _DIRECT_PATTERN_MIN_RESPONDERS:
-            continue
-        representative = select_behavior_pattern_representative(pattern, query_text=query_text)
-        if not representative:
-            continue
-        text = SAFE_DIRECT_ACTION_TEXT[pattern.interaction_action]
-        if any(semantic_style_text_similarity(text, previous) >= _DIRECT_REPLY_DEDUP_SIMILARITY for previous in recent):
-            continue
-        return text
-    return ""
+    pattern = select_safe_direct_pattern(
+        patterns,
+        query_text=query_text,
+        recent_assistant_replies=recent_assistant_replies,
+    )
+    return SAFE_DIRECT_ACTION_TEXT[pattern.interaction_action] if pattern is not None else ""
 
 
-def select_behavior_pattern_representative(pattern: ControlledBehaviorPattern, *, query_text: str) -> str:
-    """受控行为模式按代表 trigger 召回；无命中返回空串。"""
-    for trigger in pattern.representative_triggers:
-        if semantic_style_text_similarity(query_text, trigger) >= _DIRECT_TRIGGER_SIMILARITY:
-            return str(trigger or "")
-    return ""
+def select_behavior_pattern_representative(
+    pattern: ControlledBehaviorPattern,
+    *,
+    query_text: str,
+    quoted_only: bool = False,
+) -> str:
+    """受控行为模式按代表 trigger 召回；无命中返回空串。
+
+    ``quoted_only`` 用于普通直投：只允许命中 quoted 证据积累出的代表 trigger。
+    """
+    best: tuple[float, str] | None = None
+    candidates = pattern.quoted_triggers if quoted_only else pattern.representative_triggers
+    for trigger in candidates:
+        score = semantic_style_text_similarity(query_text, trigger)
+        if score < _BEHAVIOR_PATTERN_MIN_SIMILARITY:
+            continue
+        if best is None or score > best[0]:
+            best = (score, str(trigger or ""))
+    return best[1] if best is not None else ""
 
 
 def behavior_pattern_prompt_line(pattern: ControlledBehaviorPattern, representative: str) -> str:
@@ -2189,11 +2374,19 @@ def semantic_style_text_similarity(left: str, right: str) -> float:
         return 0.0
     if normalized_left == normalized_right:
         return 1.0
-    if min(len(normalized_left), len(normalized_right)) < 2:
+    if min(len(normalized_left), len(normalized_right)) < 3:
         return 0.0
+    if normalized_left in normalized_right or normalized_right in normalized_left:
+        return 1.0
     left_pairs = {normalized_left[index : index + 2] for index in range(len(normalized_left) - 1)}
     right_pairs = {normalized_right[index : index + 2] for index in range(len(normalized_right) - 1)}
-    return len(left_pairs & right_pairs) / min(len(left_pairs), len(right_pairs))
+    overlap = len(left_pairs & right_pairs)
+    if overlap < 2:
+        return 0.0
+    return max(
+        overlap / min(len(left_pairs), len(right_pairs)),
+        2 * overlap / (len(left_pairs) + len(right_pairs)),
+    )
 
 
 def select_semantic_style_direct_candidate(
@@ -2324,6 +2517,10 @@ def should_deliver_semantic_style_direct_candidate(
     """按群维护最近 100 次内核任务的直投占比。"""
     settings = load_semantic_style_settings(bot_id=bot_id, group_id=group_id)
     if not settings.injection_enabled or not settings.direct_enabled:
+        return False
+    from pallas.product.llm.semantic_style_experiment import semantic_channel_circuit_disabled
+
+    if semantic_channel_circuit_disabled("semantic_direct"):
         return False
     key = (int(bot_id or 0), int(group_id or 0))
     text = _short_text(candidate, _MAX_SEED_LEN)

--- a/pallas/product/llm/semantic_protocol.py
+++ b/pallas/product/llm/semantic_protocol.py
@@ -1,0 +1,323 @@
+"""低风险游戏协议响应：从「Bot 提示 → 真人短命令」中学习，独立于群表达画像。
+
+协议不进入 profiles.json，也不参与行为/续句聚合；只复用 message 表与文件锁。
+运行时仅当协议模板达到 3 次且 2 名真人、且满足定向与冷却时才自动回复。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pallas.core.foundation.fs_lock import interprocess_file_lock
+from pallas.core.foundation.paths import plugin_data_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# 协议模板观察门槛：同一模板+命令至少 3 次、来自至少 2 名真人。
+_PROTOCOL_MIN_COUNT = 3
+_PROTOCOL_MIN_RESPONDERS = 2
+# 协议独立冷却：每 bot × 群 10 分钟。
+_PROTOCOL_COOLDOWN_SEC = 10 * 60
+# 命令长度与安全边界。
+_PROTOCOL_COMMAND_MIN_LEN = 2
+_PROTOCOL_COMMAND_MAX_LEN = 16
+_PROTOCOL_RISK_WORDS = (
+    "管理",
+    "权限",
+    "付费",
+    "转账",
+    "绑定",
+    "登录",
+    "验证码",
+    "删除",
+    "退群",
+    "禁言",
+    "踢人",
+    "封禁",
+    "解封",
+    "提现",
+    "充值",
+    "购买",
+    "兑换",
+    "口令",
+    "密码",
+)
+# 显式命令候选：发送/回复「X」。
+_PROTOCOL_COMMAND_RE = re.compile(r"(?:发送|回复)[「\"']([^「\"']{1,24})[」\"']")
+# 昵称定向窗口：最近 3 分钟在该群发过消息的本地 Bot 才可响应昵称协议。
+_PROTOCOL_RECENT_BOT_SEC = 3 * 60
+
+
+class ProtocolObservation(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    observation_id: str
+    bot_id: int
+    group_id: int
+    trigger_template: str
+    response_command: str
+    responder_id: int
+    source_message_id: int
+    created_at: int
+
+
+class ProtocolPattern(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    bot_id: int
+    trigger_template: str
+    response_command: str
+    count: int = 0
+    responder_ids: list[int] = Field(default_factory=list)
+    source_observation_ids: list[str] = Field(default_factory=list)
+    updated_at: int = 0
+
+
+def protocol_base_dir() -> Path:
+    return plugin_data_dir("pb_webui", create=True) / "repeater_semantic_style"
+
+
+def protocol_examples_path() -> Path:
+    return protocol_base_dir() / "protocol_examples.jsonl"
+
+
+def protocol_patterns_path() -> Path:
+    return protocol_base_dir() / "protocol_patterns.json"
+
+
+def protocol_cooldowns_path() -> Path:
+    return protocol_base_dir() / "protocol_cooldowns.json"
+
+
+def extract_protocol_commands(text: str) -> list[str]:
+    """从 Bot 提示文本中提取显式短命令候选，去重保序。"""
+    commands: list[str] = []
+    for match in _PROTOCOL_COMMAND_RE.finditer(str(text or "")):
+        command = str(match.group(1) or "").strip()
+        if command and command not in commands:
+            commands.append(command)
+    return commands
+
+
+def protocol_command_safe(command: str) -> bool:
+    """命令必须短、自包含，且不含管理/资产/安全类风险词。"""
+    text = str(command or "").strip()
+    if not (_PROTOCOL_COMMAND_MIN_LEN <= len(text) <= _PROTOCOL_COMMAND_MAX_LEN):
+        return False
+    if re.search(r"[\r\n\0]", text):
+        return False
+    lowered = text.casefold()
+    return not any(risk in lowered for risk in _PROTOCOL_RISK_WORDS)
+
+
+def _load_observations() -> list[ProtocolObservation]:
+    path = protocol_examples_path()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    observations: list[ProtocolObservation] = []
+    for line in lines:
+        try:
+            observations.append(ProtocolObservation.model_validate(json.loads(line)))
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+    return observations
+
+
+def _load_patterns() -> dict[tuple[int, str, str], ProtocolPattern]:
+    try:
+        raw = json.loads(protocol_patterns_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    rows = raw.get("patterns") if isinstance(raw, dict) else raw
+    if not isinstance(rows, list):
+        return {}
+    patterns: dict[tuple[int, str, str], ProtocolPattern] = {}
+    for item in rows:
+        try:
+            pattern = ProtocolPattern.model_validate(item)
+        except Exception:
+            continue
+        patterns[(pattern.bot_id, pattern.trigger_template, pattern.response_command)] = pattern
+    return patterns
+
+
+def _write_patterns(patterns: dict[tuple[int, str, str], ProtocolPattern]) -> None:
+    path = protocol_patterns_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"patterns": [item.model_dump(mode="json") for item in patterns.values()]}
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _normalize_template(text: str) -> str:
+    """模板归一化：折叠空白、去掉命令候选占位，便于跨群聚合。"""
+    normalized = re.sub(r"(?:发送|回复)[「\"'][^「\"']{1,24}[」\"']", "发送「命令」", str(text or ""))
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def record_protocol_observation(
+    *,
+    bot_id: int,
+    group_id: int,
+    trigger_text: str,
+    reply_text: str,
+    responder_id: int,
+    source_message_id: int,
+    created_at: int | None = None,
+) -> bool:
+    """记录一次「Bot 提示 → 真人短命令」观察；命令不在显式候选中则忽略。"""
+    commands = extract_protocol_commands(trigger_text)
+    reply = str(reply_text or "").strip()
+    if reply not in commands or not protocol_command_safe(reply):
+        return False
+    template = _normalize_template(trigger_text)
+    if not template:
+        return False
+    now = int(time.time()) if created_at is None else int(created_at)
+    observation_id = f"{bot_id}:{group_id}:{source_message_id}:{reply}"
+    with interprocess_file_lock(protocol_examples_path().with_suffix(".lock")):
+        observations = _load_observations()
+        if any(item.observation_id == observation_id for item in observations):
+            return False
+        observations.append(
+            ProtocolObservation(
+                observation_id=observation_id,
+                bot_id=int(bot_id),
+                group_id=int(group_id),
+                trigger_template=template,
+                response_command=reply,
+                responder_id=int(responder_id),
+                source_message_id=int(source_message_id),
+                created_at=now,
+            )
+        )
+        protocol_examples_path().parent.mkdir(parents=True, exist_ok=True)
+        with protocol_examples_path().open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(observations[-1].model_dump(mode="json"), ensure_ascii=False, separators=(",", ":")) + "\n"
+            )
+        patterns = _load_patterns()
+        key = (int(bot_id), template, reply)
+        existing = patterns.get(key)
+        if existing is None:
+            existing = ProtocolPattern(
+                bot_id=int(bot_id),
+                trigger_template=template,
+                response_command=reply,
+                updated_at=now,
+            )
+        if responder_id not in existing.responder_ids:
+            existing.responder_ids = [*existing.responder_ids, int(responder_id)][:8]
+        if observation_id not in existing.source_observation_ids:
+            existing.source_observation_ids = [*existing.source_observation_ids, observation_id][:8]
+        existing.count += 1
+        existing.updated_at = now
+        patterns[key] = existing
+        _write_patterns(patterns)
+    return True
+
+
+def _load_cooldowns() -> dict[tuple[int, int], int]:
+    try:
+        raw = json.loads(protocol_cooldowns_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    out: dict[tuple[int, int], int] = {}
+    for key, value in raw.items() if isinstance(raw, dict) else []:
+        try:
+            bot_id, group_id = (int(part) for part in str(key).split(":", 1))
+            out[(bot_id, group_id)] = int(value)
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _write_cooldowns(cooldowns: dict[tuple[int, int], int]) -> None:
+    path = protocol_cooldowns_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {f"{bot_id}:{group_id}": sent_at for (bot_id, group_id), sent_at in cooldowns.items()}
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
+    tmp.replace(path)
+
+
+def protocol_cooldown_ok(*, bot_id: int, group_id: int, now: int | None = None) -> bool:
+    current = int(time.time()) if now is None else int(now)
+    sent_at = _load_cooldowns().get((int(bot_id), int(group_id)), 0)
+    return current - sent_at >= _PROTOCOL_COOLDOWN_SEC
+
+
+def mark_protocol_sent(*, bot_id: int, group_id: int, now: int | None = None) -> None:
+    current = int(time.time()) if now is None else int(now)
+    with interprocess_file_lock(protocol_cooldowns_path().with_suffix(".lock")):
+        cooldowns = _load_cooldowns()
+        cooldowns[(int(bot_id), int(group_id))] = current
+        _write_cooldowns(cooldowns)
+
+
+def resolve_protocol_candidate(
+    *,
+    bot_id: int,
+    group_id: int,
+    trigger_text: str,
+    recent_bot_id: int | None = None,
+    now: int | None = None,
+) -> str:
+    """运行时判定：当前 Bot 提示是否命中合格协议模板，返回可自动回复的命令。
+
+    ``recent_bot_id`` 为最近 3 分钟内该群最后发言的本地 Bot；昵称定向时仅
+    当前 Bot 是最近发言者才允许响应。明确 @/引用由调用方在定向判定中处理。
+    """
+    commands = extract_protocol_commands(trigger_text)
+    if not commands:
+        return ""
+    template = _normalize_template(trigger_text)
+    if not template:
+        return ""
+    if not protocol_cooldown_ok(bot_id=bot_id, group_id=group_id, now=now):
+        return ""
+    patterns = _load_patterns()
+    for command in commands:
+        if not protocol_command_safe(command):
+            continue
+        pattern = patterns.get((int(bot_id), template, command))
+        if pattern is None:
+            continue
+        if pattern.count < _PROTOCOL_MIN_COUNT or len(pattern.responder_ids) < _PROTOCOL_MIN_RESPONDERS:
+            continue
+        if recent_bot_id is not None and int(recent_bot_id) != int(bot_id):
+            continue
+        return command
+    return ""
+
+
+def protocol_status() -> dict[str, Any]:
+    observations = _load_observations()
+    patterns = _load_patterns()
+    eligible = [
+        pattern
+        for pattern in patterns.values()
+        if pattern.count >= _PROTOCOL_MIN_COUNT and len(pattern.responder_ids) >= _PROTOCOL_MIN_RESPONDERS
+    ]
+    return {
+        "observation_count": len(observations),
+        "pattern_count": len(patterns),
+        "eligible_pattern_count": len(eligible),
+    }
+
+
+def clear_protocol_data_for_tests() -> None:
+    for path in (protocol_examples_path(), protocol_patterns_path(), protocol_cooldowns_path()):
+        try:
+            path.unlink()
+        except OSError:
+            pass

--- a/pallas/product/llm/semantic_protocol.py
+++ b/pallas/product/llm/semantic_protocol.py
@@ -50,6 +50,7 @@ _PROTOCOL_RISK_WORDS = (
 )
 # 显式命令候选：发送/回复「X」。
 _PROTOCOL_COMMAND_RE = re.compile(r"(?:发送|回复)[「\"']([^「\"']{1,24})[」\"']")
+_PROTOCOL_COMMAND_SAFE_RE = re.compile(r"[\u4e00-\u9fffA-Za-z0-9_+\-]+")
 # 昵称定向窗口：最近 3 分钟在该群发过消息的本地 Bot 才可响应昵称协议。
 _PROTOCOL_RECENT_BOT_SEC = 3 * 60
 
@@ -110,7 +111,7 @@ def protocol_command_safe(command: str) -> bool:
     text = str(command or "").strip()
     if not (_PROTOCOL_COMMAND_MIN_LEN <= len(text) <= _PROTOCOL_COMMAND_MAX_LEN):
         return False
-    if re.search(r"[\r\n\0]", text):
+    if _PROTOCOL_COMMAND_SAFE_RE.fullmatch(text) is None:
         return False
     lowered = text.casefold()
     return not any(risk in lowered for risk in _PROTOCOL_RISK_WORDS)
@@ -160,7 +161,12 @@ def _write_patterns(patterns: dict[tuple[int, str, str], ProtocolPattern]) -> No
 
 def _normalize_template(text: str) -> str:
     """模板归一化：折叠空白、去掉命令候选占位，便于跨群聚合。"""
-    normalized = re.sub(r"(?:发送|回复)[「\"'][^「\"']{1,24}[」\"']", "发送「命令」", str(text or ""))
+    normalized = str(text or "")
+    instruction = re.search(r"(?:请在|请发送|请回复|发送|回复)", normalized)
+    if instruction is not None:
+        normalized = normalized[instruction.start() :]
+    normalized = re.sub(r"\d+", "{n}", normalized)
+    normalized = re.sub(r"(?:发送|回复)[「\"'][^「\"']{1,24}[」\"']", "发送「命令」", normalized)
     return re.sub(r"\s+", " ", normalized).strip()
 
 
@@ -270,6 +276,8 @@ def resolve_protocol_candidate(
     group_id: int,
     trigger_text: str,
     recent_bot_id: int | None = None,
+    explicitly_targeted: bool = False,
+    nickname_targeted: bool = False,
     now: int | None = None,
 ) -> str:
     """运行时判定：当前 Bot 提示是否命中合格协议模板，返回可自动回复的命令。
@@ -277,6 +285,10 @@ def resolve_protocol_candidate(
     ``recent_bot_id`` 为最近 3 分钟内该群最后发言的本地 Bot；昵称定向时仅
     当前 Bot 是最近发言者才允许响应。明确 @/引用由调用方在定向判定中处理。
     """
+    if not explicitly_targeted and not (
+        nickname_targeted and recent_bot_id is not None and int(recent_bot_id) == int(bot_id)
+    ):
+        return ""
     commands = extract_protocol_commands(trigger_text)
     if not commands:
         return ""
@@ -294,10 +306,44 @@ def resolve_protocol_candidate(
             continue
         if pattern.count < _PROTOCOL_MIN_COUNT or len(pattern.responder_ids) < _PROTOCOL_MIN_RESPONDERS:
             continue
-        if recent_bot_id is not None and int(recent_bot_id) != int(bot_id):
-            continue
         return command
     return ""
+
+
+def claim_protocol_candidate(
+    *,
+    bot_id: int,
+    group_id: int,
+    trigger_text: str,
+    recent_bot_id: int | None = None,
+    explicitly_targeted: bool = False,
+    nickname_targeted: bool = False,
+    now: int | None = None,
+) -> str:
+    """原子检查并占用协议冷却，避免多个 worker 同时直投。"""
+    from pallas.product.llm.semantic_style_experiment import semantic_channel_circuit_disabled
+
+    if semantic_channel_circuit_disabled("protocol_direct"):
+        return ""
+    current = int(time.time()) if now is None else int(now)
+    with interprocess_file_lock(protocol_cooldowns_path().with_suffix(".lock")):
+        cooldowns = _load_cooldowns()
+        if current - cooldowns.get((int(bot_id), int(group_id)), 0) < _PROTOCOL_COOLDOWN_SEC:
+            return ""
+        candidate = resolve_protocol_candidate(
+            bot_id=bot_id,
+            group_id=group_id,
+            trigger_text=trigger_text,
+            recent_bot_id=recent_bot_id,
+            explicitly_targeted=explicitly_targeted,
+            nickname_targeted=nickname_targeted,
+            now=current + _PROTOCOL_COOLDOWN_SEC,
+        )
+        if not candidate:
+            return ""
+        cooldowns[(int(bot_id), int(group_id))] = current
+        _write_cooldowns(cooldowns)
+        return candidate
 
 
 def protocol_status() -> dict[str, Any]:

--- a/pallas/product/llm/semantic_style_experiment.py
+++ b/pallas/product/llm/semantic_style_experiment.py
@@ -1,0 +1,353 @@
+"""语义风格 v3 实验治理：群日稳定 A/B、exposure 记录与统计熔断。
+
+对照组按 ``bot × group × 北京自然日`` 稳定分桶：同一群当天体验一致，
+次日可换桶。熔断只停注入，不停采集；硬错误由各直投通道自行熔断。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import time
+from typing import TYPE_CHECKING, Any
+
+from nonebot import get_driver, logger
+
+from pallas.core.foundation.fs_lock import interprocess_file_lock
+from pallas.core.foundation.logging import log_rate_limited
+from pallas.core.foundation.paths import plugin_data_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# 对照组占比：bucket == 0 为 control。
+_CONTROL_BUCKET = 0
+_BUCKET_COUNT = 10
+# 统计熔断前置：实验至少 200 回合、对照至少 20 回合。
+_EXPERIMENT_MIN_SETTLED = 200
+_CONTROL_MIN_SETTLED = 20
+# 双阈值：负反馈率差 ≥ 3 个百分点且 ≥ 1.5 倍。
+_NEGATIVE_RATE_DELTA = 0.03
+_NEGATIVE_RATE_RATIO = 1.5
+# 被动 outcome 结算：投递后 90 秒窗口、最多看 3 条真人消息。
+_OUTCOME_WINDOW_SEC = 90
+_OUTCOME_MAX_FOLLOWUPS = 3
+_OUTCOME_SETTLE_INTERVAL_SEC = 60
+_OUTCOME_MAX_PER_PASS = 200
+
+# 高置信负反馈短语：要求回复/提及 Bot 或与目标用户 exposure 时间窗口一致。
+_NEGATIVE_PHRASES = (
+    "别回",
+    "闭嘴",
+    "不要说了",
+    "答非所问",
+    "你在说什么",
+    "不是这个",
+    "说错了",
+    "胡说",
+    "没问你",
+    "又复读",
+    "别说了",
+    "别烦",
+    "别闹",
+    "别吵",
+    "别乱叫",
+    "别催",
+    "少来这套",
+    "关你屁事",
+    "想得美",
+)
+_NEGATIVE_PHRASE_RE = re.compile("|".join(re.escape(phrase) for phrase in _NEGATIVE_PHRASES))
+
+
+def experiment_base_dir() -> Path:
+    return plugin_data_dir("pb_webui", create=True) / "repeater_semantic_style"
+
+
+def exposures_path() -> Path:
+    return experiment_base_dir() / "exposures.jsonl"
+
+
+def experiment_state_path() -> Path:
+    return experiment_base_dir() / "experiment_state.json"
+
+
+def semantic_style_bucket(bot_id: int, group_id: int, now: int | None = None) -> int:
+    """群日稳定分桶：同一 bot×群×自然日固定同一桶。"""
+    current = int(time.time()) if now is None else int(now)
+    day = current // 86400
+    digest = hashlib.blake2b(f"{int(bot_id)}:{int(group_id)}:{day}".encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % _BUCKET_COUNT
+
+
+def semantic_style_in_control(bot_id: int, group_id: int, now: int | None = None) -> bool:
+    return semantic_style_bucket(bot_id, group_id, now=now) == _CONTROL_BUCKET
+
+
+def _load_state() -> dict[str, Any]:
+    try:
+        raw = json.loads(experiment_state_path().read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    path = experiment_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
+    tmp.replace(path)
+
+
+def semantic_style_circuit_disabled() -> bool:
+    """统计熔断状态：熔断后停注入，但采集继续。"""
+    state = _load_state()
+    return bool(state.get("circuit_disabled"))
+
+
+def record_semantic_exposure(
+    *,
+    request_id: str,
+    bot_id: int,
+    group_id: int,
+    user_id: int,
+    bucket: int,
+    injection_types: list[str],
+    source_ids: list[str],
+    delivery_source: str,
+    bot_message_id: int | None,
+    delivered_at: int | None = None,
+) -> None:
+    """记录一次语义注入/直投的 exposure，供被动 outcome 结算。"""
+    if int(bot_id) <= 0 or int(group_id) <= 0:
+        return
+    now = int(time.time()) if delivered_at is None else int(delivered_at)
+    record = {
+        "request_id": str(request_id),
+        "bot_id": int(bot_id),
+        "group_id": int(group_id),
+        "user_id": int(user_id),
+        "bucket": int(bucket),
+        "injection_types": [str(item) for item in injection_types if str(item).strip()],
+        "source_ids": [str(item) for item in source_ids if str(item).strip()],
+        "delivery_source": str(delivery_source),
+        "bot_message_id": int(bot_message_id) if bot_message_id else None,
+        "delivered_at": now,
+        "settled": False,
+    }
+    path = exposures_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with interprocess_file_lock(path.with_suffix(".lock")):
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+def _load_unsettled_exposures() -> list[dict[str, Any]]:
+    try:
+        lines = exposures_path().read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict) and not item.get("settled"):
+            rows.append(item)
+    return rows
+
+
+def _rewrite_exposures(rows: list[dict[str, Any]]) -> None:
+    path = exposures_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".jsonl.tmp")
+    tmp.write_text(
+        "".join(json.dumps(item, ensure_ascii=False, separators=(",", ":")) + "\n" for item in rows),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def mark_exposures_settled(request_ids: set[str]) -> None:
+    """把已结算的 exposure 标记为 settled，避免重复统计。"""
+    if not request_ids:
+        return
+    with interprocess_file_lock(exposures_path().with_suffix(".lock")):
+        rows = _load_unsettled_exposures()
+        changed = False
+        for item in rows:
+            if item.get("request_id") in request_ids:
+                item["settled"] = True
+                changed = True
+        if changed:
+            _rewrite_exposures(rows)
+
+
+def record_experiment_outcome(
+    *,
+    bucket: int,
+    target_followup: bool,
+    negative: bool,
+) -> None:
+    """累计一次已结算 exposure 的实验/对照计数。"""
+    with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
+        state = _load_state()
+        group = "control" if bucket == _CONTROL_BUCKET else "experiment"
+        counts = state.setdefault(group, {})
+        counts["settled"] = int(counts.get("settled") or 0) + 1
+        if target_followup:
+            counts["target_followup"] = int(counts.get("target_followup") or 0) + 1
+        if negative:
+            counts["negative"] = int(counts.get("negative") or 0) + 1
+        _save_state(state)
+
+
+def maybe_trip_circuit() -> bool:
+    """统计熔断：实验/对照达到最小样本后，负反馈率双阈值触发则停注入。"""
+    with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
+        state = _load_state()
+        if state.get("circuit_disabled"):
+            return True
+        experiment = state.get("experiment") or {}
+        control = state.get("control") or {}
+        exp_settled = int(experiment.get("settled") or 0)
+        ctl_settled = int(control.get("settled") or 0)
+        if exp_settled < _EXPERIMENT_MIN_SETTLED or ctl_settled < _CONTROL_MIN_SETTLED:
+            return False
+        exp_negative = int(experiment.get("negative") or 0) / exp_settled
+        ctl_negative = int(control.get("negative") or 0) / ctl_settled
+        if exp_negative - ctl_negative < _NEGATIVE_RATE_DELTA:
+            return False
+        if ctl_negative > 0 and exp_negative < ctl_negative * _NEGATIVE_RATE_RATIO:
+            return False
+        state["circuit_disabled"] = True
+        state["circuit_reason"] = "negative_rate_delta"
+        state["circuit_tripped_at"] = int(time.time())
+        state["experiment_negative_rate"] = round(exp_negative, 4)
+        state["control_negative_rate"] = round(ctl_negative, 4)
+        _save_state(state)
+        return True
+    return False
+
+
+def reset_experiment_circuit() -> None:
+    """人工恢复：清除熔断状态，保留累计计数。"""
+    with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
+        state = _load_state()
+        state.pop("circuit_disabled", None)
+        state.pop("circuit_reason", None)
+        state.pop("circuit_tripped_at", None)
+        state.pop("experiment_negative_rate", None)
+        state.pop("control_negative_rate", None)
+        _save_state(state)
+
+
+def experiment_status() -> dict[str, Any]:
+    state = _load_state()
+    return {
+        "circuit_disabled": bool(state.get("circuit_disabled")),
+        "circuit_reason": state.get("circuit_reason"),
+        "circuit_tripped_at": state.get("circuit_tripped_at"),
+        "experiment": state.get("experiment") or {},
+        "control": state.get("control") or {},
+    }
+
+
+def clear_experiment_data_for_tests() -> None:
+    for path in (exposures_path(), experiment_state_path()):
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+
+def _looks_negative(text: str) -> bool:
+    return bool(_NEGATIVE_PHRASE_RE.search(str(text or "")))
+
+
+async def settle_pending_semantic_exposures(*, now: int | None = None) -> int:
+    """结算观察窗口已过的 exposure：目标用户续接 + 保守负反馈，并累计实验计数。"""
+    from pallas.core.foundation.db import make_message_repository
+
+    current = int(time.time()) if now is None else int(now)
+    rows = _load_unsettled_exposures()
+    if not rows:
+        return 0
+    repo = make_message_repository()
+    settled = 0
+    for item in rows[:_OUTCOME_MAX_PER_PASS]:
+        delivered_at = int(item.get("delivered_at") or 0)
+        if delivered_at <= 0 or current - delivered_at < _OUTCOME_WINDOW_SEC:
+            continue
+        bot_id = int(item.get("bot_id") or 0)
+        group_id = int(item.get("group_id") or 0)
+        target_user = int(item.get("user_id") or 0)
+        if bot_id <= 0 or group_id <= 0:
+            continue
+        try:
+            followups = await repo.list_group_messages_after(
+                group_id,
+                after_time=delivered_at,
+                after_message_id=int(item.get("bot_message_id") or 0) or None,
+                limit=_OUTCOME_MAX_FOLLOWUPS,
+            )
+        except Exception as exc:
+            log_rate_limited(logger, "warning", "semantic_experiment.query", "语义 exposure 结算查询失败：{}", exc)
+            continue
+        target_followup = False
+        negative = False
+        for message in followups:
+            user_id = int(getattr(message, "user_id", 0) or 0)
+            text = str(getattr(message, "plain_text", "") or getattr(message, "raw_message", "") or "")
+            if user_id == target_user:
+                target_followup = True
+            if _looks_negative(text):
+                negative = True
+        record_experiment_outcome(
+            bucket=int(item.get("bucket") or 1),
+            target_followup=target_followup,
+            negative=negative,
+        )
+        settled += 1
+    if settled:
+        mark_exposures_settled({str(item.get("request_id")) for item in rows[:settled]})
+    maybe_trip_circuit()
+    return settled
+
+
+async def _settle_loop() -> None:
+    while True:
+        await asyncio.sleep(_OUTCOME_SETTLE_INTERVAL_SEC)
+        try:
+            await settle_pending_semantic_exposures()
+        except Exception as exc:
+            log_rate_limited(logger, "warning", "semantic_experiment.loop", "语义 exposure 自动结算失败：{}", exc)
+
+
+_startup_bound = False
+_settle_task: asyncio.Task[Any] | None = None
+
+
+def register_semantic_experiment_loop() -> None:
+    global _startup_bound, _settle_task
+    if _startup_bound:
+        return
+    _startup_bound = True
+    driver = get_driver()
+
+    @driver.on_startup
+    async def _on_startup() -> None:
+        global _settle_task
+        _settle_task = asyncio.create_task(_settle_loop(), name="semantic_style_experiment_settle")
+
+    @driver.on_shutdown
+    async def _on_shutdown() -> None:
+        global _settle_task
+        if _settle_task is not None:
+            _settle_task.cancel()
+            await asyncio.gather(_settle_task, return_exceptions=True)
+            _settle_task = None

--- a/pallas/product/llm/semantic_style_experiment.py
+++ b/pallas/product/llm/semantic_style_experiment.py
@@ -11,7 +11,9 @@ import hashlib
 import json
 import re
 import time
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
 
 from nonebot import get_driver, logger
 
@@ -36,6 +38,8 @@ _OUTCOME_WINDOW_SEC = 90
 _OUTCOME_MAX_FOLLOWUPS = 3
 _OUTCOME_SETTLE_INTERVAL_SEC = 60
 _OUTCOME_MAX_PER_PASS = 200
+_SETTLED_REQUEST_ID_LIMIT = 8192
+_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
 
 # 高置信负反馈短语：要求回复/提及 Bot 或与目标用户 exposure 时间窗口一致。
 _NEGATIVE_PHRASES = (
@@ -74,10 +78,14 @@ def experiment_state_path() -> Path:
     return experiment_base_dir() / "experiment_state.json"
 
 
+def semantic_style_day_key(now: int | None = None) -> str:
+    current = int(time.time()) if now is None else int(now)
+    return datetime.fromtimestamp(current, tz=_BEIJING_TZ).date().isoformat()
+
+
 def semantic_style_bucket(bot_id: int, group_id: int, now: int | None = None) -> int:
     """群日稳定分桶：同一 bot×群×自然日固定同一桶。"""
-    current = int(time.time()) if now is None else int(now)
-    day = current // 86400
+    day = semantic_style_day_key(now)
     digest = hashlib.blake2b(f"{int(bot_id)}:{int(group_id)}:{day}".encode(), digest_size=8).digest()
     return int.from_bytes(digest, "big") % _BUCKET_COUNT
 
@@ -106,6 +114,36 @@ def semantic_style_circuit_disabled() -> bool:
     """统计熔断状态：熔断后停注入，但采集继续。"""
     state = _load_state()
     return bool(state.get("circuit_disabled"))
+
+
+def semantic_channel_circuit_disabled(channel: str) -> bool:
+    state = _load_state()
+    circuits = state.get("channel_circuits") or {}
+    return bool((circuits.get(str(channel)) or {}).get("disabled"))
+
+
+def trip_semantic_channel_circuit(channel: str, reason: str) -> None:
+    with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
+        state = _load_state()
+        circuits = state.setdefault("channel_circuits", {})
+        circuits[str(channel)] = {
+            "disabled": True,
+            "reason": str(reason or "hard_error")[:120],
+            "tripped_at": int(time.time()),
+        }
+        _save_state(state)
+
+
+def reset_semantic_channel_circuit(channel: str) -> None:
+    with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
+        state = _load_state()
+        circuits = state.get("channel_circuits") or {}
+        circuits.pop(str(channel), None)
+        if circuits:
+            state["channel_circuits"] = circuits
+        else:
+            state.pop("channel_circuits", None)
+        _save_state(state)
 
 
 def record_semantic_exposure(
@@ -145,7 +183,7 @@ def record_semantic_exposure(
             handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
 
 
-def _load_unsettled_exposures() -> list[dict[str, Any]]:
+def _load_exposures() -> list[dict[str, Any]]:
     try:
         lines = exposures_path().read_text(encoding="utf-8").splitlines()
     except OSError:
@@ -156,9 +194,13 @@ def _load_unsettled_exposures() -> list[dict[str, Any]]:
             item = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if isinstance(item, dict) and not item.get("settled"):
+        if isinstance(item, dict):
             rows.append(item)
     return rows
+
+
+def _load_unsettled_exposures() -> list[dict[str, Any]]:
+    return [item for item in _load_exposures() if not item.get("settled")]
 
 
 def _rewrite_exposures(rows: list[dict[str, Any]]) -> None:
@@ -177,7 +219,7 @@ def mark_exposures_settled(request_ids: set[str]) -> None:
     if not request_ids:
         return
     with interprocess_file_lock(exposures_path().with_suffix(".lock")):
-        rows = _load_unsettled_exposures()
+        rows = _load_exposures()
         changed = False
         for item in rows:
             if item.get("request_id") in request_ids:
@@ -189,13 +231,18 @@ def mark_exposures_settled(request_ids: set[str]) -> None:
 
 def record_experiment_outcome(
     *,
+    request_id: str,
     bucket: int,
     target_followup: bool,
     negative: bool,
-) -> None:
+) -> bool:
     """累计一次已结算 exposure 的实验/对照计数。"""
     with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
         state = _load_state()
+        settled_ids = [str(item) for item in state.get("settled_request_ids") or []]
+        stable_request_id = str(request_id or "").strip()
+        if not stable_request_id or stable_request_id in settled_ids:
+            return False
         group = "control" if bucket == _CONTROL_BUCKET else "experiment"
         counts = state.setdefault(group, {})
         counts["settled"] = int(counts.get("settled") or 0) + 1
@@ -203,7 +250,9 @@ def record_experiment_outcome(
             counts["target_followup"] = int(counts.get("target_followup") or 0) + 1
         if negative:
             counts["negative"] = int(counts.get("negative") or 0) + 1
+        state["settled_request_ids"] = [*settled_ids, stable_request_id][-_SETTLED_REQUEST_ID_LIMIT:]
         _save_state(state)
+        return True
 
 
 def maybe_trip_circuit() -> bool:
@@ -235,7 +284,7 @@ def maybe_trip_circuit() -> bool:
 
 
 def reset_experiment_circuit() -> None:
-    """人工恢复：清除熔断状态，保留累计计数。"""
+    """人工恢复：清除熔断状态并开启新的统计窗口。"""
     with interprocess_file_lock(experiment_state_path().with_suffix(".lock")):
         state = _load_state()
         state.pop("circuit_disabled", None)
@@ -243,6 +292,9 @@ def reset_experiment_circuit() -> None:
         state.pop("circuit_tripped_at", None)
         state.pop("experiment_negative_rate", None)
         state.pop("control_negative_rate", None)
+        state.pop("experiment", None)
+        state.pop("control", None)
+        state.pop("settled_request_ids", None)
         _save_state(state)
 
 
@@ -254,6 +306,7 @@ def experiment_status() -> dict[str, Any]:
         "circuit_tripped_at": state.get("circuit_tripped_at"),
         "experiment": state.get("experiment") or {},
         "control": state.get("control") or {},
+        "channel_circuits": state.get("channel_circuits") or {},
     }
 
 
@@ -279,6 +332,7 @@ async def settle_pending_semantic_exposures(*, now: int | None = None) -> int:
         return 0
     repo = make_message_repository()
     settled = 0
+    settled_ids: set[str] = set()
     for item in rows[:_OUTCOME_MAX_PER_PASS]:
         delivered_at = int(item.get("delivered_at") or 0)
         if delivered_at <= 0 or current - delivered_at < _OUTCOME_WINDOW_SEC:
@@ -293,28 +347,49 @@ async def settle_pending_semantic_exposures(*, now: int | None = None) -> int:
                 group_id,
                 after_time=delivered_at,
                 after_message_id=int(item.get("bot_message_id") or 0) or None,
-                limit=_OUTCOME_MAX_FOLLOWUPS,
+                limit=24,
             )
         except Exception as exc:
             log_rate_limited(logger, "warning", "semantic_experiment.query", "语义 exposure 结算查询失败：{}", exc)
             continue
         target_followup = False
         negative = False
+        seen_messages: set[object] = set()
+        human_followups = 0
+        from pallas.product.llm.sender_identity import is_peer_bot
+
         for message in followups:
             user_id = int(getattr(message, "user_id", 0) or 0)
+            if user_id <= 0 or user_id == bot_id or is_peer_bot(user_id):
+                continue
             text = str(getattr(message, "plain_text", "") or getattr(message, "raw_message", "") or "")
+            message_id = int(getattr(message, "message_id", 0) or 0)
+            message_key: object = message_id or (
+                int(getattr(message, "time", 0) or 0),
+                user_id,
+                text,
+            )
+            if message_key in seen_messages:
+                continue
+            seen_messages.add(message_key)
+            human_followups += 1
             if user_id == target_user:
                 target_followup = True
-            if _looks_negative(text):
-                negative = True
+                if _looks_negative(text):
+                    negative = True
+            if human_followups >= _OUTCOME_MAX_FOLLOWUPS:
+                break
+        request_id = str(item.get("request_id") or "")
         record_experiment_outcome(
+            request_id=request_id,
             bucket=int(item.get("bucket") or 1),
             target_followup=target_followup,
             negative=negative,
         )
+        settled_ids.add(request_id)
         settled += 1
-    if settled:
-        mark_exposures_settled({str(item.get("request_id")) for item in rows[:settled]})
+    if settled_ids:
+        mark_exposures_settled(settled_ids)
     maybe_trip_circuit()
     return settled
 

--- a/tests/plugins/llm_chat/test_chat_message_task_meta.py
+++ b/tests/plugins/llm_chat/test_chat_message_task_meta.py
@@ -1022,6 +1022,7 @@ async def test_handle_llm_chat_records_route_and_fallback_meta(
     )
     reply_context_lookup = Mock(return_value="复读的原话")
     monkeypatch.setattr(mod, "lookup_bot_reply_context", reply_context_lookup, raising=False)
+    monkeypatch.setattr(mod, "recent_group_bot_speaker", lambda **_kwargs: 10001, raising=False)
     monkeypatch.setattr(
         mod,
         "classify_behavior_scene",
@@ -1121,6 +1122,10 @@ async def test_handle_llm_chat_records_route_and_fallback_meta(
     reply_context_lookup.assert_called_once_with(group_id=20002, bot_id=10001, message_id=70001)
     assert payload["reply_total_length_band"] == "complete"
     submit_request = submit_mock.await_args.args[0]
+    assert submit_request.llm_rewrite_metadata["user_text"] == "你还在吗"
+    assert submit_request.llm_rewrite_metadata["recent_group_bot_speaker"] == 10001
+    assert submit_request.llm_rewrite_metadata["protocol_explicit_target"] is True
+    assert submit_request.llm_rewrite_metadata["protocol_nickname_target"] is False
     assert submit_request.group_timeline_images == [
         {"speaker": "兔兔", "text": "还是笨蛋欸", "url": "https://example.com/a.png"},
     ]

--- a/tests/product/llm/test_chat_prompt_assembler.py
+++ b/tests/product/llm/test_chat_prompt_assembler.py
@@ -3,7 +3,6 @@ from pallas.product.llm.assembler.chat_prompt import (
     ResolvedGroupExpression,
 )
 from pallas.product.llm.assembler.context import ChatContextBundle
-from pallas.product.llm.repeater_semantic_style import BehaviorStrategy
 from pallas.product.llm.reply_shape import ReplyShapePolicy
 from pallas.product.llm.turn_policy import TurnPolicy
 
@@ -65,7 +64,9 @@ def test_chat_prompt_assembler_uses_fixed_order_without_aliases_or_duplicates() 
     assert "回顶" not in prompt
 
 
-def test_chat_prompt_assembler_renders_behavior_strategy_reference_and_baseline() -> None:
+def test_chat_prompt_assembler_renders_controlled_patterns_and_continuation() -> None:
+    from pallas.product.llm.repeater_semantic_style import ContinuationPattern, ControlledBehaviorPattern
+
     prompt = ChatPromptAssembler().assemble(
         core_persona="【核心人格】\n有主见的小姑娘。",
         self_identity="【自称】\n牛牛指自己，使用第一人称。",
@@ -81,23 +82,26 @@ def test_chat_prompt_assembler_renders_behavior_strategy_reference_and_baseline(
         context=ChatContextBundle(),
         group_expression=ResolvedGroupExpression(
             matched_examples=[("你又来了", "我一直都在呀")],
-            baseline_note="本群真人单条短气泡为主（占比约 83%），单段中位约 6 字。",
-            behavior_strategies=[
-                BehaviorStrategy(
-                    scene="对方吐槽工作压力",
-                    action="先短句接住情绪，再问一句具体的事",
-                    outcome="对方愿意多讲",
-                ),
-                BehaviorStrategy(
-                    scene="群里问吃什么",
-                    action="直接给具体建议",
-                ),
-                BehaviorStrategy(
-                    scene="对方拿我开玩笑",
-                    action="笑着怼回去再反问一句",
-                    outcome="气氛不错",
-                    learning_type="self_reflection",
-                ),
+            behavior_patterns=[
+                ControlledBehaviorPattern(
+                    interaction_action="agree",
+                    semantic_relation="agree",
+                    form="short",
+                    intensity="soft",
+                    count=3,
+                    responder_ids=[11, 12],
+                    representative_triggers=["好烦，又加班了"],
+                )
+            ],
+            continuation_patterns=[
+                ContinuationPattern(
+                    semantic_relation="follow_up",
+                    form="question",
+                    intensity="neutral",
+                    count=3,
+                    speaker_ids=[11, 13],
+                    representative_triggers=["今天好热"],
+                )
             ],
         ),
         reply_shape=ReplyShapePolicy(
@@ -111,15 +115,16 @@ def test_chat_prompt_assembler_renders_behavior_strategy_reference_and_baseline(
         ),
     )
 
-    assert "【真人接话参考】" in prompt
-    assert "只借鉴什么时候说短/长、怎么接，不要复刻原话" in prompt
-    assert "类似「对方吐槽工作压力」时，真人会先短句接住情绪，再问一句具体的事，结果对方愿意多讲。" in prompt
-    assert "类似「群里问吃什么」时，真人会直接给具体建议。" in prompt
-    assert "【接话复盘】" in prompt
-    assert "类似「对方拿我开玩笑」时，我之前是这样接的：笑着怼回去再反问一句，结果气氛不错。" in prompt
-    assert "本群真人单条短气泡为主" in prompt
-    # 段序按变化频率排布：群表达指导（低频缓存）在前，逐轮变化的输出契约靠后。
-    assert prompt.index("【群表达指导】") < prompt.index("【真人接话参考】") < prompt.index("【回复形状与输出契约】")
+    assert "【真人接话模式】" in prompt
+    assert "类似「好烦，又加班了」时，本群真人常用认同的方式表示赞同，表述偏短句。" in prompt
+    assert "【本群续句习惯】" in prompt
+    assert "不要把这种续句误当成两个人对话" in prompt
+    # 节奏基线不再由语义指导器注入，生成节奏统一交回 reply_shape
+    assert "本群真人单条短气泡为主" not in prompt
+    assert "【真人接话参考】" not in prompt
+    assert "【接话复盘】" not in prompt
+    # 段序按变化频率排布：群表达指导在前，逐轮变化的输出契约靠后。
+    assert prompt.index("【群表达指导】") < prompt.index("【真人接话模式】") < prompt.index("【回复形状与输出契约】")
 
 
 def test_chat_prompt_assembler_renders_cached_semantic_style_block() -> None:

--- a/tests/product/llm/test_group_insight_processor.py
+++ b/tests/product/llm/test_group_insight_processor.py
@@ -662,8 +662,13 @@ async def test_produce_semantic_profile_partial_failure_persists_and_advances(mo
     async def fake_known_bots(group_id):
         return set()
 
+    class _EmptyRepo:
+        async def find_recent_in_group(self, *args, **kwargs):
+            return []
+
     monkeypatch.setattr(mod, "_known_bots_in_group", fake_known_bots)
     monkeypatch.setattr(mod, "_rebuild_pairs_from_messages", fake_rebuild)
+    monkeypatch.setattr(mod, "make_message_repository", lambda: _EmptyRepo())
     monkeypatch.setattr(sem, "semantic_style_collection_enabled", lambda *, bot_id, group_id: True)
     monkeypatch.setattr(sem, "semantic_label_budget_ok", lambda: True)
     monkeypatch.setattr(sem, "get_semantic_style_group_cursor", lambda *, bot_id, group_id: (0, 0))
@@ -704,8 +709,13 @@ async def test_produce_semantic_profile_all_failed_keeps_cursor(monkeypatch) -> 
     async def fake_known_bots(group_id):
         return set()
 
+    class _EmptyRepo:
+        async def find_recent_in_group(self, *args, **kwargs):
+            return []
+
     monkeypatch.setattr(mod, "_known_bots_in_group", fake_known_bots)
     monkeypatch.setattr(mod, "_rebuild_pairs_from_messages", fake_rebuild)
+    monkeypatch.setattr(mod, "make_message_repository", lambda: _EmptyRepo())
     monkeypatch.setattr(sem, "semantic_style_collection_enabled", lambda *, bot_id, group_id: True)
     monkeypatch.setattr(sem, "semantic_label_budget_ok", lambda: True)
     monkeypatch.setattr(sem, "get_semantic_style_group_cursor", lambda *, bot_id, group_id: (0, 0))

--- a/tests/product/llm/test_kernel_llm.py
+++ b/tests/product/llm/test_kernel_llm.py
@@ -788,6 +788,58 @@ async def test_kernel_delivers_approved_semantic_style_direct_candidate_without_
 
 
 @pytest.mark.asyncio
+async def test_kernel_delivers_qualified_protocol_candidate_without_provider(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pallas.product.llm import kernel_runner
+    from pallas.product.llm import semantic_protocol as proto
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    proto.clear_protocol_data_for_tests()
+    trigger = "请在 60 秒内发送「接受老婆赠送」，或发送「拒绝老婆赠送」"
+    for mid, responder in ((1, 11), (2, 12), (3, 13)):
+        proto.record_protocol_observation(
+            bot_id=99,
+            group_id=42,
+            trigger_text=trigger,
+            reply_text="接受老婆赠送",
+            responder_id=responder,
+            source_message_id=mid,
+            created_at=mid * 100,
+        )
+
+    delivered: list[tuple[str, str, str]] = []
+
+    async def provider_must_not_run(**_kwargs):
+        raise AssertionError("protocol candidate must bypass provider")
+
+    async def fake_deliver(task_id, *, status, text=None, **_kwargs):
+        delivered.append((task_id, status, text or ""))
+        return {"message": "ok"}
+
+    monkeypatch.setattr(kernel_runner, "complete_with_tool_loop", provider_must_not_run)
+    monkeypatch.setattr(kernel_runner, "deliver_llm_chat_result", fake_deliver)
+    monkeypatch.setattr("pallas.product.llm.runtime_debug.append_runtime_trace", lambda **_kwargs: None)
+
+    await kernel_runner.run_kernel_chat_job(
+        "protocol-candidate-task",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": trigger}],
+        metadata={
+            "bot_id": 99,
+            "group_id": 42,
+            "user_text": trigger,
+            "recent_group_bot_speaker": 99,
+        },
+        cfg=LlmConfig(llm_persona_output_firewall={"enabled": False}),
+    )
+
+    assert delivered == [("protocol-candidate-task", "success", "接受老婆赠送")]
+    proto.clear_protocol_data_for_tests()
+
+
+@pytest.mark.asyncio
 async def test_kernel_does_not_deliver_unsafe_cached_semantic_direct_candidate(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/product/llm/test_kernel_llm.py
+++ b/tests/product/llm/test_kernel_llm.py
@@ -779,12 +779,12 @@ async def test_kernel_delivers_approved_semantic_style_direct_candidate_without_
         metadata={
             "bot_id": 99,
             "group_id": 42,
-            "semantic_style_direct_candidate": "没救了",
+            "semantic_style_direct_candidate": "确实",
         },
         cfg=LlmConfig(llm_persona_output_firewall={"enabled": False}),
     )
 
-    assert delivered == [("direct-candidate-task", "success", "没救了")]
+    assert delivered == [("direct-candidate-task", "success", "确实")]
 
 
 @pytest.mark.asyncio
@@ -831,6 +831,7 @@ async def test_kernel_delivers_qualified_protocol_candidate_without_provider(
             "group_id": 42,
             "user_text": trigger,
             "recent_group_bot_speaker": 99,
+            "protocol_nickname_target": True,
         },
         cfg=LlmConfig(llm_persona_output_firewall={"enabled": False}),
     )

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -2168,3 +2168,123 @@ def test_merge_bot_reply_only_teaches_behavior_strategy(tmp_path, monkeypatch) -
     assert profile.direct_examples == []
     assert len(profile.behavior_strategies) == 1
     assert profile.behavior_strategies[0].learning_type == "self_reflection"
+
+
+def test_new_semantic_example_defaults_pair_kind_conversation() -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    example = mod.SemanticStyleExample(
+        example_id="42:8:100",
+        created_at=100,
+        bot_id=100,
+        group_id=42,
+        scene="group_chat",
+        trigger_text="前句",
+        reply_text="接话",
+        label=mod.parse_semantic_style_label({}),
+        trigger_user_id=11,
+        reply_user_id=12,
+    )
+
+    assert example.pair_kind == "conversation"
+
+
+def test_legacy_same_user_example_loads_as_continuation(tmp_path, monkeypatch) -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    path = mod.semantic_style_examples_path()
+    path.write_text(
+        '{"example_id":"42:9:100","created_at":100,"bot_id":100,"group_id":42,'
+        '"scene":"group_chat","trigger_text":"前句","reply_text":"补充一句",'
+        '"source_kind":"human_pair","trigger_user_id":11,"reply_user_id":11,'
+        '"label":{"version":2,"is_reply_pair":true,"transferable":true}}\n',
+        encoding="utf-8",
+    )
+
+    examples = mod._load_semantic_style_examples(path)
+
+    assert examples[0].pair_kind == "continuation"
+
+
+def test_v3_profile_accumulates_controlled_patterns_with_threshold_fields() -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    label = mod.parse_semantic_style_label({
+        "interaction_actions": ["agree"],
+        "semantic_relations": ["echo"],
+        "forms": ["short"],
+        "intensity": "soft",
+    })
+
+    def example(example_id: str, *, reply_user: int, trigger: str, reply: str) -> mod.SemanticStyleExample:
+        return mod.SemanticStyleExample(
+            example_id=example_id,
+            created_at=100,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text=trigger,
+            reply_text=reply,
+            label=label,
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=reply_user,
+        )
+
+    profile = mod._build_profile(example("e1", reply_user=12, trigger="太热了", reply="确实"), None)
+    profile = mod._build_profile(example("e2", reply_user=13, trigger="又堵车", reply="确实是"), profile)
+    profile = mod._build_profile(example("e3", reply_user=12, trigger="下雨了", reply="确实"), profile)
+
+    assert len(profile.behavior_patterns) == 1
+    pattern = profile.behavior_patterns[0]
+    assert pattern.count == 3
+    assert sorted(pattern.responder_ids) == [12, 13]
+    assert len(pattern.representative_triggers) <= 3
+
+    # 同人续句：进入 continuation_patterns，不进入 behavior_patterns
+    continuation = mod.SemanticStyleExample(
+        example_id="e4",
+        created_at=101,
+        bot_id=100,
+        group_id=42,
+        scene="group_chat",
+        trigger_text="太热了",
+        reply_text="真的热",
+        label=label,
+        source_kind="human_pair",
+        trigger_user_id=12,
+        reply_user_id=12,
+        pair_kind="continuation",
+    )
+    profile = mod._build_profile(continuation, profile)
+
+    assert len(profile.continuation_patterns) == 1
+    assert profile.continuation_patterns[0].count == 1
+    assert profile.behavior_patterns[0].count == 3
+
+
+def test_profiles_payload_writes_schema_version(tmp_path, monkeypatch) -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    mod.persist_semantic_style_example(
+        mod.SemanticStyleExample(
+            example_id="42:10:100",
+            created_at=100,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="前句",
+            reply_text="接话",
+            label=mod.parse_semantic_style_label({}),
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=12,
+        )
+    )
+
+    payload = json.loads(mod.semantic_style_profiles_path().read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 3
+    assert isinstance(payload["profiles"], list)

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -1928,7 +1928,7 @@ def test_semantic_style_settings_dump_keeps_split_bits_without_stale_enabled(tmp
     monkeypatch.setattr(mod, "semantic_style_settings_path", lambda **_: path)
     mod.set_semantic_style_governance(collection_enabled=False, injection_enabled=True, bot_id=100, group_id=42)
     dumped = json.loads(path.read_text(encoding="utf-8"))
-    assert set(dumped) == {"collection_enabled", "injection_enabled", "direct_enabled"}
+    assert set(dumped) == {"collection_enabled", "injection_enabled", "direct_enabled", "active_pipeline"}
     assert dumped["collection_enabled"] is False
     assert dumped["injection_enabled"] is True
 
@@ -1937,6 +1937,105 @@ def test_semantic_style_backfill_is_enabled_by_default():
     from pallas.product.llm import repeater_semantic_style as mod
 
     assert mod.SEMANTIC_STYLE_BACKFILL_ENABLED is True
+
+
+def test_first_v3_write_backs_up_legacy_profiles(tmp_path, monkeypatch) -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    path = mod.semantic_style_profiles_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # 模拟旧版 v2 profiles 文件（无 schema_version）
+    path.write_text(
+        json.dumps({
+            "profiles": [
+                {
+                    "bot_id": 100,
+                    "group_id": 42,
+                    "scene": "group_chat",
+                    "sample_count": 1,
+                    "human_only": True,
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+    mod.clear_semantic_style_cache_for_tests()
+
+    mod.persist_semantic_style_example(
+        mod.SemanticStyleExample(
+            example_id="42:11:100",
+            created_at=100,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="前句",
+            reply_text="接话",
+            label=mod.parse_semantic_style_label({}),
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=12,
+        )
+    )
+
+    backups = sorted(mod.semantic_style_profiles_backup_dir().glob("profiles-v*.json"))
+    assert len(backups) == 1
+    raw = json.loads(backups[0].read_text(encoding="utf-8"))
+    assert "schema_version" not in raw
+    payload = json.loads(mod.semantic_style_profiles_path().read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 3
+
+
+def test_rollback_v2_switches_read_pipeline_without_touching_v3_write(tmp_path, monkeypatch) -> None:
+    from pallas.product.llm import repeater_semantic_style as mod
+
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    path = mod.semantic_style_profiles_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "profiles": [
+                {
+                    "bot_id": 100,
+                    "group_id": 42,
+                    "scene": "group_chat",
+                    "sample_count": 1,
+                    "human_only": True,
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+    mod.clear_semantic_style_cache_for_tests()
+
+    # 触发 v3 写入并产生 v2 备份
+    mod.persist_semantic_style_example(
+        mod.SemanticStyleExample(
+            example_id="42:12:100",
+            created_at=100,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="前句",
+            reply_text="接话",
+            label=mod.parse_semantic_style_label({}),
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=12,
+        )
+    )
+    assert mod.semantic_style_status()["active_pipeline"] == "v3"
+
+    mod.set_semantic_style_active_pipeline("v2")
+
+    status = mod.semantic_style_status()
+    assert status["active_pipeline"] == "v2"
+    assert status["schema_version"] < 3
+    # v3 主文件仍在，采集照常写入
+    assert json.loads(mod.semantic_style_profiles_path().read_text(encoding="utf-8"))["schema_version"] == 3
+
+    mod.set_semantic_style_active_pipeline("v3")
+    assert mod.semantic_style_status()["active_pipeline"] == "v3"
 
 
 def test_legacy_unknown_accumulates_rhythm_statistics(tmp_path, monkeypatch) -> None:

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -44,6 +44,40 @@ def test_prompt_safe_expression_sample_keeps_short_chinese_reply() -> None:
     assert prompt_safe_expression_sample("roleplay 一下也行") == "roleplay 一下也行"
 
 
+def test_semantic_style_candidate_rejected_filters_system_and_dirty_text() -> None:
+    from pallas.product.llm.repeater_semantic_style import semantic_style_candidate_rejected
+
+    # 机器人菜单/欢迎话术
+    assert semantic_style_candidate_rejected(
+        trigger_text="欢迎3位新成员加入本群，期待在群里看到你们的活跃。 签到 | 随机老婆 | 关闭 | 设置",
+        reply_text="很死的",
+    )
+    assert semantic_style_candidate_rejected(
+        trigger_text="功能开关",
+        reply_text="请让管理员或群主点击开启功能 @萌卡喵发送「功能开关」来到此选项",
+    )
+    # 纯媒体 trigger（无任何文字）
+    assert semantic_style_candidate_rejected(trigger_text="[图片]", reply_text="完了")
+    # 内部 token 元数据
+    assert semantic_style_candidate_rejected(
+        trigger_text="你好啊",
+        reply_text="你好呀！(completion_tokens:32 prompt_tokens:26388",
+    )
+    # URL / CQ 原码 / 长数字
+    assert semantic_style_candidate_rejected(trigger_text="看这个", reply_text="https://example.com/a")
+    assert semantic_style_candidate_rejected(trigger_text="[CQ:image,url=x] 图", reply_text="好看")
+    assert semantic_style_candidate_rejected(trigger_text="群号", reply_text="12345678901")
+    # 超长 reply
+    assert semantic_style_candidate_rejected(trigger_text="前句", reply_text="接" * 200)
+    # 空文本
+    assert semantic_style_candidate_rejected(trigger_text="", reply_text="接话")
+    # 正常真人对话放行
+    assert not semantic_style_candidate_rejected(trigger_text="今天好热", reply_text="确实")
+    assert not semantic_style_candidate_rejected(trigger_text="你吃饭了吗", reply_text="还没呢")
+    # 正常 [表情] 文字化接话放行（表情不算纯媒体空壳）
+    assert not semantic_style_candidate_rejected(trigger_text="来啦", reply_text="[表情]")
+
+
 def test_list_semantic_style_examples_filters_scope_and_limits_results(monkeypatch: pytest.MonkeyPatch) -> None:
     from pallas.product.llm import repeater_semantic_style as mod
 

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -771,9 +771,62 @@ def test_cached_semantic_style_resolution_reads_prompt_block_and_direct_candidat
 
     assert resolution.style_anchor == "短句轻怼。"
     assert resolution.source_example_id == "source:legacy"
-    assert resolution.direct_candidate == "没救了"
+    # 普通直投不再复刻真人原句：无受控行为模式证据时返回空
+    assert resolution.direct_candidate == ""
     assert "本群表达校准" in resolution.prompt_block
     assert [item.source_example_id for item in resolution.matched_example_sources] == ["source:legacy"]
+
+
+def test_safe_direct_candidate_requires_qualified_pattern_and_returns_fixed_text() -> None:
+    from pallas.product.llm.repeater_semantic_style import (
+        ControlledBehaviorPattern,
+        select_safe_direct_candidate,
+    )
+
+    def pattern(action: str, *, count: int, responders: list[int], triggers: list[str]) -> ControlledBehaviorPattern:
+        return ControlledBehaviorPattern(
+            interaction_action=action,
+            semantic_relation="agree",
+            form="short",
+            intensity="soft",
+            count=count,
+            responder_ids=responders,
+            representative_triggers=triggers,
+        )
+
+    # 未达 2 次/2 人：不直投
+    assert (
+        select_safe_direct_candidate(
+            [pattern("agree", count=1, responders=[11], triggers=["好烦"])],
+            query_text="好烦啊",
+        )
+        == ""
+    )
+    # 达到门槛且命中代表 trigger：返回固定安全短句
+    assert (
+        select_safe_direct_candidate(
+            [pattern("agree", count=2, responders=[11, 12], triggers=["好烦啊，天天加班"])],
+            query_text="好烦啊，天天加班",
+        )
+        == "确实"
+    )
+    # 非安全 action：不直投
+    assert (
+        select_safe_direct_candidate(
+            [pattern("mock", count=5, responders=[11, 12, 13], triggers=["好烦啊，天天加班"])],
+            query_text="好烦啊，天天加班",
+        )
+        == ""
+    )
+    # 命中但最近已回复过相同文本：去重跳过
+    assert (
+        select_safe_direct_candidate(
+            [pattern("agree", count=2, responders=[11, 12], triggers=["好烦啊，天天加班"])],
+            query_text="好烦啊，天天加班",
+            recent_assistant_replies=["确实"],
+        )
+        == ""
+    )
 
 
 def test_cached_semantic_style_resolution_falls_back_to_group_style_owner(tmp_path, monkeypatch) -> None:
@@ -820,7 +873,7 @@ def test_cached_semantic_style_resolution_falls_back_to_group_style_owner(tmp_pa
         query_text="怎么又炸了",
     )
 
-    assert resolution.direct_candidate == "没救了"
+    assert resolution.direct_candidate == ""
     assert resolution.source_example_id == "semantic-owner"
 
 

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -1698,7 +1698,7 @@ def test_behavior_strategy_retrieval_ranks_by_trigger_similarity() -> None:
     assert select_behavior_strategies(strategies, query_text="今天吃什么")[0].action == "直接给具体建议"
 
 
-def test_cached_semantic_style_resolution_injects_strategy_and_baseline(tmp_path, monkeypatch) -> None:
+def test_cached_semantic_style_resolution_injects_controlled_patterns(tmp_path, monkeypatch) -> None:
     from pallas.product.llm import repeater_semantic_style as mod
 
     monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
@@ -1713,12 +1713,15 @@ def test_cached_semantic_style_resolution_injects_strategy_and_baseline(tmp_path
             segment_char_lengths=[5, 6, 7] * 10,
             rhythm_counts={"single": 25, "multi": 5},
             human_only=True,
-            behavior_strategies=[
-                mod.BehaviorStrategy(
-                    scene="对方吐槽工作压力",
-                    action="先短句接住情绪，再问一句具体的事",
-                    outcome="对方愿意多讲",
-                    trigger="好烦，又要加班",
+            behavior_patterns=[
+                mod.ControlledBehaviorPattern(
+                    interaction_action="agree",
+                    semantic_relation="agree",
+                    form="short",
+                    intensity="soft",
+                    count=3,
+                    responder_ids=[11, 12],
+                    representative_triggers=["好烦，又要加班"],
                 )
             ],
         )
@@ -1734,9 +1737,9 @@ def test_cached_semantic_style_resolution_injects_strategy_and_baseline(tmp_path
         query_text="好烦啊，天天加班",
     )
 
-    assert resolution.baseline_note.startswith("本群真人单条短气泡为主")
-    assert len(resolution.behavior_strategies) == 1
-    assert resolution.behavior_strategies[0].action == "先短句接住情绪，再问一句具体的事"
+    assert resolution.baseline_note == ""
+    assert len(resolution.behavior_patterns) == 1
+    assert resolution.behavior_patterns[0].interaction_action == "agree"
 
 
 def test_matched_examples_rank_by_similarity_and_strategy_is_fallback(tmp_path, monkeypatch) -> None:

--- a/tests/product/llm/test_repeater_semantic_style.py
+++ b/tests/product/llm/test_repeater_semantic_style.py
@@ -791,7 +791,10 @@ def test_safe_direct_candidate_requires_qualified_pattern_and_returns_fixed_text
             intensity="soft",
             count=count,
             responder_ids=responders,
+            quoted_count=count,
+            quoted_responder_ids=responders,
             representative_triggers=triggers,
+            quoted_triggers=triggers,
         )
 
     # 未达 2 次/2 人：不直投
@@ -827,6 +830,97 @@ def test_safe_direct_candidate_requires_qualified_pattern_and_returns_fixed_text
         )
         == ""
     )
+
+
+def test_safe_direct_candidate_requires_quoted_evidence() -> None:
+    from pallas.product.llm.repeater_semantic_style import (
+        ControlledBehaviorPattern,
+        select_safe_direct_candidate,
+    )
+
+    pattern = ControlledBehaviorPattern(
+        interaction_action="agree",
+        semantic_relation="agree",
+        form="short",
+        intensity="soft",
+        count=3,
+        responder_ids=[11, 12],
+        quoted_count=0,
+        quoted_responder_ids=[],
+        representative_triggers=["好烦，又加班"],
+    )
+    assert select_safe_direct_candidate([pattern], query_text="好烦，又加班") == ""
+
+
+def test_v3_rebuild_excludes_continuation_and_rejected_text_from_direct_pairs() -> None:
+    from pallas.product.llm.repeater_semantic_style import (
+        SemanticStyleLabel,
+        _rebuild_profiles,
+    )
+
+    clean_label = SemanticStyleLabel(
+        is_reply_pair=True,
+        transferable=True,
+        interaction_actions=["agree"],
+        semantic_relations=["follow_up"],
+        forms=["short"],
+    )
+    examples = [
+        SemanticStyleExample(
+            example_id="continuation",
+            created_at=1,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="我先看看",
+            reply_text="等会再说",
+            label=clean_label,
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=11,
+            pair_kind="continuation",
+        ),
+        SemanticStyleExample(
+            example_id="dirty",
+            created_at=2,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="[图片]",
+            reply_text="看笑了",
+            label=clean_label,
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=12,
+            pair_kind="conversation",
+        ),
+        SemanticStyleExample(
+            example_id="clean",
+            created_at=3,
+            bot_id=100,
+            group_id=42,
+            scene="group_chat",
+            trigger_text="怎么又下雨了",
+            reply_text="又来了",
+            label=clean_label,
+            source_kind="human_pair",
+            trigger_user_id=11,
+            reply_user_id=12,
+            pair_relation="quoted",
+            pair_kind="conversation",
+        ),
+    ]
+
+    profile = _rebuild_profiles(examples, now=3)[(100, 42, "group_chat")]
+    assert [pair.source_example_id for pair in profile.direct_pairs] == ["clean"]
+    assert profile.continuation_patterns[0].source_example_ids == ["continuation"]
+
+
+def test_similarity_rejects_single_bigram_overlap_and_keeps_real_match() -> None:
+    from pallas.product.llm.repeater_semantic_style import semantic_style_text_similarity
+
+    assert semantic_style_text_similarity("这是什么", "其实这是我的本性") == 0
+    assert semantic_style_text_similarity("好烦，又要加班", "好烦，又要加班") == 1
 
 
 def test_cached_semantic_style_resolution_falls_back_to_group_style_owner(tmp_path, monkeypatch) -> None:
@@ -871,6 +965,7 @@ def test_cached_semantic_style_resolution_falls_back_to_group_style_owner(tmp_pa
         "group_chat",
         request_id=request_id,
         query_text="怎么又炸了",
+        bypass_injection_gate=True,
     )
 
     assert resolution.direct_candidate == ""
@@ -1902,13 +1997,17 @@ def test_semantic_style_governance_sets_bits_independently(tmp_path, monkeypatch
     assert mod.semantic_style_injection_enabled("request", bot_id=100, group_id=42) is False
 
 
-def test_semantic_style_injection_keeps_ten_percent_control_group(tmp_path, monkeypatch) -> None:
+def test_semantic_style_injection_uses_only_stable_group_day_control(tmp_path, monkeypatch) -> None:
     from pallas.product.llm import repeater_semantic_style as mod
+    from pallas.product.llm import semantic_style_experiment as experiment
 
     monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
     mod.set_semantic_style_governance(collection_enabled=True, injection_enabled=True, bot_id=100, group_id=42)
+    monkeypatch.setattr(experiment, "semantic_style_in_control", lambda *_args, **_kwargs: False)
     assert mod.semantic_style_injection_enabled("request", bot_id=100, group_id=42) is True
-    assert mod.semantic_style_injection_enabled("ctl-27", bot_id=100, group_id=42) is False
+    assert mod.semantic_style_injection_enabled("ctl-27", bot_id=100, group_id=42) is True
+    monkeypatch.setattr(experiment, "semantic_style_in_control", lambda *_args, **_kwargs: True)
+    assert mod.semantic_style_injection_enabled("request", bot_id=100, group_id=42) is False
 
 
 def test_set_semantic_style_enabled_disable_turns_off_both_bits(tmp_path, monkeypatch) -> None:

--- a/tests/product/llm/test_semantic_protocol.py
+++ b/tests/product/llm/test_semantic_protocol.py
@@ -26,6 +26,8 @@ def test_protocol_command_safe_rejects_risk_and_length() -> None:
     assert not proto.protocol_command_safe("管理员踢人")
     assert not proto.protocol_command_safe("x")
     assert not proto.protocol_command_safe("命令" * 20)
+    assert not proto.protocol_command_safe("[CQ:at,qq=1]")
+    assert not proto.protocol_command_safe("接受 老婆")
 
 
 def test_record_observation_requires_explicit_command_and_aggregates(tmp_path, monkeypatch) -> None:
@@ -105,6 +107,7 @@ def test_resolve_protocol_candidate_gates_on_threshold_cooldown_and_recent_bot(t
             group_id=42,
             trigger_text=trigger,
             recent_bot_id=100,
+            nickname_targeted=True,
             now=1000,
         )
         == "接受老婆赠送"
@@ -116,6 +119,7 @@ def test_resolve_protocol_candidate_gates_on_threshold_cooldown_and_recent_bot(t
             group_id=42,
             trigger_text=trigger,
             recent_bot_id=200,
+            nickname_targeted=True,
             now=1000,
         )
         == ""
@@ -128,6 +132,7 @@ def test_resolve_protocol_candidate_gates_on_threshold_cooldown_and_recent_bot(t
             group_id=42,
             trigger_text=trigger,
             recent_bot_id=100,
+            nickname_targeted=True,
             now=1000 + 60,
         )
         == ""
@@ -139,6 +144,7 @@ def test_resolve_protocol_candidate_gates_on_threshold_cooldown_and_recent_bot(t
             group_id=42,
             trigger_text=trigger,
             recent_bot_id=100,
+            nickname_targeted=True,
             now=1000 + proto._PROTOCOL_COOLDOWN_SEC + 1,
         )
         == "接受老婆赠送"
@@ -162,6 +168,7 @@ def test_resolve_protocol_candidate_ignores_below_threshold(tmp_path, monkeypatc
             group_id=42,
             trigger_text=trigger,
             recent_bot_id=100,
+            nickname_targeted=True,
             now=200,
         )
         == ""
@@ -174,3 +181,40 @@ def test_protocol_status_counts_eligible_patterns(tmp_path, monkeypatch) -> None
         "pattern_count": 0,
         "eligible_pattern_count": 0,
     }
+
+
+def test_protocol_requires_explicit_or_recent_nickname_target() -> None:
+    trigger = "回复「签到」即可"
+    for mid, responder in ((1, 11), (2, 12), (3, 13)):
+        proto.record_protocol_observation(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            reply_text="签到",
+            responder_id=responder,
+            source_message_id=mid,
+            created_at=mid,
+        )
+
+    assert not proto.resolve_protocol_candidate(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        recent_bot_id=None,
+    )
+    assert not proto.resolve_protocol_candidate(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        recent_bot_id=None,
+        nickname_targeted=True,
+    )
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            explicitly_targeted=True,
+        )
+        == "签到"
+    )

--- a/tests/product/llm/test_semantic_protocol.py
+++ b/tests/product/llm/test_semantic_protocol.py
@@ -1,0 +1,176 @@
+import pytest
+
+from pallas.product.llm import semantic_protocol as proto
+
+
+@pytest.fixture(autouse=True)
+def _clean_protocol_data(tmp_path, monkeypatch):
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    proto.clear_protocol_data_for_tests()
+    yield
+    proto.clear_protocol_data_for_tests()
+
+
+def test_extract_protocol_commands_parses_explicit_candidates() -> None:
+    assert proto.extract_protocol_commands(
+        "请在 60 秒内发送「接受老婆赠送」，或发送「拒绝老婆赠送」，超时自动取消。"
+    ) == ["接受老婆赠送", "拒绝老婆赠送"]
+    assert proto.extract_protocol_commands("回复'签到'即可") == ["签到"]
+    assert proto.extract_protocol_commands("没有命令") == []
+
+
+def test_protocol_command_safe_rejects_risk_and_length() -> None:
+    assert proto.protocol_command_safe("接受老婆赠送")
+    assert proto.protocol_command_safe("签到")
+    assert not proto.protocol_command_safe("转账100")
+    assert not proto.protocol_command_safe("管理员踢人")
+    assert not proto.protocol_command_safe("x")
+    assert not proto.protocol_command_safe("命令" * 20)
+
+
+def test_record_observation_requires_explicit_command_and_aggregates(tmp_path, monkeypatch) -> None:
+    trigger = "请在 60 秒内发送「接受老婆赠送」，或发送「拒绝老婆赠送」"
+    # 非显式候选：忽略
+    assert not proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="随便回一句",
+        responder_id=11,
+        source_message_id=1,
+        created_at=100,
+    )
+    # 显式候选且安全：记录
+    assert proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="接受老婆赠送",
+        responder_id=11,
+        source_message_id=1,
+        created_at=100,
+    )
+    assert proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="接受老婆赠送",
+        responder_id=12,
+        source_message_id=2,
+        created_at=200,
+    )
+    assert proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="接受老婆赠送",
+        responder_id=13,
+        source_message_id=3,
+        created_at=300,
+    )
+    # 幂等：同 observation_id 不重复计数
+    assert not proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="接受老婆赠送",
+        responder_id=11,
+        source_message_id=1,
+        created_at=400,
+    )
+
+    status = proto.protocol_status()
+    assert status["observation_count"] == 3
+    assert status["pattern_count"] == 1
+    assert status["eligible_pattern_count"] == 1
+
+
+def test_resolve_protocol_candidate_gates_on_threshold_cooldown_and_recent_bot(tmp_path, monkeypatch) -> None:
+    trigger = "请在 60 秒内发送「接受老婆赠送」，或发送「拒绝老婆赠送」"
+    for mid, responder in ((1, 11), (2, 12), (3, 13)):
+        proto.record_protocol_observation(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            reply_text="接受老婆赠送",
+            responder_id=responder,
+            source_message_id=mid,
+            created_at=mid * 100,
+        )
+
+    # 达到 3 次/2 人且当前 Bot 是最近发言者：可响应
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            recent_bot_id=100,
+            now=1000,
+        )
+        == "接受老婆赠送"
+    )
+    # 最近发言者是其他 Bot：昵称定向不响应
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            recent_bot_id=200,
+            now=1000,
+        )
+        == ""
+    )
+    # 冷却期内不响应
+    proto.mark_protocol_sent(bot_id=100, group_id=42, now=1000)
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            recent_bot_id=100,
+            now=1000 + 60,
+        )
+        == ""
+    )
+    # 冷却结束后恢复
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            recent_bot_id=100,
+            now=1000 + proto._PROTOCOL_COOLDOWN_SEC + 1,
+        )
+        == "接受老婆赠送"
+    )
+
+
+def test_resolve_protocol_candidate_ignores_below_threshold(tmp_path, monkeypatch) -> None:
+    trigger = "回复「签到」即可"
+    proto.record_protocol_observation(
+        bot_id=100,
+        group_id=42,
+        trigger_text=trigger,
+        reply_text="签到",
+        responder_id=11,
+        source_message_id=1,
+        created_at=100,
+    )
+    assert (
+        proto.resolve_protocol_candidate(
+            bot_id=100,
+            group_id=42,
+            trigger_text=trigger,
+            recent_bot_id=100,
+            now=200,
+        )
+        == ""
+    )
+
+
+def test_protocol_status_counts_eligible_patterns(tmp_path, monkeypatch) -> None:
+    assert proto.protocol_status() == {
+        "observation_count": 0,
+        "pattern_count": 0,
+        "eligible_pattern_count": 0,
+    }

--- a/tests/product/llm/test_semantic_style_experiment.py
+++ b/tests/product/llm/test_semantic_style_experiment.py
@@ -1,0 +1,78 @@
+import pytest
+
+from pallas.product.llm import semantic_style_experiment as exp
+
+
+@pytest.fixture(autouse=True)
+def _clean_experiment_data(tmp_path, monkeypatch):
+    monkeypatch.setenv("PALLAS_DATA_DIR", str(tmp_path))
+    exp.clear_experiment_data_for_tests()
+    yield
+    exp.clear_experiment_data_for_tests()
+
+
+def test_semantic_style_bucket_is_stable_per_group_day() -> None:
+    # 同一 bot×群×日：稳定
+    assert exp.semantic_style_bucket(100, 42, now=1_000_000) == exp.semantic_style_bucket(100, 42, now=1_000_000)
+    # 不同群：可能不同桶
+    assert exp.semantic_style_bucket(100, 42, now=1_000_000) == exp.semantic_style_bucket(100, 42, now=1_000_000)
+    # 不同日：可换桶
+    assert (
+        exp.semantic_style_bucket(100, 42, now=1_000_000) != exp.semantic_style_bucket(100, 42, now=1_000_000 + 86400)
+        or True
+    )
+    # 桶范围
+    for bot in range(1, 20):
+        for group in range(1, 20):
+            assert 0 <= exp.semantic_style_bucket(bot, group, now=1_000_000) < 10
+
+
+def test_record_exposure_and_settle(tmp_path, monkeypatch) -> None:
+    exp.record_semantic_exposure(
+        request_id="req-1",
+        bot_id=100,
+        group_id=42,
+        user_id=11,
+        bucket=3,
+        injection_types=["behavior_pattern"],
+        source_ids=["src-1"],
+        delivery_source="provider",
+        bot_message_id=500,
+        delivered_at=1_000,
+    )
+    exp.mark_exposures_settled({"req-1"})
+    # 已结算的不再出现在未结算列表
+    assert exp._load_unsettled_exposures() == []
+
+
+def test_experiment_outcome_and_circuit_trip(tmp_path, monkeypatch) -> None:
+    # 未达最小样本：不熔断
+    for _ in range(10):
+        exp.record_experiment_outcome(bucket=1, target_followup=True, negative=False)
+    assert not exp.maybe_trip_circuit()
+
+    # 实验 200 回合、对照 20 回合，实验负反馈率显著更高：熔断
+    for _ in range(200):
+        exp.record_experiment_outcome(bucket=1, target_followup=False, negative=True)
+    for _ in range(20):
+        exp.record_experiment_outcome(bucket=0, target_followup=True, negative=False)
+
+    assert exp.maybe_trip_circuit()
+    status = exp.experiment_status()
+    assert status["circuit_disabled"] is True
+    assert status["circuit_reason"] == "negative_rate_delta"
+
+    # 熔断后注入位关闭
+    assert exp.semantic_style_circuit_disabled() is True
+
+    # 人工恢复
+    exp.reset_experiment_circuit()
+    assert exp.semantic_style_circuit_disabled() is False
+
+
+def test_circuit_not_tripped_when_rates_close(tmp_path, monkeypatch) -> None:
+    for _ in range(200):
+        exp.record_experiment_outcome(bucket=1, target_followup=True, negative=False)
+    for _ in range(20):
+        exp.record_experiment_outcome(bucket=0, target_followup=True, negative=False)
+    assert not exp.maybe_trip_circuit()

--- a/tests/product/llm/test_semantic_style_experiment.py
+++ b/tests/product/llm/test_semantic_style_experiment.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from pallas.product.llm import semantic_style_experiment as exp
@@ -12,14 +14,12 @@ def _clean_experiment_data(tmp_path, monkeypatch):
 
 
 def test_semantic_style_bucket_is_stable_per_group_day() -> None:
-    # 同一 bot×群×日：稳定
-    assert exp.semantic_style_bucket(100, 42, now=1_000_000) == exp.semantic_style_bucket(100, 42, now=1_000_000)
-    # 不同群：可能不同桶
-    assert exp.semantic_style_bucket(100, 42, now=1_000_000) == exp.semantic_style_bucket(100, 42, now=1_000_000)
-    # 不同日：可换桶
-    assert (
-        exp.semantic_style_bucket(100, 42, now=1_000_000) != exp.semantic_style_bucket(100, 42, now=1_000_000 + 86400)
-        or True
+    # 2026-09-07 23:59:59 / 2026-09-08 00:00:01（北京时间）跨自然日。
+    before_midnight = 1_788_710_399
+    after_midnight = before_midnight + 2
+    assert exp.semantic_style_day_key(before_midnight) != exp.semantic_style_day_key(after_midnight)
+    assert exp.semantic_style_bucket(100, 42, now=before_midnight) == exp.semantic_style_bucket(
+        100, 42, now=before_midnight
     )
     # 桶范围
     for bot in range(1, 20):
@@ -48,14 +48,20 @@ def test_record_exposure_and_settle(tmp_path, monkeypatch) -> None:
 def test_experiment_outcome_and_circuit_trip(tmp_path, monkeypatch) -> None:
     # 未达最小样本：不熔断
     for _ in range(10):
-        exp.record_experiment_outcome(bucket=1, target_followup=True, negative=False)
+        exp.record_experiment_outcome(
+            request_id=f"warm-{_}", bucket=1, target_followup=True, negative=False
+        )
     assert not exp.maybe_trip_circuit()
 
     # 实验 200 回合、对照 20 回合，实验负反馈率显著更高：熔断
     for _ in range(200):
-        exp.record_experiment_outcome(bucket=1, target_followup=False, negative=True)
+        exp.record_experiment_outcome(
+            request_id=f"exp-{_}", bucket=1, target_followup=False, negative=True
+        )
     for _ in range(20):
-        exp.record_experiment_outcome(bucket=0, target_followup=True, negative=False)
+        exp.record_experiment_outcome(
+            request_id=f"ctl-{_}", bucket=0, target_followup=True, negative=False
+        )
 
     assert exp.maybe_trip_circuit()
     status = exp.experiment_status()
@@ -68,11 +74,62 @@ def test_experiment_outcome_and_circuit_trip(tmp_path, monkeypatch) -> None:
     # 人工恢复
     exp.reset_experiment_circuit()
     assert exp.semantic_style_circuit_disabled() is False
+    assert exp.maybe_trip_circuit() is False
 
 
 def test_circuit_not_tripped_when_rates_close(tmp_path, monkeypatch) -> None:
     for _ in range(200):
-        exp.record_experiment_outcome(bucket=1, target_followup=True, negative=False)
+        exp.record_experiment_outcome(
+            request_id=f"exp-ok-{_}", bucket=1, target_followup=True, negative=False
+        )
     for _ in range(20):
-        exp.record_experiment_outcome(bucket=0, target_followup=True, negative=False)
+        exp.record_experiment_outcome(
+            request_id=f"ctl-ok-{_}", bucket=0, target_followup=True, negative=False
+        )
     assert not exp.maybe_trip_circuit()
+
+
+@pytest.mark.asyncio
+async def test_settlement_marks_actual_rows_and_counts_each_request_once(monkeypatch) -> None:
+    exp.record_semantic_exposure(
+        request_id="young",
+        bot_id=100,
+        group_id=42,
+        user_id=11,
+        bucket=1,
+        injection_types=[],
+        source_ids=[],
+        delivery_source="provider",
+        bot_message_id=501,
+        delivered_at=950,
+    )
+    exp.record_semantic_exposure(
+        request_id="old",
+        bot_id=100,
+        group_id=42,
+        user_id=11,
+        bucket=1,
+        injection_types=[],
+        source_ids=[],
+        delivery_source="provider",
+        bot_message_id=502,
+        delivered_at=100,
+    )
+
+    class Repo:
+        async def list_group_messages_after(self, *_args, **_kwargs):
+            return [
+                SimpleNamespace(message_id=1, user_id=99, plain_text="想得美", raw_message=""),
+                SimpleNamespace(message_id=1, user_id=99, plain_text="想得美", raw_message=""),
+                SimpleNamespace(message_id=2, user_id=11, plain_text="接着聊", raw_message=""),
+            ]
+
+    monkeypatch.setattr("pallas.core.foundation.db.make_message_repository", lambda: Repo())
+
+    assert await exp.settle_pending_semantic_exposures(now=1000) == 1
+    assert [item["request_id"] for item in exp._load_unsettled_exposures()] == ["young"]
+    status = exp.experiment_status()
+    assert status["experiment"] == {"settled": 1, "target_followup": 1}
+
+    exp.record_experiment_outcome(request_id="old", bucket=1, target_followup=True, negative=True)
+    assert exp.experiment_status()["experiment"] == {"settled": 1, "target_followup": 1}

--- a/tools/experimental/semantic_style_audit.py
+++ b/tools/experimental/semantic_style_audit.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from operator import itemgetter
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
@@ -36,14 +37,20 @@ from pallas.product.llm.repeater_semantic_style import (  # noqa: E402
 )
 
 
-def load_profiles() -> list[SemanticStyleProfile]:
-    path = REPO_ROOT / "data" / "pb_webui" / "repeater_semantic_style" / "profiles.json"
+def _load_json_rows(path: Path) -> list[dict]:
     if not path.exists():
-        raise SystemExit(f"profiles.json not found: {path}")
+        raise SystemExit(f"file not found: {path}")
     raw = json.loads(path.read_text(encoding="utf-8"))
-    rows = raw.get("profiles") if isinstance(raw, dict) else raw
+    rows = raw.get("profiles") if isinstance(raw, dict) and isinstance(raw.get("profiles"), list) else raw
+    if not isinstance(rows, list):
+        raise SystemExit(f"invalid rows shape: {path}")
+    return rows
+
+
+def load_profiles(path: Path | None = None) -> list[SemanticStyleProfile]:
+    rows = _load_json_rows(path or REPO_ROOT / "data" / "pb_webui" / "repeater_semantic_style" / "profiles.json")
     items: list[SemanticStyleProfile] = []
-    for item in rows or []:
+    for item in rows:
         try:
             items.append(SemanticStyleProfile.model_validate(item))
         except Exception:
@@ -116,10 +123,66 @@ def audit_profile(profile: SemanticStyleProfile) -> dict[str, object]:
     return entries
 
 
+def audit_examples(path: Path) -> dict[str, object]:
+    """审计 examples.jsonl 的样本来源组成，供 v3 分类前后对比。"""
+    if not path.exists():
+        raise SystemExit(f"file not found: {path}")
+    rows = 0
+    total = 0
+    same_user = 0
+    media_trigger = 0
+    template_hits = 0
+    token_meta = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        rows += 1
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        total += 1
+        trigger_uid = int(item.get("trigger_user_id") or 0)
+        reply_uid = int(item.get("reply_user_id") or 0)
+        if trigger_uid > 0 and trigger_uid == reply_uid:
+            same_user += 1
+        trigger = str(item.get("trigger_text") or "")
+        reply = str(item.get("reply_text") or "")
+        stripped_trigger = re.sub(r"\[(?:图片|媒体|表情)\]", "", trigger).strip()
+        if trigger.strip() in ("[图片]", "[媒体]") or (trigger and not stripped_trigger):
+            media_trigger += 1
+        combined = f"{trigger} {reply}"
+        if re.search(r"(发送[「\"]|管理员|群主|功能开关|领取|签到|老婆赠送|请在\s*\d+\s*秒)", combined):
+            template_hits += 1
+        if re.search(r"(completion_tokens|prompt_tokens|finish_reason|token_usage)", combined, re.IGNORECASE):
+            token_meta += 1
+    return {
+        "rows": rows,
+        "parsed": total,
+        "same_user_rate": round(same_user / total, 4) if total else 0,
+        "media_trigger_rate": round(media_trigger / total, 4) if total else 0,
+        "template_hit_rate": round(template_hits / total, 4) if total else 0,
+        "token_meta_count": token_meta,
+    }
+
+
+def _print_example_stats(stats: dict[str, object]) -> None:
+    print("=" * 60)
+    print("examples.jsonl 样本组成审计")
+    print("=" * 60)
+    print(f"行数 {stats['rows']} 已解析 {stats['parsed']}")
+    print(f"同人续句率 {stats['same_user_rate']:.1%}")
+    print(f"纯媒体 trigger 率 {stats['media_trigger_rate']:.1%}")
+    print(f"系统模板命中率 {stats['template_hit_rate']:.1%}")
+    print(f"token 元数据泄漏 {stats['token_meta_count']}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="审计语义风格指导器离线产出质量。")
     parser.add_argument("--min-sample", type=int, default=8, help="只审计样本数 ≥ 该值的 profile")
     parser.add_argument("--out", type=Path, default=REPO_ROOT / "data" / "llm" / "semantic_style_audit.json")
+    parser.add_argument("--profiles", type=Path, default=None, help="覆盖 profiles.json 路径")
+    parser.add_argument("--examples", type=Path, default=None, help="覆盖 examples.jsonl 路径")
     parser.add_argument(
         "--json",
         action="store_true",
@@ -127,9 +190,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    profiles = load_profiles()
+    profiles = load_profiles(path=args.profiles)
+    total = len(profiles)
     profiles = [profile for profile in profiles if profile.sample_count >= args.min_sample]
-    print(f"profiles 总数 {len(load_profiles())}，>= min-sample({args.min_sample}) {len(profiles)} 个")
+    print(f"profiles 总数 {total}，>= min-sample({args.min_sample}) {len(profiles)} 个")
+
+    if args.examples is not None:
+        example_stats = audit_examples(args.examples)
+        if args.json:
+            print(json.dumps({"examples": example_stats}, ensure_ascii=False))
+        else:
+            _print_example_stats(example_stats)
 
     audited = [audit_profile(profile) for profile in profiles]
 


### PR DESCRIPTION
行为策略收为受控 action/relation/form 聚合，3 次且 2 名真人方可注入；同人续句独立成 continuation 模式；普通直投只发送固定安全短句；低风险游戏协议独立响应（昵称定向 + 10 分钟冷却）；群日稳定 A/B 与负反馈双阈值自动熔断；首次 v3 写入自动备份 v2，支持 14 天读管线回滚。

- 采集/画像/召回/prompt 注入/直投/协议/实验治理完整闭环
- 生产数据 dry-run 验证：3526 条自由策略收敛为 100 条可注入受控模式，无脏文本/英文/场景无关注入
- 详见 docs/agent/research/2026-09-08-semantic-style-v3-dryrun.md

## Sourcery 摘要

采用受治理的语义风格 v3 流程，在将延续内容和低风险协议与普通提示指导隔离的同时，学习安全且有证据支持的群体行为。

新功能：
- 引入受控的语义行为和延续模式，并为提示注入设置证据阈值。
- 增加独立的低风险协议学习，以及有针对性且受冷却时间限制的直接响应。
- 增加稳定的每日 A/B 实验，支持曝光跟踪、结果结算和自动熔断。

错误修复：
- 从语义样本中过滤仅包含媒体的内容、系统模板、URL、元数据及其他脏文本。
- 防止将同一用户的延续内容，以及不安全或不符合条件的行为模式视为可复用的对话示例。

增强功能：
- 将提示指导、固定的安全直接回复、延续习惯和协议响应分离为不同的处理路径。
- 增加 v3 配置文件架构迁移，自动创建 v2 备份，并支持读流程回滚选项。
- 通过运行时元数据和 WebUI API 暴露语义注入来源、治理状态、协议状态和回滚控制。
- 扩展语义风格审计，以检查示例质量，并支持可配置的配置文件和示例输入。

文档：
- 记录 v3 语义风格流程、协议处理、迁移与回滚行为，以及实验治理。

测试：
- 增加对受控模式阈值、延续分类、数据过滤、安全直接回复、协议门控、A/B 分桶、曝光结算、熔断和 v2 回滚的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt a governed semantic-style v3 pipeline that learns safe, evidence-backed group behaviors while isolating continuations and low-risk protocols from ordinary prompt guidance.

New Features:
- Introduce controlled semantic behavior and continuation patterns with evidence thresholds for prompt injection.
- Add independent low-risk protocol learning and targeted, cooldown-limited direct responses.
- Add stable daily A/B experimentation with exposure tracking, outcome settlement, and automatic circuit breaking.

Bug Fixes:
- Filter media-only content, system templates, URLs, metadata, and other dirty text from semantic samples.
- Prevent same-user continuations and unsafe or unqualified behavior patterns from being treated as reusable conversational examples.

Enhancements:
- Separate prompt guidance, fixed safe direct replies, continuation habits, and protocol responses into distinct handling paths.
- Add v3 profile schema migration with automatic v2 backups and a read-pipeline rollback option.
- Expose semantic injection sources, governance state, protocol status, and rollback controls through runtime metadata and WebUI APIs.
- Extend semantic style auditing to inspect example quality and support configurable profile and example inputs.

Documentation:
- Document the v3 semantic-style pipeline, protocol handling, migration and rollback behavior, and experiment governance.

Tests:
- Add coverage for controlled pattern thresholds, continuation classification, data filtering, safe direct responses, protocol gating, A/B bucketing, exposure settlement, circuit breaking, and v2 rollback.

</details>